### PR TITLE
Implement --since flag for comment filtering

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -59,6 +59,31 @@ resolve_pr_head_sha() {
   gh api "repos/$owner_repo/pulls/$pr_number" --jq '.head.sha'
 }
 
+resolve_since_timestamp() {
+  local since_input="${1:-}"
+  if [ -z "$since_input" ]; then
+    echo ""
+    return
+  fi
+  if [ "$since_input" = "last-commit" ]; then
+    git log -1 --format=%cI HEAD || die "failed to resolve last-commit timestamp"
+    return
+  fi
+  if echo "$since_input" | grep -qE '^[0-9a-fA-F]{40}$'; then
+    git log -1 --format=%cI "$since_input" 2>/dev/null || die "unknown commit: $since_input"
+    return
+  fi
+  if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    echo "${since_input}T00:00:00Z"
+    return
+  fi
+  if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$'; then
+    echo "${since_input}Z"
+    return
+  fi
+  die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+}
+
 cmd_comments() {
   local pr_number="" since_ref="" all_comments=true
 
@@ -70,7 +95,7 @@ cmd_comments() {
         ;;
       --since)
         [ $# -ge 2 ] || die "missing value for --since"
-        die "--since is not yet implemented"
+        since_ref=$(resolve_since_timestamp "$2"); shift 2
         ;;
       --all)  all_comments=true; shift ;;
       -h|--help) usage; exit 0 ;;
@@ -121,6 +146,10 @@ cmd_comments() {
 
   local merged
   merged=$(printf '%s\n%s\n' "$review_json" "$issue_json" | jq -s 'flatten | sort_by(.created)')
+
+  if [ -n "$since_ref" ]; then
+    merged=$(echo "$merged" | jq --arg since "$since_ref" '[.[] | select(.created >= $since)]')
+  fi
 
   echo "$merged" | jq -r '.[] | if .source == "review-comment" then "--- review-comment\nauthor: \(.author)\ncreated: \(.created)\npath: \(.path)\nline: \(.line)\nbody: \(.body)" + (if (.replies | length) > 0 then "\n" + (.replies | map(">>> reply\nauthor: \(.author)\ncreated: \(.created)\nbody: \(.body)") | join("\n")) else "" end) else "--- issue-comment\nauthor: \(.author)\ncreated: \(.created)\nbody: \(.body)" end'
 }

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -95,7 +95,7 @@ resolve_since_timestamp() {
 }
 
 cmd_comments() {
-  local pr_number="" since_ref="" all_comments=true
+  local pr_number="" since_ref="" force_all=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -107,11 +107,15 @@ cmd_comments() {
         [ $# -ge 2 ] || die "missing value for --since"
         since_ref=$(resolve_since_timestamp "$2"); shift 2
         ;;
-      --all)  all_comments=true; shift ;;
+      --all)  force_all=true; shift ;;
       -h|--help) usage; exit 0 ;;
       *) die "unknown option: $1" ;;
     esac
   done
