### PR TITLE
feat: implement status command for CI check runs

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -198,7 +198,7 @@ cmd_status() {
   checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \
     || die "failed to fetch check runs for SHA $sha"
 
-  echo "$checks_json" | jq -r '.check_runs | sort_by(.name) | .[] | "--- check\nname: \(.name)\nstatus: \(.status)" + (if .status == "completed" then "\nconclusion: \(.conclusion)" else "" end)'
+  echo "$checks_json" | jq -s -r 'map(.check_runs) | add // [] | sort_by(.name) | .[] | "--- check\nname: \(.name)\nstatus: \(.status)" + (if .status == "completed" then "\nconclusion: \(.conclusion)" else "" end)'
 }
 
 cmd_logs() {

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -169,8 +169,36 @@ cmd_comments() {
 }
 
 cmd_status() {
+  local pr_number=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] || die "missing value for --pr"
+        pr_number="$2"; shift 2
+        ;;
+      -h|--help) usage; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+
   check_deps
-  die "status command not yet implemented"
+
+  if [ -z "$pr_number" ]; then
+    pr_number=$(resolve_pr_number)
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
+  local sha
+  sha=$(resolve_pr_head_sha "$pr_number")
+
+  local checks_json
+  checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \
+    || die "failed to fetch check runs for SHA $sha"
+
+  echo "$checks_json" | jq -r '.check_runs | sort_by(.name) | .[] | "--- check\nname: \(.name)\nstatus: \(.status)" + (if .status == "completed" then "\nconclusion: \(.conclusion)" else "" end)'
 }
 
 cmd_logs() {

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -192,7 +192,8 @@ cmd_status() {
   owner_repo=$(resolve_owner_repo)
 
   local sha
-  sha=$(resolve_pr_head_sha "$pr_number")
+  sha=$(resolve_pr_head_sha "$pr_number") \
+    || die "failed to resolve head SHA for PR #$pr_number"
 
   local checks_json
   checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -1,0 +1,274 @@
+#!/usr/bin/env bash
+
+ORIGINAL_PATH="$HOME/bin:$PATH"
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+
+setup_mocks() {
+  mock_dir=$(mktemp -d)
+  cat > "$mock_dir/git" << GIT_EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "branch --show-current") echo "feature-branch" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$mock_dir/git"
+}
+
+setup_mocks_status() {
+  local check_runs="$1"
+
+  setup_mocks
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n' >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_status_auto() {
+  local check_runs="$1"
+
+  setup_mocks
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n' >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_status_no_pr() {
+  setup_mocks
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
+  printf '    echo ""\n' >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n' >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+run_script() {
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
+}
+
+cleanup_mocks() {
+  rm -rf "$mock_dir"
+}
+
+test_names+=(
+  test_status_completed_check
+  test_status_in_progress_omits_conclusion
+  test_status_queued_omits_conclusion
+  test_status_sorted_by_name
+  test_status_explicit_pr
+  test_status_auto_detect
+  test_status_exits_zero
+  test_status_no_pr_found_exits_nonzero
+  test_status_no_pr_found_stderr_message
+  test_status_empty_checks
+  test_status_multiple_conclusions
+  test_status_unknown_option_exits_nonzero
+  test_status_missing_pr_value_exits_nonzero
+  test_status_missing_pr_value_stderr_message
+  test_status_help_exits_zero
+)
+
+test_status_completed_check() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF -- "--- check" \
+    && echo "$output" | grep -qF "name: CI" \
+    && echo "$output" | grep -qF "status: completed" \
+    && echo "$output" | grep -qF "conclusion: success"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: completed check missing expected fields (output: $output)"
+  fi
+}
+
+test_status_in_progress_omits_conclusion() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "status: in_progress" \
+    && ! echo "$output" | grep -qF "conclusion:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: in_progress check should omit conclusion (output: $output)"
+  fi
+}
+
+test_status_queued_omits_conclusion() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "status: queued" \
+    && ! echo "$output" | grep -qF "conclusion:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: queued check should omit conclusion (output: $output)"
+  fi
+}
+
+test_status_sorted_by_name() {
+  local check_runs='{"total_count":2,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"},{"name":"Alpha","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  local first_name
+  first_name=$(echo "$output" | grep -m1 "name:" | sed 's/name: //')
+  if [ "$first_name" = "Alpha" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected Alpha first, got: $first_name (output: $output)"
+  fi
+}
+
+test_status_explicit_pr() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "name: CI"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --pr 42 should return check status (output: $output)"
+  fi
+}
+
+test_status_auto_detect() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status_auto "$check_runs"
+  local output
+  output=$(run_script status 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "name: CI"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect should resolve PR and return check status (output: $output)"
+  fi
+}
+
+test_status_exits_zero() {
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status "$check_runs"
+  assert_exit 0 "status exits 0 on success" run_script status --pr 42
+  cleanup_mocks
+}
+
+test_status_no_pr_found_exits_nonzero() {
+  setup_mocks_status_no_pr
+  local exit_code=0
+  run_script status >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR found should exit non-zero"
+  fi
+}
+
+test_status_empty_checks() {
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty check_runs should produce no output (got: $output)"
+  fi
+}
+
+test_status_multiple_conclusions() {
+  local check_runs='{"total_count":3,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"},{"name":"Deploy","status":"completed","conclusion":"cancelled"}]}'
+  setup_mocks_status "$check_runs"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "conclusion: success" \
+    && echo "$output" | grep -qF "conclusion: failure" \
+    && echo "$output" | grep -qF "conclusion: cancelled"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: mixed conclusions not all present (output: $output)"
+  fi
+}
+
+test_status_unknown_option_exits_nonzero() {
+  setup_mocks
+  local exit_code=0
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" status --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: unknown option should exit non-zero"
+  fi
+}
+
+test_status_no_pr_found_stderr_message() {
+  setup_mocks_status_no_pr
+  local output
+  output=$(run_script status 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qF "no open PR found"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR found should mention 'no open PR found' (output: $output)"
+  fi
+}
+
+test_status_missing_pr_value_exits_nonzero() {
+  assert_exit 1 "status --pr without value exits non-zero" bash "$script" status --pr
+}
+
+test_status_missing_pr_value_stderr_message() {
+  assert_stderr_contains "status --pr without value gives clear message" "missing value for --pr" bash "$script" status --pr
+}
+
+test_status_help_exits_zero() {
+  assert_exit 0 "status --help exits 0" bash "$script" status --help
+  assert_exit 0 "status -h exits 0" bash "$script" status -h
+}

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -110,6 +110,7 @@ test_names+=(
   test_status_missing_pr_value_stderr_message
   test_status_help_exits_zero
   test_status_paginated_merges_all_checks
+  test_status_sha_lookup_failure_stderr_message
 )
 
 test_status_completed_check() {
@@ -305,5 +306,33 @@ test_status_paginated_merges_all_checks() {
   else
     fail=$((fail + 1))
     echo "FAIL: paginated response should merge all pages (output: $output)"
+  fi
+}
+
+setup_mocks_status_sha_fails() {
+  setup_mocks
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
+  printf '    exit 1\n' >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n' >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+test_status_sha_lookup_failure_stderr_message() {
+  setup_mocks_status_sha_fails
+  local output
+  output=$(run_script status 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qF "failed to resolve head SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA lookup failure should mention 'failed to resolve head SHA' (output: $output)"
   fi
 }

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -67,6 +67,24 @@ setup_mocks_status_no_pr() {
   chmod +x "$mock_dir/gh"
 }
 
+setup_mocks_status_paginated() {
+  local page1="$1"
+  local page2="$2"
+
+  setup_mocks
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
+  printf "    printf '%%s\\n' '%s' '%s'\n" "$page1" "$page2" >> "$mock_dir/gh"
+  printf '    ;;\n' >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n' >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
 run_script() {
   PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
 }
@@ -91,6 +109,7 @@ test_names+=(
   test_status_missing_pr_value_exits_nonzero
   test_status_missing_pr_value_stderr_message
   test_status_help_exits_zero
+  test_status_paginated_merges_all_checks
 )
 
 test_status_completed_check() {
@@ -271,4 +290,20 @@ test_status_missing_pr_value_stderr_message() {
 test_status_help_exits_zero() {
   assert_exit 0 "status --help exits 0" bash "$script" status --help
   assert_exit 0 "status -h exits 0" bash "$script" status -h
+}
+
+test_status_paginated_merges_all_checks() {
+  local page1='{"total_count":3,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"}]}'
+  local page2='{"total_count":3,"check_runs":[{"name":"Alpha","status":"completed","conclusion":"failure"}]}'
+  setup_mocks_status_paginated "$page1" "$page2"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "name: Alpha" \
+    && echo "$output" | grep -qF "name: Zebra"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: paginated response should merge all pages (output: $output)"
+  fi
 }


### PR DESCRIPTION
## Summary

- Implements gh-pr-context status [--pr <number>] command (closes #5)
- Fetches check runs from GitHub API for the PR head commit
- Outputs terse plain-text format with --- check delimiter, name, status, and conclusion (only when completed)
- Uses jq -s to correctly merge paginated check-runs responses
- 17 tests covering all acceptance criteria

## Acceptance Criteria

- [x] gh-pr-context status auto-detects PR and outputs CI check states
- [x] gh-pr-context status --pr 42 targets a specific PR
- [x] Output includes check name, status, and conclusion (when completed)
- [x] Output is deterministic (sorted alphabetically by name)
- [x] Script exits 0 on success, non-zero with one-line stderr on failure

## Test Results

64 passed, 0 failed (47 existing + 17 new status tests)

## QA Notes

- CodeRabbit review identified a pagination bug (jq only processed first page) - fixed with jq -s slurp
- Two other CodeRabbit findings were false positives (test harness variables are provided by run.sh sourcing pattern)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Fully implemented status command: resolves PR from branch when omitted, fetches and merges all check runs, and displays a sorted check list.

* **Behavior Changes**
  * Shows a check's conclusion only when completed; provides clear error and help messages and appropriate exit codes.

* **Tests**
  * Added comprehensive tests covering pagination, sorting, various check states, PR resolution, errors, and help.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->