### PR TITLE
feat: test harness + all module tests (#7)

### DIFF
--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -1,0 +1,396 @@
+#!/usr/bin/env bash
+
+ORIGINAL_PATH="$HOME/bin:$PATH"
+
+HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+
+setup_mocks_base() {
+  mock_dir=$(mktemp -d)
+  cat > "$mock_dir/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$mock_dir/git"
+}
+
+setup_mocks_comments() {
+  local pr_reviews="$1" pr_issues="$2"
+  setup_mocks_base
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
+  printf '    ;;\n'                      >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'  >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$pr_issues"  >> "$mock_dir/gh"
+  printf '    ;;\n'                      >> "$mock_dir/gh"
+  printf '  *"pulls/comments/"*"/replies"*)\n' >> "$mock_dir/gh"
+  printf '    echo "[]"\n'              >> "$mock_dir/gh"
+  printf '    ;;\n'                     >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'            >> "$mock_dir/gh"
+  printf 'esac\n'                      >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_comments_with_reply() {
+  local pr_reviews="$1" reply_json="$2"
+  setup_mocks_base
+  echo "$reply_json" > "$mock_dir/replies_77.json"
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
+  printf '    ;;\n'                      >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'  >> "$mock_dir/gh"
+  printf "    echo '[]'\n"              >> "$mock_dir/gh"
+  printf '    ;;\n'                      >> "$mock_dir/gh"
+  printf '  *"pulls/comments/"*"/replies"*)\n' >> "$mock_dir/gh"
+  cat >> "$mock_dir/gh" << 'RMOCK'
+    _cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
+    _d=$(dirname "$0")
+    [ -f "${_d}/replies_${_cid}.json" ] && cat "${_d}/replies_${_cid}.json" || echo "[]"
+    ;;
+RMOCK
+  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
+  printf 'esac\n'           >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_status() {
+  local check_runs="$1"
+  setup_mocks_base
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42"*)\n'                   >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$HEAD_SHA"          >> "$mock_dir/gh"
+  printf '    ;;\n'                             >> "$mock_dir/gh"
+  printf '  *"check-runs"*)\n'                 >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$check_runs"        >> "$mock_dir/gh"
+  printf '    ;;\n'                             >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                    >> "$mock_dir/gh"
+  printf 'esac\n'                              >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_logs() {
+  local check_runs="$1" log_content="$2"
+  setup_mocks_base
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42"*)\n'                   >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$HEAD_SHA"          >> "$mock_dir/gh"
+  printf '    ;;\n'                             >> "$mock_dir/gh"
+  printf '  *"check-runs"*)\n'                 >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$check_runs"        >> "$mock_dir/gh"
+  printf '    ;;\n'                             >> "$mock_dir/gh"
+  printf '  *"logs"*)\n'                        >> "$mock_dir/gh"
+  printf "    printf '%%s' '%s'\n" "$log_content" >> "$mock_dir/gh"
+  printf '    ;;\n'                             >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                    >> "$mock_dir/gh"
+  printf 'esac\n'                              >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+run_script() {
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
+}
+
+cleanup_mocks() {
+  rm -rf "$mock_dir"
+}
+
+test_names+=(
+  test_fmt_review_comment_delimiter
+  test_fmt_review_comment_field_order
+  test_fmt_review_comment_no_raw_json
+  test_fmt_review_comment_no_trailing_whitespace_on_fields
+  test_fmt_issue_comment_delimiter
+  test_fmt_issue_comment_fields_present
+  test_fmt_issue_comment_no_path_line
+  test_fmt_issue_comment_no_raw_json
+  test_fmt_reply_marker
+  test_fmt_reply_fields
+  test_fmt_check_completed_delimiter_and_fields
+  test_fmt_check_non_completed_no_conclusion_field
+  test_fmt_check_no_raw_json
+  test_fmt_log_delimiter_and_name
+  test_fmt_log_no_raw_json
+  test_fmt_empty_comments_produces_no_output
+  test_fmt_empty_checks_produces_no_output
+  test_fmt_all_passing_logs_no_output
+)
+
+test_fmt_review_comment_delimiter() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
+  setup_mocks_comments "$review" '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qxF -- "--- review-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: review comment must start with '--- review-comment' on its own line (output: $output)"
+  fi
+}
+
+test_fmt_review_comment_field_order() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
+  setup_mocks_comments "$review" '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local author_n created_n path_n line_n body_n
+  author_n=$(echo "$output"  | grep -n "^author:"  | head -1 | cut -d: -f1)
+  created_n=$(echo "$output" | grep -n "^created:" | head -1 | cut -d: -f1)
+  path_n=$(echo "$output"   | grep -n "^path:"    | head -1 | cut -d: -f1)
+  line_n=$(echo "$output"   | grep -n "^line:"    | head -1 | cut -d: -f1)
+  body_n=$(echo "$output"   | grep -n "^body:"    | head -1 | cut -d: -f1)
+  if [ "$author_n" -lt "$created_n" ] \
+    && [ "$created_n" -lt "$path_n" ] \
+    && [ "$path_n" -lt "$line_n" ] \
+    && [ "$line_n" -lt "$body_n" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: review comment fields must appear in order author→created→path→line→body (lines: $author_n $created_n $path_n $line_n $body_n)"
+  fi
+}
+
+test_fmt_review_comment_no_raw_json() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
+  setup_mocks_comments "$review" '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if ! echo "$output" | grep -qP '^\s*[\[{]'; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: raw JSON must not appear in output (output: $output)"
+  fi
+}
+
+test_fmt_review_comment_no_trailing_whitespace_on_fields() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
+  setup_mocks_comments "$review" '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local bad_lines
+  bad_lines=$(echo "$output" | grep -P '^(author|created|path|line|body|name|status|conclusion):.*\s+$' || true)
+  if [ -z "$bad_lines" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: field lines must not have trailing whitespace (bad lines: $bad_lines)"
+  fi
+}
+
+test_fmt_issue_comment_delimiter() {
+  local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
+  setup_mocks_comments '[]' "$issue"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qxF -- "--- issue-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comment must start with '--- issue-comment' on its own line (output: $output)"
+  fi
+}
+
+test_fmt_issue_comment_fields_present() {
+  local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello world"}]'
+  setup_mocks_comments '[]' "$issue"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "author: bob" \
+    && echo "$output" | grep -qF "created: 2025-01-01T11:00:00Z" \
+    && echo "$output" | grep -qF "body: hello world"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comment missing author/created/body (output: $output)"
+  fi
+}
+
+test_fmt_issue_comment_no_path_line() {
+  local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello"}]'
+  setup_mocks_comments '[]' "$issue"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if ! echo "$output" | grep -qE "^path:|^line:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comment must not contain path: or line: fields (output: $output)"
+  fi
+}
+
+test_fmt_issue_comment_no_raw_json() {
+  local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hi"}]'
+  setup_mocks_comments '[]' "$issue"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if ! echo "$output" | grep -qP '^\s*[\[{]'; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: raw JSON must not appear in issue comment output (output: $output)"
+  fi
+}
+
+test_fmt_reply_marker() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
+  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"a reply"}]'
+  setup_mocks_comments_with_reply "$review" "$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qxF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply must use exactly '>>> reply' marker on its own line (output: $output)"
+  fi
+}
+
+test_fmt_reply_fields() {
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
+  local reply='[{"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","body":"the reply body"}]'
+  setup_mocks_comments_with_reply "$review" "$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "author: replyauthor" \
+    && echo "$output" | grep -qF "created: 2025-03-15T09:00:00Z" \
+    && echo "$output" | grep -qF "body: the reply body"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply block must contain author, created, body fields (output: $output)"
+  fi
+}
+
+test_fmt_check_completed_delimiter_and_fields() {
+  local checks='{"total_count":1,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"}]}'
+  setup_mocks_status "$checks"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qxF -- "--- check" \
+    && echo "$output" | grep -qF "name: Build" \
+    && echo "$output" | grep -qF "status: completed" \
+    && echo "$output" | grep -qF "conclusion: success"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: completed check must have --- check delimiter + name/status/conclusion (output: $output)"
+  fi
+}
+
+test_fmt_check_non_completed_no_conclusion_field() {
+  local checks='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
+  setup_mocks_status "$checks"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "status: queued" && ! echo "$output" | grep -qF "conclusion:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: non-completed check must omit conclusion field (output: $output)"
+  fi
+}
+
+test_fmt_check_no_raw_json() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"failure"}]}'
+  setup_mocks_status "$checks"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if ! echo "$output" | grep -qP '^\s*[\[{]'; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: raw JSON must not appear in status output (output: $output)"
+  fi
+}
+
+test_fmt_log_delimiter_and_name() {
+  local checks='{"total_count":1,"check_runs":[{"id":99,"name":"Test Suite","status":"completed","conclusion":"failure"}]}'
+  local log="line one\nline two"
+  setup_mocks_logs "$checks" "$log"
+  local output
+  output=$(run_script logs --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qxF -- "--- log" && echo "$output" | grep -qF "name: Test Suite"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: log block must have '--- log' delimiter and 'name:' field (output: $output)"
+  fi
+}
+
+test_fmt_log_no_raw_json() {
+  local checks='{"total_count":1,"check_runs":[{"id":99,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  local log="error: build failed"
+  setup_mocks_logs "$checks" "$log"
+  local output
+  output=$(run_script logs --pr 42 2>&1)
+  cleanup_mocks
+  local header_lines
+  header_lines=$(echo "$output" | grep -E "^(--- log|name:)")
+  if ! echo "$header_lines" | grep -qP '[\[{]'; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: log header lines must not contain raw JSON (output: $output)"
+  fi
+}
+
+test_fmt_empty_comments_produces_no_output() {
+  setup_mocks_comments '[]' '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty PR comments must produce no output (got: $output)"
+  fi
+}
+
+test_fmt_empty_checks_produces_no_output() {
+  local checks='{"total_count":0,"check_runs":[]}'
+  setup_mocks_status "$checks"
+  local output
+  output=$(run_script status --pr 42 2>&1)
+  cleanup_mocks
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty check_runs must produce no output (got: $output)"
+  fi
+}
+
+test_fmt_all_passing_logs_no_output() {
+  local checks='{"total_count":2,"check_runs":[{"id":1,"name":"A","status":"completed","conclusion":"success"},{"id":2,"name":"B","status":"completed","conclusion":"success"}]}'
+  setup_mocks_logs "$checks" "should not appear"
+  local output
+  output=$(run_script logs --pr 42 2>&1)
+  cleanup_mocks
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: all-passing checks must produce no log output (got: $output)"
+  fi
+}

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -4,6 +4,7 @@ ORIGINAL_PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
+# setup_mocks_base creates a temporary mock directory and installs a minimal git mock that returns a fixed remote URL and branch name.
 setup_mocks_base() {
   mock_dir=$(mktemp -d)
   cat > "$mock_dir/git" << 'GIT_EOF'
@@ -17,6 +18,7 @@ GIT_EOF
   chmod +x "$mock_dir/git"
 }
 
+# setup_mocks_comments creates a mock `gh` in $mock_dir (calls setup_mocks_base) that echoes the provided JSON for `pulls/42/comments` and `issues/42/comments` and returns `[]` for `pulls/comments/*/replies`; parameters: `pr_reviews` — JSON to echo for `pulls/42/comments`, `pr_issues` — JSON to echo for `issues/42/comments`.
 setup_mocks_comments() {
   local pr_reviews="$1" pr_issues="$2"
   setup_mocks_base
@@ -35,6 +37,7 @@ setup_mocks_comments() {
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_comments_with_reply creates a temporary mock environment, writes the provided reply JSON to replies_77.json, and installs a mock `gh` that returns the given PR review comments, empty issue comments, and serves per-comment reply JSON (by comment id) for tests.
 setup_mocks_comments_with_reply() {
   local pr_reviews="$1" reply_json="$2"
   setup_mocks_base
@@ -58,6 +61,7 @@ RMOCK
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_status creates a temporary mock environment and writes a mock `gh` executable that returns the fixed HEAD SHA for `pulls/42` and echoes the provided `check_runs` JSON when invoked with `check-runs`.
 setup_mocks_status() {
   local check_runs="$1"
   setup_mocks_base
@@ -73,6 +77,7 @@ setup_mocks_status() {
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_logs creates a temporary mock directory and an executable `gh` that returns the fixed HEAD_SHA for `pulls/42`, the provided `check_runs` JSON for check-run queries, and the given `log_content` for `logs` requests.
 setup_mocks_logs() {
   local check_runs="$1" log_content="$2"
   setup_mocks_base
@@ -91,10 +96,12 @@ setup_mocks_logs() {
   chmod +x "$mock_dir/gh"
 }
 
+# run_script runs the target script with the mock directory prepended to PATH so the mock executables override real tools.
 run_script() {
   PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
 }
 
+# cleanup_mocks removes the temporary mock directory used for test mocks.
 cleanup_mocks() {
   rm -rf "$mock_dir"
 }
@@ -120,6 +127,7 @@ test_names+=(
   test_fmt_all_passing_logs_no_output
 )
 
+# test_fmt_review_comment_delimiter verifies that formatted review comments begin with `--- review-comment` on a line by itself.
 test_fmt_review_comment_delimiter() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -134,6 +142,7 @@ test_fmt_review_comment_delimiter() {
   fi
 }
 
+# test_fmt_review_comment_field_order tests that review comment fields appear in the order author→created→path→line→body in the formatted comments output.
 test_fmt_review_comment_field_order() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -157,6 +166,7 @@ test_fmt_review_comment_field_order() {
   fi
 }
 
+# test_fmt_review_comment_no_raw_json ensures formatted review comment output contains no raw JSON-like characters (`[`, `{`) at the start of any line.
 test_fmt_review_comment_no_raw_json() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -171,6 +181,7 @@ test_fmt_review_comment_no_raw_json() {
   fi
 }
 
+# test_fmt_review_comment_no_trailing_whitespace_on_fields checks that formatted field lines (author, created, path, line, body, name, status, conclusion) do not end with trailing whitespace.
 test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -187,6 +198,7 @@ test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   fi
 }
 
+# test_fmt_issue_comment_delimiter verifies that running `comments --pr` emits a line containing only `--- issue-comment` for issue comments.
 test_fmt_issue_comment_delimiter() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
   setup_mocks_comments '[]' "$issue"
@@ -201,6 +213,7 @@ test_fmt_issue_comment_delimiter() {
   fi
 }
 
+# test_fmt_issue_comment_fields_present verifies that issue comment output contains `author`, `created`, and `body` fields.
 test_fmt_issue_comment_fields_present() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello world"}]'
   setup_mocks_comments '[]' "$issue"
@@ -217,6 +230,7 @@ test_fmt_issue_comment_fields_present() {
   fi
 }
 
+# test_fmt_issue_comment_no_path_line ensures issue comment output contains no lines beginning with `path:` or `line:`.
 test_fmt_issue_comment_no_path_line() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello"}]'
   setup_mocks_comments '[]' "$issue"
@@ -231,6 +245,7 @@ test_fmt_issue_comment_no_path_line() {
   fi
 }
 
+# test_fmt_issue_comment_no_raw_json verifies that issue comment output does not contain lines beginning with JSON delimiters (`[` or `{`), ensuring no raw JSON is printed.
 test_fmt_issue_comment_no_raw_json() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hi"}]'
   setup_mocks_comments '[]' "$issue"
@@ -245,6 +260,7 @@ test_fmt_issue_comment_no_raw_json() {
   fi
 }
 
+# test_fmt_reply_marker verifies that a reply is rendered using exactly the line '>>> reply' on its own line.
 test_fmt_reply_marker() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"a reply"}]'
@@ -260,6 +276,7 @@ test_fmt_reply_marker() {
   fi
 }
 
+# test_fmt_reply_fields verifies that a reply block in the formatted comments output includes `author`, `created`, and `body` fields.
 test_fmt_reply_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","body":"the reply body"}]'
@@ -277,6 +294,7 @@ test_fmt_reply_fields() {
   fi
 }
 
+# test_fmt_check_completed_delimiter_and_fields verifies that a completed check run produces a `--- check` delimiter and includes `name:`, `status: completed`, and `conclusion: success` in the formatter output.
 test_fmt_check_completed_delimiter_and_fields() {
   local checks='{"total_count":1,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$checks"
@@ -294,6 +312,7 @@ test_fmt_check_completed_delimiter_and_fields() {
   fi
 }
 
+# test_fmt_check_non_completed_no_conclusion_field verifies that a non-completed check outputs its `status` and omits any `conclusion:` field.
 test_fmt_check_non_completed_no_conclusion_field() {
   local checks='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
   setup_mocks_status "$checks"
@@ -308,6 +327,7 @@ test_fmt_check_non_completed_no_conclusion_field() {
   fi
 }
 
+# test_fmt_check_no_raw_json asserts that the `status --pr` output contains no lines beginning with raw JSON characters (`[` or `{`).
 test_fmt_check_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"failure"}]}'
   setup_mocks_status "$checks"
@@ -322,6 +342,7 @@ test_fmt_check_no_raw_json() {
   fi
 }
 
+# test_fmt_log_delimiter_and_name verifies that logs output includes the '--- log' delimiter and a `name:` field for a check run.
 test_fmt_log_delimiter_and_name() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"Test Suite","status":"completed","conclusion":"failure"}]}'
   local log="line one\nline two"