+
+  if [ "$force_all" = true ]; then
+    since_ref=""
+  fi
 
   check_deps
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -66,19 +66,29 @@ resolve_since_timestamp() {
     return
   fi
   if [ "$since_input" = "last-commit" ]; then
-    git log -1 --format=%cI HEAD || die "failed to resolve last-commit timestamp"
+    local epoch
+    epoch=$(git log -1 --format=%ct HEAD) || die "failed to resolve last-commit timestamp"
+    echo "$epoch" | jq -Rr 'tonumber | todate'
     return
   fi
   if echo "$since_input" | grep -qE '^[0-9a-fA-F]{40}$'; then
-    git log -1 --format=%cI "$since_input" 2>/dev/null || die "unknown commit: $since_input"
+    local epoch
+    epoch=$(git log -1 --format=%ct "$since_input" 2>/dev/null) || die "unknown commit: $since_input"
+    echo "$epoch" | jq -Rr 'tonumber | todate'
     return
   fi
   if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
-    echo "${since_input}T00:00:00Z"
+    local ts="${since_input}T00:00:00Z"
+    echo "$ts" | jq -R -e 'fromdateiso8601' >/dev/null 2>&1 \
+      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    echo "$ts"
     return
   fi
   if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$'; then
-    echo "${since_input}Z"
+    local ts="${since_input}Z"
+    echo "$ts" | jq -R -e 'fromdateiso8601' >/dev/null 2>&1 \
+      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    echo "$ts"
     return
   fi
   die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -13,6 +13,8 @@ test_names+=(
   test_since_invalid_format_stderr_message
   test_since_malformed_sha_exits_nonzero
   test_since_malformed_sha_stderr_message
+  test_since_invalid_calendar_date_exits_nonzero
+  test_since_invalid_calendar_date_stderr_message
 )
 
 test_no_args_exits_nonzero() {
@@ -62,4 +64,12 @@ test_since_malformed_sha_exits_nonzero() {
 
 test_since_malformed_sha_stderr_message() {
   assert_stderr_contains "--since short SHA gives clear message" "invalid --since value" bash "$script" comments --since "abc123"
+}
+
+test_since_invalid_calendar_date_exits_nonzero() {
+  assert_exit 1 "--since with impossible date exits non-zero" bash "$script" comments --since "2025-13-40"
+}
+
+test_since_invalid_calendar_date_stderr_message() {
+  assert_stderr_contains "--since impossible date gives clear message" "invalid --since value" bash "$script" comments --since "2025-13-40"
 }

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -68,8 +68,14 @@ test_since_malformed_sha_stderr_message() {
 
 test_since_invalid_calendar_date_exits_nonzero() {
   assert_exit 1 "--since with impossible date exits non-zero" bash "$script" comments --since "2025-13-40"
+  assert_exit 1 "--since with invalid month exits non-zero" bash "$script" comments --since "2025-13-01"
+  assert_exit 1 "--since with invalid day exits non-zero" bash "$script" comments --since "2023-02-30"
+  assert_exit 1 "--since with invalid hour exits non-zero" bash "$script" comments --since "2023-01-01T25:00:00"
 }
 
 test_since_invalid_calendar_date_stderr_message() {
   assert_stderr_contains "--since impossible date gives clear message" "invalid --since value" bash "$script" comments --since "2025-13-40"
+  assert_stderr_contains "--since invalid month gives clear message" "invalid --since value" bash "$script" comments --since "2025-13-01"
+  assert_stderr_contains "--since invalid day gives clear message" "invalid --since value" bash "$script" comments --since "2023-02-30"
+  assert_stderr_contains "--since invalid hour gives clear message" "invalid --since value" bash "$script" comments --since "2023-01-01T25:00:00"
 }

--- a/test/test_cli.sh
+++ b/test/test_cli.sh
@@ -7,7 +7,12 @@ test_names+=(
   test_unknown_option_exits_nonzero
   test_missing_pr_value_exits_nonzero
   test_missing_pr_value_stderr_message
-  test_since_flag_not_yet_implemented
+  test_missing_since_value_exits_nonzero
+  test_missing_since_value_stderr_message
+  test_since_invalid_format_exits_nonzero
+  test_since_invalid_format_stderr_message
+  test_since_malformed_sha_exits_nonzero
+  test_since_malformed_sha_stderr_message
 )
 
 test_no_args_exits_nonzero() {
@@ -35,6 +40,26 @@ test_missing_pr_value_stderr_message() {
   assert_stderr_contains "--pr without value gives clear message" "missing value for --pr" bash "$script" comments --pr
 }
 
-test_since_flag_not_yet_implemented() {
-  assert_stderr_contains "--since not yet implemented" "not yet implemented" bash "$script" comments --since 2025-01-01
+test_missing_since_value_exits_nonzero() {
+  assert_exit 1 "--since without value exits non-zero" bash "$script" comments --since
+}
+
+test_missing_since_value_stderr_message() {
+  assert_stderr_contains "--since without value gives clear message" "missing value for --since" bash "$script" comments --since
+}
+
+test_since_invalid_format_exits_nonzero() {
+  assert_exit 1 "--since with invalid format exits non-zero" bash "$script" comments --since "not-a-date"
+}
+
+test_since_invalid_format_stderr_message() {
+  assert_stderr_contains "--since invalid format gives clear message" "invalid --since value" bash "$script" comments --since "not-a-date"
+}
+
+test_since_malformed_sha_exits_nonzero() {
+  assert_exit 1 "--since with short SHA exits non-zero" bash "$script" comments --since "abc123"
+}
+
+test_since_malformed_sha_stderr_message() {
+  assert_stderr_contains "--since short SHA gives clear message" "invalid --since value" bash "$script" comments --since "abc123"
 }

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -2,14 +2,22 @@
 
 ORIGINAL_PATH="$HOME/bin:$PATH"
 
+KNOWN_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+UNKNOWN_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+MOCK_HEAD_TS="2025-06-01T10:00:00Z"
+MOCK_SHA_TS="2025-06-15T12:00:00Z"
+
 setup_mocks() {
   mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << 'GIT_EOF'
+  cat > "$mock_dir/git" << GIT_EOF
 #!/usr/bin/env bash
-case "$*" in
+case "\$*" in
   "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
   "branch --show-current") echo "feature-branch" ;;
   "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  "log -1 --format=%cI HEAD") echo "$MOCK_HEAD_TS" ;;
+  "log -1 --format=%cI $KNOWN_SHA") echo "$MOCK_SHA_TS" ;;
+  "log -1 --format=%cI $UNKNOWN_SHA") exit 1 ;;
   *) exit 1 ;;
 esac
 GIT_EOF
@@ -105,6 +113,15 @@ test_names+=(
   test_comments_issue_stays_flat
   test_comments_replies_sorted_under_parent
   test_comments_reply_in_main_response_not_duplicated
+  test_since_last_commit_filters_old
+  test_since_date_filters_old
+  test_since_datetime_filters_old
+  test_since_sha_filters_old
+  test_since_no_filter_returns_all
+  test_since_last_commit_includes_equal
+  test_since_filters_replies_too
+  test_since_unknown_sha_exits_nonzero
+  test_since_unknown_sha_stderr_message
 )
 
 test_comments_empty_pr_no_output() {
@@ -338,5 +355,146 @@ test_comments_reply_in_main_response_not_duplicated() {
   else
     fail=$((fail + 1))
     echo "FAIL: reply should appear exactly once, got $reply_count occurrences (output: $output)"
+  fi
+}
+
+test_since_last_commit_filters_old() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-05-01T09:00:00Z","path":"a.sh","line":1,"body":"old comment"},{"user":{"login":"bob"},"created_at":"2025-07-01T10:00:00Z","path":"b.sh","line":2,"body":"new comment"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"exact match"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --since last-commit 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol" \
+    && ! echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since last-commit should filter old comments (output: $output)"
+  fi
+}
+
+test_since_date_filters_old() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-05-15T23:59:59Z","path":"a.sh","line":1,"body":"before date"},{"user":{"login":"bob"},"created_at":"2025-06-01T00:00:00Z","path":"b.sh","line":2,"body":"on date"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-15T12:00:00Z","body":"after date"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --since 2025-06-01 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol" \
+    && ! echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since 2025-06-01 should filter comments before that date (output: $output)"
+  fi
+}
+
+test_since_datetime_filters_old() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-06-01T09:59:59Z","path":"a.sh","line":1,"body":"before datetime"},{"user":{"login":"bob"},"created_at":"2025-06-01T10:00:00Z","path":"b.sh","line":2,"body":"exact datetime"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T12:00:00Z","body":"after datetime"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --since 2025-06-01T10:00:00 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol" \
+    && ! echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since 2025-06-01T10:00:00 should filter comments before that datetime (output: $output)"
+  fi
+}
+
+test_since_sha_filters_old() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-06-10T09:00:00Z","path":"a.sh","line":1,"body":"before sha"},{"user":{"login":"bob"},"created_at":"2025-06-20T10:00:00Z","path":"b.sh","line":2,"body":"after sha"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-15T12:00:00Z","body":"exact sha ts"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --since "$KNOWN_SHA" 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol" \
+    && ! echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <SHA> should filter comments before SHA timestamp (output: $output)"
+  fi
+}
+
+test_since_no_filter_returns_all() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"old"},{"user":{"login":"bob"},"created_at":"2025-12-01T10:00:00Z","path":"b.sh","line":2,"body":"new"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"mid"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "alice" \
+    && echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: without --since all comments should be returned (output: $output)"
+  fi
+}
+
+test_since_last_commit_includes_equal() {
+  local issue_json="[{\"user\":{\"login\":\"alice\"},\"created_at\":\"$MOCK_HEAD_TS\",\"body\":\"exactly at HEAD ts\"}]"
+  setup_mocks_with_pr '[]' "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --since last-commit 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since should include comments at exact timestamp (output: $output)"
+  fi
+}
+
+test_since_filters_replies_too() {
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"}]'
+  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","body":"old reply"},{"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","body":"new reply"}]'
+  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local output
+  output=$(run_script comments --pr 42 --since 2025-06-01T00:00:00 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "carol" \
+    && ! echo "$output" | grep -qF "old reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since should filter replies too (output: $output)"
+  fi
+}
+
+test_since_unknown_sha_exits_nonzero() {
+  setup_mocks_with_pr '[]' '[]'
+  local exit_code=0
+  run_script comments --pr 42 --since "$UNKNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since with unknown SHA should exit non-zero"
+  fi
+}
+
+test_since_unknown_sha_stderr_message() {
+  setup_mocks_with_pr '[]' '[]'
+  local output
+  output=$(run_script comments --pr 42 --since "$UNKNOWN_SHA" 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qF "unknown commit"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since with unknown SHA should mention unknown commit (output: $output)"
   fi
 }

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -6,6 +6,8 @@ KNOWN_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 UNKNOWN_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 MOCK_HEAD_TS="2025-06-01T10:00:00Z"
 MOCK_SHA_TS="2025-06-15T12:00:00Z"
+MOCK_HEAD_EPOCH="1748772000"
+MOCK_SHA_EPOCH="1749988800"
 
 setup_mocks() {
   mock_dir=$(mktemp -d)
@@ -15,9 +17,9 @@ case "\$*" in
   "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
   "branch --show-current") echo "feature-branch" ;;
   "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  "log -1 --format=%cI HEAD") echo "$MOCK_HEAD_TS" ;;
-  "log -1 --format=%cI $KNOWN_SHA") echo "$MOCK_SHA_TS" ;;
-  "log -1 --format=%cI $UNKNOWN_SHA") exit 1 ;;
+  "log -1 --format=%ct HEAD") echo "$MOCK_HEAD_EPOCH" ;;
+  "log -1 --format=%ct $KNOWN_SHA") echo "$MOCK_SHA_EPOCH" ;;
+  "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
   *) exit 1 ;;
 esac
 GIT_EOF

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -120,6 +120,7 @@ test_names+=(
   test_since_datetime_filters_old
   test_since_sha_filters_old
   test_since_no_filter_returns_all
+  test_since_all_overrides_since
   test_since_last_commit_includes_equal
   test_since_filters_replies_too
   test_since_unknown_sha_exits_nonzero
@@ -442,6 +443,23 @@ test_since_no_filter_returns_all() {
   else
     fail=$((fail + 1))
     echo "FAIL: without --since all comments should be returned (output: $output)"
+  fi
+}
+
+test_since_all_overrides_since() {
+  local review_json='[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"old"},{"user":{"login":"bob"},"created_at":"2025-12-01T10:00:00Z","path":"b.sh","line":2,"body":"new"}]'
+  local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"mid"}]'
+  setup_mocks_with_pr "$review_json" "$issue_json"
+  local output
+  output=$(run_script comments --pr 42 --all --since 2025-12-01T00:00:00 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "alice" \
+    && echo "$output" | grep -qF "bob" \
+    && echo "$output" | grep -qF "carol"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --all should override --since and return all comments (output: $output)"
   fi
 }
 


### PR DESCRIPTION
## Summary

- Add `resolve_since_timestamp()` helper that converts `--since` input to an ISO-8601 timestamp, supporting five variants: `last-commit`, 40-char SHA, `YYYY-MM-DD`, `YYYY-MM-DDTHH:mm:ss`, and empty/omitted
- Wire the helper into `cmd_comments` argument parsing, replacing the previous `die "--since is not yet implemented"` stub
- Apply two-level timestamp filtering: reply-level filter during reply fetch (existing dead code activated) and top-level filter on the merged/sorted JSON after merge
- Replace the stub CLI test with validation tests for invalid format, malformed SHA, and missing value; add 9 integration tests covering all `--since` variants, boundary cases, reply filtering, and unknown SHA error handling

Closes #4


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Implemented a robust `--since` filter for comments supporting `last-commit`, full commit SHAs, `YYYY-MM-DD`, and `YYYY-MM-DDTHH:mm:ss`; invalid or unknown values now error. `--since` no longer aborts the command, `--all` overrides it, and filtering applies to both top-level comments and replies.

* **Tests**
  * Added extensive CLI and comment tests for missing/invalid inputs, unknown SHAs, stderr messages, all supported formats, edge cases, and reply filtering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->