@@ -337,6 +358,7 @@ test_fmt_log_delimiter_and_name() {
   fi
 }
 
+# test_fmt_log_no_raw_json verifies that `logs --pr` header lines (`--- log` and `name:`) do not contain raw JSON-like characters such as `[` or `{`.
 test_fmt_log_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log="error: build failed"
@@ -354,6 +376,7 @@ test_fmt_log_no_raw_json() {
   fi
 }
 
+# test_fmt_empty_comments_produces_no_output verifies that when PR review comments and issue comments are empty the formatter produces no output.
 test_fmt_empty_comments_produces_no_output() {
   setup_mocks_comments '[]' '[]'
   local output
@@ -367,6 +390,7 @@ test_fmt_empty_comments_produces_no_output() {
   fi
 }
 
+# test_fmt_empty_checks_produces_no_output verifies that running `status --pr` produces no output when the repository has zero check runs.
 test_fmt_empty_checks_produces_no_output() {
   local checks='{"total_count":0,"check_runs":[]}'
   setup_mocks_status "$checks"
@@ -381,6 +405,7 @@ test_fmt_empty_checks_produces_no_output() {
   fi
 }
 
+# test_fmt_all_passing_logs_no_output verifies that when all check runs conclude with success, the `logs --pr` command produces no output.
 test_fmt_all_passing_logs_no_output() {
   local checks='{"total_count":2,"check_runs":[{"id":1,"name":"A","status":"completed","conclusion":"success"},{"id":2,"name":"B","status":"completed","conclusion":"success"}]}'
   setup_mocks_logs "$checks" "should not appear"

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+
+ORIGINAL_PATH="$HOME/bin:$PATH"
+
+setup_mocks_base() {
+  mock_dir=$(mktemp -d)
+  cat > "$mock_dir/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$mock_dir/git"
+}
+
+setup_mocks_auto_detect() {
+  setup_mocks_base
+  local head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls?head=acme:my-feature"*)\n'         >> "$mock_dir/gh"
+  printf "    echo '99'\n"                              >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"pulls/99/comments"*)\n'                  >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"issues/99/comments"*)\n'                 >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"pulls/99"*)\n'                           >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$head_sha"                 >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"check-runs"*)\n'                         >> "$mock_dir/gh"
+  printf '    echo '"'"'{"total_count":0,"check_runs":[]}'"'"'\n' >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
+  printf 'esac\n'                                     >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_explicit_pr() {
+  setup_mocks_base
+  local head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls?head="*)\n'                        >> "$mock_dir/gh"
+  printf '    echo "SHOULD NOT BE CALLED" >&2; exit 1\n' >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"pulls/55/comments"*)\n'                  >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"issues/55/comments"*)\n'                 >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"pulls/55"*)\n'                           >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$head_sha"                 >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *"check-runs"*)\n'                         >> "$mock_dir/gh"
+  printf '    echo '"'"'{"total_count":0,"check_runs":[]}'"'"'\n' >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
+  printf 'esac\n'                                     >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_no_pr() {
+  setup_mocks_base
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls?head=acme:my-feature"*)\n'         >> "$mock_dir/gh"
+  printf '    echo ""\n'                               >> "$mock_dir/gh"
+  printf '    ;;\n'                                    >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
+  printf 'esac\n'                                     >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+setup_mocks_api_fail() {
+  setup_mocks_base
+  printf '#!/usr/bin/env bash\nexit 1\n' > "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+run_script() {
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
+}
+
+cleanup_mocks() {
+  rm -rf "$mock_dir"
+}
+
+test_names+=(
+  test_pr_resolution_auto_detect_comments
+  test_pr_resolution_auto_detect_status
+  test_pr_resolution_auto_detect_logs
+  test_pr_resolution_explicit_pr_skips_autodetect_comments
+  test_pr_resolution_explicit_pr_skips_autodetect_status
+  test_pr_resolution_explicit_pr_skips_autodetect_logs
+  test_pr_resolution_no_pr_found_exits_nonzero
+  test_pr_resolution_no_pr_found_stderr_message
+  test_pr_resolution_api_fail_exits_nonzero
+  test_pr_resolution_api_fail_stderr_message
+)
+
+test_pr_resolution_auto_detect_comments() {
+  setup_mocks_auto_detect
+  local exit_code=0
+  run_script comments >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect should resolve PR 99 and succeed for comments (exit: $exit_code)"
+  fi
+}
+
+test_pr_resolution_auto_detect_status() {
+  setup_mocks_auto_detect
+  local exit_code=0
+  run_script status >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect should resolve PR 99 and succeed for status (exit: $exit_code)"
+  fi
+}
+
+test_pr_resolution_auto_detect_logs() {
+  setup_mocks_auto_detect
+  local exit_code=0
+  run_script logs >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect should resolve PR 99 and succeed for logs (exit: $exit_code)"
+  fi
+}
+
+test_pr_resolution_explicit_pr_skips_autodetect_comments() {
+  setup_mocks_explicit_pr
+  local output exit_code=0
+  output=$(run_script comments --pr 55 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr should not trigger auto-detect for comments (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_pr_resolution_explicit_pr_skips_autodetect_status() {
+  setup_mocks_explicit_pr
+  local output exit_code=0
+  output=$(run_script status --pr 55 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr should not trigger auto-detect for status (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_pr_resolution_explicit_pr_skips_autodetect_logs() {
+  setup_mocks_explicit_pr
+  local output exit_code=0
+  output=$(run_script logs --pr 55 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr should not trigger auto-detect for logs (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_pr_resolution_no_pr_found_exits_nonzero() {
+  setup_mocks_no_pr
+  local exit_code=0
+  run_script comments >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR found should exit non-zero"
+  fi
+}
+
+test_pr_resolution_no_pr_found_stderr_message() {
+  setup_mocks_no_pr
+  local output
+  output=$(run_script comments 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qF "no open PR found"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR found should mention 'no open PR found' (output: $output)"
+  fi
+}
+
+test_pr_resolution_api_fail_exits_nonzero() {
+  setup_mocks_api_fail
+  local exit_code=0
+  run_script comments >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+test_pr_resolution_api_fail_stderr_message() {
+  setup_mocks_api_fail
+  local output
+  output=$(run_script comments 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qiF "failed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should emit a failure message (output: $output)"
+  fi
+}

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -2,6 +2,7 @@
 
 ORIGINAL_PATH="$HOME/bin:$PATH"
 
+# setup_mocks_base creates a temporary mock directory and installs a mock git executable that returns a fixed remote URL for "remote get-url origin" and a fixed branch name for "rev-parse --abbrev-ref HEAD".
 setup_mocks_base() {
   mock_dir=$(mktemp -d)
   cat > "$mock_dir/git" << 'GIT_EOF'
@@ -15,6 +16,7 @@ GIT_EOF
   chmod +x "$mock_dir/git"
 }
 
+# setup_mocks_auto_detect creates mock `git` and `gh` executables in the temporary mock directory that simulate auto-detection of an open pull request (PR 99) and return canned responses for PR details, comments, issue comments, and check-runs.
 setup_mocks_auto_detect() {
   setup_mocks_base
   local head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -39,6 +41,7 @@ setup_mocks_auto_detect() {
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_explicit_pr creates temporary mock git and gh commands where gh returns data for PR 55 (a fixed head SHA, empty comments, and empty check-runs) and fails with an error if PR auto-detection is attempted.
 setup_mocks_explicit_pr() {
   setup_mocks_base
   local head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -63,6 +66,7 @@ setup_mocks_explicit_pr() {
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_no_pr creates mock `git` and `gh` executables in `$mock_dir`; the `gh` mock returns an empty response for `pulls?head=acme:my-feature` (simulating no open PR) and exits with status 1 for any other invocation.
 setup_mocks_no_pr() {
   setup_mocks_base
   printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
@@ -74,16 +78,19 @@ setup_mocks_no_pr() {
   chmod +x "$mock_dir/gh"
 }
 
+# setup_mocks_api_fail creates mock environment and places a `gh` mock that immediately exits with status 1 to simulate API failures.
 setup_mocks_api_fail() {
   setup_mocks_base
   printf '#!/usr/bin/env bash\nexit 1\n' > "$mock_dir/gh"
   chmod +x "$mock_dir/gh"
 }
 
+# run_script executes the target script under test with the mock directory prepended to PATH, forwarding all arguments.
 run_script() {
   PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
 }
 
+# cleanup_mocks removes the temporary mock directory created by the setup functions.
 cleanup_mocks() {
   rm -rf "$mock_dir"
 }
@@ -101,6 +108,7 @@ test_names+=(
   test_pr_resolution_api_fail_stderr_message
 )
 
+# test_pr_resolution_auto_detect_comments verifies that auto-detection resolves to pull request 99 and that running the `comments` subcommand exits successfully, updating the global pass/fail counters and printing a failure message on error.
 test_pr_resolution_auto_detect_comments() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -114,6 +122,7 @@ test_pr_resolution_auto_detect_comments() {
   fi
 }
 
+# test_pr_resolution_auto_detect_status verifies that auto-detect finds PR 99 and the `status` subcommand exits successfully.
 test_pr_resolution_auto_detect_status() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -127,6 +136,7 @@ test_pr_resolution_auto_detect_status() {
   fi
 }
 
+# test_pr_resolution_auto_detect_logs runs the `logs` subcommand with auto-detected PR mocks and increments `pass` on success or `fail` and prints a failure message on non-zero exit.
 test_pr_resolution_auto_detect_logs() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -140,6 +150,7 @@ test_pr_resolution_auto_detect_logs() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_comments verifies that invoking the script's `comments` subcommand with an explicit `--pr` uses the provided PR and does not trigger auto-detection.
 test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -153,6 +164,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_status verifies that providing `--pr` prevents auto-detection when running the `status` subcommand; it increments `pass` on success or `fail` and prints a failure message containing the exit code and captured output.
 test_pr_resolution_explicit_pr_skips_autodetect_status() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -166,6 +178,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_status() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_logs verifies that running the script's `logs` subcommand with `--pr 55` does not invoke auto-detection (output must not contain "SHOULD NOT BE CALLED") and increments the `pass` or `fail` counters accordingly.
 test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -179,6 +192,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   fi
 }
 
+# test_pr_resolution_no_pr_found_exits_nonzero verifies that the target script exits with a non-zero status when no open pull request is found.
 test_pr_resolution_no_pr_found_exits_nonzero() {
   setup_mocks_no_pr
   local exit_code=0
@@ -192,6 +206,7 @@ test_pr_resolution_no_pr_found_exits_nonzero() {
   fi
 }
 
+# test_pr_resolution_no_pr_found_stderr_message verifies that when no open PR exists the script writes "no open PR found" to stderr.
 test_pr_resolution_no_pr_found_stderr_message() {
   setup_mocks_no_pr
   local output
@@ -205,6 +220,7 @@ test_pr_resolution_no_pr_found_stderr_message() {
   fi
 }
 
+# test_pr_resolution_api_fail_exits_nonzero Verifies that when the mocked GitHub CLI fails, invoking the script's `comments` command exits with a non-zero status; increments `pass` on non-zero, otherwise increments `fail` and prints a failure message.
 test_pr_resolution_api_fail_exits_nonzero() {
   setup_mocks_api_fail
   local exit_code=0
@@ -218,6 +234,7 @@ test_pr_resolution_api_fail_exits_nonzero() {
   fi
 }
 
+# test_pr_resolution_api_fail_stderr_message verifies that when the GitHub API returns an error the script prints a failure message containing "failed" (case-insensitive) and updates the pass/fail counters.
 test_pr_resolution_api_fail_stderr_message() {
   setup_mocks_api_fail
   local output

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -2,6 +2,7 @@
 
 ORIGINAL_PATH="$HOME/bin:$PATH"
 
+# setup_mocks_base creates a temporary mock directory and installs an executable mock `git` that returns a fixed repo URL for `remote get-url origin` and a fixed branch for `rev-parse --abbrev-ref HEAD`, exiting with status 1 for any other invocation.
 setup_mocks_base() {
   mock_dir=$(mktemp -d)
   cat > "$mock_dir/git" << 'GIT_EOF'
@@ -15,6 +16,7 @@ GIT_EOF
   chmod +x "$mock_dir/git"
 }
 
+# setup_mocks_nesting creates a temporary mock environment (mock `git` and `gh` CLIs) and per-comment reply JSON fixtures for testing comment/reply nesting; it accepts `pr_reviews` and `pr_issues` JSON strings followed by zero or more `"<cid>:<json>"` reply_spec arguments and writes `replies_<cid>.json`, then installs a `gh` mock that returns the provided data for pulls/42/comments, issues/42/comments, and pulls/comments/<id>/replies.
 setup_mocks_nesting() {
   local pr_reviews="$1"
   local pr_issues="$2"
@@ -52,10 +54,12 @@ REPLY_MOCK
   chmod +x "$mock_dir/gh"
 }
 
+# run_script executes the target script with the mock directory placed first in PATH, passing through all arguments.
 run_script() {
   PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
 }
 
+# cleanup_mocks removes the temporary mock directory created for test mocks.
 cleanup_mocks() {
   rm -rf "$mock_dir"
 }
@@ -74,6 +78,8 @@ test_names+=(
   test_nesting_multiple_replies_under_one_parent
 )
 
+# test_nesting_reply_block_present verifies that a review comment with a nested reply produces a reply block containing the literal ">>> reply" marker.
+# Mocks a single review comment and its reply, runs `comments --pr 42`, and increments the global `pass`/`fail` counters based on whether the marker appears in the output.
 test_nesting_reply_block_present() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
@@ -89,6 +95,7 @@ test_nesting_reply_block_present() {
   fi
 }
 
+# test_nesting_reply_appears_after_parent verifies that the reply marker ">>> reply" appears after its parent review comment in the script output.
 test_nesting_reply_appears_after_parent() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
@@ -107,6 +114,7 @@ test_nesting_reply_appears_after_parent() {
   fi
 }
 
+# test_nesting_reply_uses_marker verifies that a nested review reply is rendered with the ">>> reply" marker.
 test_nesting_reply_uses_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
@@ -122,6 +130,7 @@ test_nesting_reply_uses_marker() {
   fi
 }
 
+# test_nesting_reply_contains_author_created_body verifies that a reply's rendered block includes the `author`, `created`, and `body` fields.
 test_nesting_reply_contains_author_created_body() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
   local reply='[{"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","body":"reply body text"}]'
@@ -139,6 +148,7 @@ test_nesting_reply_contains_author_created_body() {
   fi
 }
 
+# test_nesting_in_reply_to_id_not_top_level ensures a review comment that has an `in_reply_to_id` is not rendered as a top-level `review-comment` block when running `comments --pr 42`.
 test_nesting_in_reply_to_id_not_top_level() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
@@ -159,6 +169,7 @@ test_nesting_in_reply_to_id_not_top_level() {
   fi
 }
 
+# test_nesting_no_replies_no_marker verifies that a review comment without replies does not produce the ">>> reply" marker in the script output.
 test_nesting_no_replies_no_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"lone parent"}]'
   setup_mocks_nesting "$review" '[]'
@@ -173,6 +184,7 @@ test_nesting_no_replies_no_marker() {
   fi
 }
 
+# test_nesting_issue_comment_no_reply_marker verifies that issue-level comments are rendered without the '>>> reply' marker.
 test_nesting_issue_comment_no_reply_marker() {
   local issue='[{"user":{"login":"carol"},"created_at":"2025-01-01T10:00:00Z","body":"issue-level comment"}]'
   setup_mocks_nesting '[]' "$issue"
@@ -187,6 +199,7 @@ test_nesting_issue_comment_no_reply_marker() {
   fi
 }
 
+# test_nesting_multiple_parents_independent_replies verifies that two separate review comments each render their own independent replies and updates the global pass/fail counters.
 test_nesting_multiple_parents_independent_replies() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -206,6 +219,7 @@ test_nesting_multiple_parents_independent_replies() {
   fi
 }
 
+# test_nesting_reply_only_under_correct_parent verifies that a reply is rendered only under its corresponding parent review comment and not under other parent comment blocks.
 test_nesting_reply_only_under_correct_parent() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -226,6 +240,7 @@ test_nesting_reply_only_under_correct_parent() {
   fi
 }
 
+# test_nesting_replies_sorted_chronologically verifies that replies for a review comment are rendered in ascending order by `created_at`, so the oldest reply appears first.
 test_nesting_replies_sorted_chronologically() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[
@@ -247,6 +262,7 @@ test_nesting_replies_sorted_chronologically() {
   fi
 }
 
+# test_nesting_multiple_replies_under_one_parent verifies that two separate replies to a single review comment produce two distinct `>>> reply` markers in the script output.
 test_nesting_multiple_replies_under_one_parent() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -1,0 +1,268 @@
+#!/usr/bin/env bash
+
+ORIGINAL_PATH="$HOME/bin:$PATH"
+
+setup_mocks_base() {
+  mock_dir=$(mktemp -d)
+  cat > "$mock_dir/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$mock_dir/git"
+}
+
+setup_mocks_nesting() {
+  local pr_reviews="$1"
+  local pr_issues="$2"
+  shift 2
+
+  setup_mocks_base
+
+  local reply_spec cid rdata
+  for reply_spec in "$@"; do
+    cid="${reply_spec%%:*}"
+    rdata="${reply_spec#*:}"
+    echo "$rdata" > "$mock_dir/replies_${cid}.json"
+  done
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'                >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$pr_reviews"              >> "$mock_dir/gh"
+  printf '    ;;\n'                                   >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'               >> "$mock_dir/gh"
+  printf "    echo '%s'\n" "$pr_issues"               >> "$mock_dir/gh"
+  printf '    ;;\n'                                   >> "$mock_dir/gh"
+  printf '  *"pulls/comments/"*"/replies"*)\n'       >> "$mock_dir/gh"
+  cat >> "$mock_dir/gh" << 'REPLY_MOCK'
+    _cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
+    _mdir=$(dirname "$0")
+    if [ -f "${_mdir}/replies_${_cid}.json" ]; then
+      cat "${_mdir}/replies_${_cid}.json"
+    else
+      echo "[]"
+    fi
+    ;;
+REPLY_MOCK
+  printf '  *) exit 1 ;;\n'                          >> "$mock_dir/gh"
+  printf 'esac\n'                                    >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+run_script() {
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
+}
+
+cleanup_mocks() {
+  rm -rf "$mock_dir"
+}
+
+test_names+=(
+  test_nesting_reply_block_present
+  test_nesting_reply_appears_after_parent
+  test_nesting_reply_uses_marker
+  test_nesting_reply_contains_author_created_body
+  test_nesting_in_reply_to_id_not_top_level
+  test_nesting_no_replies_no_marker
+  test_nesting_issue_comment_no_reply_marker
+  test_nesting_multiple_parents_independent_replies
+  test_nesting_reply_only_under_correct_parent
+  test_nesting_replies_sorted_chronologically
+  test_nesting_multiple_replies_under_one_parent
+)
+
+test_nesting_reply_block_present() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
+  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply block should contain '>>> reply' marker (output: $output)"
+  fi
+}
+
+test_nesting_reply_appears_after_parent() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"}]'
+  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local parent_line reply_line
+  parent_line=$(echo "$output" | grep -n "body: parent comment" | cut -d: -f1)
+  reply_line=$(echo "$output" | grep -n ">>> reply" | cut -d: -f1)
+  if [ -n "$parent_line" ] && [ -n "$reply_line" ] && [ "$reply_line" -gt "$parent_line" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: >>> reply ($reply_line) should appear after parent ($parent_line) (output: $output)"
+  fi
+}
+
+test_nesting_reply_uses_marker() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
+  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: nested reply must use '>>> reply' prefix (output: $output)"
+  fi
+}
+
+test_nesting_reply_contains_author_created_body() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
+  local reply='[{"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","body":"reply body text"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "author: replyuser" \
+    && echo "$output" | grep -qF "created: 2025-06-01T08:00:00Z" \
+    && echo "$output" | grep -qF "body: reply body text"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply block must contain author, created, and body fields (output: $output)"
+  fi
+}
+
+test_nesting_in_reply_to_id_not_top_level() {
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
+    {"id":11,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline child"}
+  ]'
+  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline child"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local block_count
+  block_count=$(echo "$output" | grep -c "^--- review-comment" || true)
+  if [ "$block_count" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: comment with in_reply_to_id should not appear as top-level review-comment (blocks: $block_count, output: $output)"
+  fi
+}
+
+test_nesting_no_replies_no_marker() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"lone parent"}]'
+  setup_mocks_nesting "$review" '[]'
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if ! echo "$output" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: comment with no replies must not contain '>>> reply' (output: $output)"
+  fi
+}
+
+test_nesting_issue_comment_no_reply_marker() {
+  local issue='[{"user":{"login":"carol"},"created_at":"2025-01-01T10:00:00Z","body":"issue-level comment"}]'
+  setup_mocks_nesting '[]' "$issue"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "issue-comment" && ! echo "$output" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comments must never have '>>> reply' markers (output: $output)"
+  fi
+}
+
+test_nesting_multiple_parents_independent_replies() {
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+  ]'
+  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply to A"}]'
+  local reply20='[{"user":{"login":"dave"},"created_at":"2025-01-01T13:00:00Z","body":"reply to B"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply10" "20:$reply20"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  if echo "$output" | grep -qF "reply to A" && echo "$output" | grep -qF "reply to B"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: each parent must carry its own independent replies (output: $output)"
+  fi
+}
+
+test_nesting_reply_only_under_correct_parent() {
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+  ]'
+  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"only for A"}]'
+  setup_mocks_nesting "$review" '[]' "10:$reply10"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local parent_b_section
+  parent_b_section=$(echo "$output" | sed -n '/body: parent B/,/^---/p')
+  if echo "$output" | grep -qF "only for A" && ! echo "$parent_b_section" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply should appear only under correct parent (output: $output)"
+  fi
+}
+
+test_nesting_replies_sorted_chronologically() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
+  local replies='[
+    {"user":{"login":"charlie"},"created_at":"2025-01-03T10:00:00Z","body":"third"},
+    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"second"},
+    {"user":{"login":"alice"},"created_at":"2025-01-01T11:00:00Z","body":"first"}
+  ]'
+  setup_mocks_nesting "$review" '[]' "10:$replies"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local first_reply_body
+  first_reply_body=$(echo "$output" | grep -A3 ">>> reply" | grep "body:" | head -1 | sed 's/body: //')
+  if [ "$first_reply_body" = "first" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: replies must be sorted ascending by created_at, expected 'first', got: '$first_reply_body' (output: $output)"
+  fi
+}
+
+test_nesting_multiple_replies_under_one_parent() {
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
+  local replies='[
+    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"reply one"},
+    {"user":{"login":"carol"},"created_at":"2025-01-03T10:00:00Z","body":"reply two"}
+  ]'
+  setup_mocks_nesting "$review" '[]' "10:$replies"
+  local output
+  output=$(run_script comments --pr 42 2>&1)
+  cleanup_mocks
+  local reply_count
+  reply_count=$(echo "$output" | grep -c ">>> reply" || true)
+  if [ "$reply_count" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected 2 reply markers, got $reply_count (output: $output)"
+  fi
+}

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env bash
+
+ORIGINAL_PATH="$HOME/bin:$PATH"
+
+KNOWN_SHA="cccccccccccccccccccccccccccccccccccccccc"
+UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
+
+HEAD_EPOCH="1742040000"
+SHA_EPOCH="1751587200"
+
+setup_mocks() {
+  mock_dir=$(mktemp -d)
+  cat > "$mock_dir/git" << GIT_EOF
+#!/usr/bin/env bash
+case "\$*" in
+  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+  "log -1 --format=%ct HEAD")    echo "$HEAD_EPOCH" ;;
+  "log -1 --format=%ct $KNOWN_SHA") echo "$SHA_EPOCH" ;;
+  "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$mock_dir/git"
+
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'           >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'          >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
+  printf 'esac\n'                               >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+}
+
+run_script() {
+  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
+}
+
+cleanup_mocks() {
+  rm -rf "$mock_dir"
+}
+
+test_names+=(
+  test_since_empty_resolves_to_empty
+  test_since_last_commit_exits_zero
+  test_since_last_commit_format_is_iso8601
+  test_since_known_sha_exits_zero
+  test_since_known_sha_format_is_iso8601
+  test_since_date_only_exits_zero
+  test_since_date_only_appends_midnight_utc
+  test_since_datetime_exits_zero
+  test_since_datetime_appends_z
+  test_since_unknown_sha_exits_nonzero
+  test_since_unknown_sha_stderr_mentions_unknown_commit
+  test_since_invalid_format_exits_nonzero
+  test_since_invalid_format_stderr_message
+  test_since_invalid_month_exits_nonzero
+  test_since_invalid_day_exits_nonzero
+  test_since_invalid_hour_exits_nonzero
+  test_since_short_sha_treated_as_invalid
+)
+
+test_since_empty_resolves_to_empty() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: omitting --since should exit 0 (exit: $exit_code)"
+  fi
+}
+
+test_since_last_commit_exits_zero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since last-commit >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since last-commit should exit 0 (exit: $exit_code)"
+  fi
+}
+
+test_since_last_commit_format_is_iso8601() {
+  setup_mocks
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
+  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
+  printf "    echo '[{\"user\":{\"login\":\"bot\"},\"created_at\":\"2099-01-01T00:00:00Z\",\"body\":\"future\"}]'\n" >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
+  printf 'esac\n'                                >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since last-commit 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: last-commit timestamp should be valid ISO-8601 and allow future comments through (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_since_known_sha_exits_zero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since "$KNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <known-sha> should exit 0 (exit: $exit_code)"
+  fi
+}
+
+test_since_known_sha_format_is_iso8601() {
+  setup_mocks
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
+  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
+  printf "    echo '[{\"user\":{\"login\":\"bot\"},\"created_at\":\"2099-01-01T00:00:00Z\",\"body\":\"future\"}]'\n" >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
+  printf 'esac\n'                                >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since "$KNOWN_SHA" 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <sha> timestamp should be valid ISO-8601 and allow future comments through (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_since_date_only_exits_zero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since 2025-06-15 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since YYYY-MM-DD should exit 0 (exit: $exit_code)"
+  fi
+}
+
+test_since_date_only_appends_midnight_utc() {
+  setup_mocks
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
+  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
+  printf "    echo '[{\"user\":{\"login\":\"alice\"},\"created_at\":\"2025-06-15T00:00:00Z\",\"body\":\"on midnight\"}]'\n" >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
+  printf 'esac\n'                                >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since 2025-06-15 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "on midnight"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: YYYY-MM-DD should resolve to midnight UTC and include comments at that instant (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_since_datetime_exits_zero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since 2025-06-15T08:30:00 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since YYYY-MM-DDTHH:mm:ss should exit 0 (exit: $exit_code)"
+  fi
+}
+
+test_since_datetime_appends_z() {
+  setup_mocks
+  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
+  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
+  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
+  printf "    echo '[{\"user\":{\"login\":\"bob\"},\"created_at\":\"2025-06-15T08:30:00Z\",\"body\":\"exact ts\"}]'\n" >> "$mock_dir/gh"
+  printf '    ;;\n'                               >> "$mock_dir/gh"
+  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
+  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
+  printf '    ;;\n'                              >> "$mock_dir/gh"
+  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
+  printf 'esac\n'                                >> "$mock_dir/gh"
+  chmod +x "$mock_dir/gh"
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since 2025-06-15T08:30:00 2>&1) || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "exact ts"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: datetime without Z should append Z and include comment at that instant (exit: $exit_code, output: $output)"
+  fi
+}
+
+test_since_unknown_sha_exits_nonzero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since "$UNKNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
+  cleanup_mocks
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <unknown-sha> should exit non-zero"
+  fi
+}
+
+test_since_unknown_sha_stderr_mentions_unknown_commit() {
+  setup_mocks
+  local output
+  output=$(run_script comments --pr 42 --since "$UNKNOWN_SHA" 2>&1) || true
+  cleanup_mocks
+  if echo "$output" | grep -qF "unknown commit"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <unknown-sha> should mention 'unknown commit' (output: $output)"
+  fi
+}
+
+test_since_invalid_format_exits_nonzero() {
+  assert_exit 1 "--since with arbitrary string exits non-zero" bash "$script" comments --pr 42 --since "not-a-date-at-all"
+}
+
+test_since_invalid_format_stderr_message() {
+  assert_stderr_contains "--since invalid format error message" "invalid --since value" bash "$script" comments --pr 42 --since "not-a-date-at-all"
+}
+
+test_since_invalid_month_exits_nonzero() {
+  assert_exit 1 "--since with month 13 exits non-zero" bash "$script" comments --pr 42 --since "2025-13-01"
+}
+
+test_since_invalid_day_exits_nonzero() {
+  assert_exit 1 "--since with day 32 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-32"
+}
+
+test_since_invalid_hour_exits_nonzero() {
+  assert_exit 1 "--since with hour 25 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-01T25:00:00"
+}
+
+test_since_short_sha_treated_as_invalid() {
+  assert_exit 1 "--since with 7-char sha exits non-zero" bash "$script" comments --pr 42 --since "abc1234"
+  assert_stderr_contains "--since 7-char sha emits invalid error" "invalid --since value" bash "$script" comments --pr 42 --since "abc1234"
+}

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -8,6 +8,7 @@ UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
 HEAD_EPOCH="1742040000"
 SHA_EPOCH="1751587200"
 
+# setup_mocks creates a temporary directory, writes mock `git` and `gh` executables into it (assigned to `$mock_dir`), and makes them executable for use in tests.
 setup_mocks() {
   mock_dir=$(mktemp -d)
   cat > "$mock_dir/git" << GIT_EOF
@@ -38,10 +39,12 @@ GIT_EOF
   chmod +x "$mock_dir/gh"
 }
 
+# run_script runs the target script with the mock directory prepended to PATH and forwards all arguments.
 run_script() {
   PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
 }
 
+# cleanup_mocks removes the temporary mock directory created by setup_mocks.
 cleanup_mocks() {
   rm -rf "$mock_dir"
 }
@@ -66,6 +69,7 @@ test_names+=(
   test_since_short_sha_treated_as_invalid
 )
 
+# test_since_empty_resolves_to_empty verifies that running `comments --pr 42` without a `--since` argument exits with status 0.
 test_since_empty_resolves_to_empty() {
   setup_mocks
   local exit_code=0
@@ -79,6 +83,7 @@ test_since_empty_resolves_to_empty() {
   fi
 }
 
+# test_since_last_commit_exits_zero verifies that running `comments --pr 42 --since last-commit` exits with status 0; it sets up mocks, runs the command, tears down mocks, increments `pass` on success or `fail` and prints a failure message including the exit code on error.
 test_since_last_commit_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -92,6 +97,7 @@ test_since_last_commit_exits_zero() {
   fi
 }
 
+# test_since_last_commit_format_is_iso8601 verifies that `--since last-commit` is treated as an ISO-8601 timestamp, allowing comments with future `created_at` values to appear and the command to exit successfully.
 test_since_last_commit_format_is_iso8601() {
   setup_mocks
   printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
@@ -118,6 +124,7 @@ test_since_last_commit_format_is_iso8601() {
   fi
 }
 
+# test_since_known_sha_exits_zero verifies that invoking the `comments --pr 42 --since "$KNOWN_SHA"` command exits with status 0.
 test_since_known_sha_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -131,6 +138,7 @@ test_since_known_sha_exits_zero() {
   fi
 }
 
+# test_since_known_sha_format_is_iso8601 verifies that using a known commit SHA with --since accepts ISO-8601 timestamps and allows comments with a matching future `created_at` to appear in the command output.
 test_since_known_sha_format_is_iso8601() {
   setup_mocks
   printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
@@ -157,6 +165,7 @@ test_since_known_sha_format_is_iso8601() {
   fi
 }
 
+# test_since_date_only_exits_zero verifies that invoking the CLI with a date-only `--since` value (YYYY-MM-DD) for PR 42 exits with status 0.
 test_since_date_only_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -170,6 +179,7 @@ test_since_date_only_exits_zero() {
   fi
 }
 
+# test_since_date_only_appends_midnight_utc verifies that a date-only `--since` value is treated as midnight UTC and that comments with a `created_at` timestamp at that instant are included in the command output.
 test_since_date_only_appends_midnight_utc() {
   setup_mocks
   printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
@@ -196,6 +206,8 @@ test_since_date_only_appends_midnight_utc() {
   fi
 }
 
+# test_since_datetime_exits_zero verifies that running `comments --pr 42 --since 2025-06-15T08:30:00` exits with status 0.
+# It sets up mock `git`/`gh` binaries, runs the command capturing the exit code, updates the `pass`/`fail` counters, and cleans up mocks.
 test_since_datetime_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -209,6 +221,7 @@ test_since_datetime_exits_zero() {
   fi
 }
 
+# test_since_datetime_appends_z tests that a --since datetime without a trailing `Z` is interpreted as UTC and that comments with the exact resulting timestamp are included in the command output.
 test_since_datetime_appends_z() {
   setup_mocks
   printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
@@ -235,6 +248,7 @@ test_since_datetime_appends_z() {
   fi
 }
 
+# test_since_unknown_sha_exits_nonzero verifies that running `comments --pr 42 --since <unknown SHA>` results in a non-zero exit status.
 test_since_unknown_sha_exits_nonzero() {
   setup_mocks
   local exit_code=0
@@ -248,6 +262,7 @@ test_since_unknown_sha_exits_nonzero() {
   fi
 }
 
+# test_since_unknown_sha_stderr_mentions_unknown_commit runs the comments command with `--since` set to an unknown SHA and verifies the output contains the literal substring "unknown commit".
 test_since_unknown_sha_stderr_mentions_unknown_commit() {
   setup_mocks
   local output
@@ -261,26 +276,32 @@ test_since_unknown_sha_stderr_mentions_unknown_commit() {
   fi
 }
 
+# test_since_invalid_format_exits_nonzero asserts that invoking the `comments` command with `--since` set to an arbitrary non-date string exits with a non-zero status.
 test_since_invalid_format_exits_nonzero() {
   assert_exit 1 "--since with arbitrary string exits non-zero" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
+# test_since_invalid_format_stderr_message checks that providing a malformed --since value causes the command to emit "invalid --since value" to stderr.
 test_since_invalid_format_stderr_message() {
   assert_stderr_contains "--since invalid format error message" "invalid --since value" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
+# test_since_invalid_month_exits_nonzero verifies that providing `--since` with an invalid month (`13`) causes the command to exit with a non-zero status.
 test_since_invalid_month_exits_nonzero() {
   assert_exit 1 "--since with month 13 exits non-zero" bash "$script" comments --pr 42 --since "2025-13-01"
 }
 
+# test_since_invalid_day_exits_nonzero asserts that invoking comments with --since "2025-01-32" exits with a non-zero status.
 test_since_invalid_day_exits_nonzero() {
   assert_exit 1 "--since with day 32 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-32"
 }
 
+# test_since_invalid_hour_exits_nonzero verifies that invoking comments --pr 42 with --since "2025-01-01T25:00:00" exits with a non-zero status.
 test_since_invalid_hour_exits_nonzero() {
   assert_exit 1 "--since with hour 25 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-01T25:00:00"
 }
 
+# test_since_short_sha_treated_as_invalid verifies that passing a 7-character SHA to `--since` causes the command to exit non-zero and emits "invalid --since value" on stderr.
 test_since_short_sha_treated_as_invalid() {
   assert_exit 1 "--since with 7-char sha exits non-zero" bash "$script" comments --pr 42 --since "abc1234"
   assert_stderr_contains "--since 7-char sha emits invalid error" "invalid --since value" bash "$script" comments --pr 42 --since "abc1234"


### PR DESCRIPTION
## Summary

Adds comprehensive test coverage for all 8 modules of `gh-pr-context`, closing the testing gap identified in #7.

**57 new tests** across 4 new test files, bringing total coverage from 82 to **139 tests**.

## Changes

| New File | Tests | Module Coverage |
|---|---|---|
| `test/test_pr_resolution.sh` | 10 | Auto-detect, explicit --pr, no-PR-found, API-fail |
| `test/test_since_resolution.sh` | 17 | All 5 --since variants + edge cases |
| `test/test_reply_nesting.sh` | 11 | Reply threading, in_reply_to_id, chronological sort |
| `test/test_output_formatter.sh` | 19 | Exact delimiters, field order, no raw JSON |

No production code changes. test/run.sh auto-discovers the new files.

## Fixes vs CodeRabbit plan

The CodeRabbit-provided test code had 4 bugs identified during codebase analysis:

1. **PR lookup mocks** returned full JSON but the script uses `--jq`. Fixed to echo just the number.
2. **Case pattern ordering** - specific paths reordered before generic globs.
3. **Empty PR response** fixed to echo empty string instead of `[]`.
4. **Windows compat** - added `--` end-of-options to grep calls with `---` patterns.

## Testing

```
139 passed, 0 failed
```

## CodeRabbit review findings

5 findings, all dismissed:
- 4x "add `set -euo pipefail`" - false positive; test files are sourced by run.sh which already sets this
- 1x "wc -l undercount in production code" - out of scope; no production changes in this PR

Closes #7


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded test suites covering output formatting (comments, replies, checks, logs) with strict delimiter/field/whitespace rules.
  * Added comprehensive tests for reply nesting, ordering, and correct parent association.
  * Added PR resolution tests for auto-detection and explicit PR override behavior, including API-failure handling.
  * Added extensive --since parsing tests for SHAs, dates, datetimes, and malformed/unknown inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->