### PR TITLE
feat: add curl-able installer and install tests (closes #8)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts must use LF line endings
+*.sh text eol=lf
+gh-pr-context text eol=lf
+install.sh text eol=lf

--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Install to a custom directory:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | bash -s /usr/local/bin
 ```
 
+Or use the `INSTALL_DIR` environment variable:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | INSTALL_DIR=/usr/local/bin bash
+```
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,7 @@ BRANCH="master"
 SCRIPT_NAME="gh-pr-context"
 RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
 
+# die prints an error message to stderr and exits with status 1.
 die() {
   echo "error: $1" >&2
   exit 1

--- a/install.sh
+++ b/install.sh
@@ -14,14 +14,14 @@ die() {
 
 install_dir="${INSTALL_DIR:-${1:-$HOME/.local/bin}}"
 
-mkdir -p "$install_dir" || die "failed to create directory: $install_dir"
+mkdir -p "$install_dir" 2>/dev/null || die "failed to create directory: $install_dir"
 
-tmp=$(mktemp) || die "failed to create temp file"
+tmp=$(mktemp 2>/dev/null) || die "failed to create temp file"
 trap 'rm -f "$tmp"' EXIT
 
-curl -fsSL "$RAW_BASE/$SCRIPT_NAME" -o "$tmp" || die "failed to download $SCRIPT_NAME"
+curl -fsSL "$RAW_BASE/$SCRIPT_NAME" -o "$tmp" >/dev/null 2>&1 || die "failed to download $SCRIPT_NAME"
 
-mv "$tmp" "$install_dir/$SCRIPT_NAME" || die "failed to write to $install_dir/$SCRIPT_NAME"
-chmod +x "$install_dir/$SCRIPT_NAME" || die "failed to set executable permissions on $install_dir/$SCRIPT_NAME"
+mv "$tmp" "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to write to $install_dir/$SCRIPT_NAME"
+chmod +x "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to set executable permissions on $install_dir/$SCRIPT_NAME"
 
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPO="akepo225/gh-pr-context"
+BRANCH="master"
+SCRIPT_NAME="gh-pr-context"
+RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
+
+die() {
+  echo "error: $1" >&2
+  exit 1
+}
+
+install_dir="${INSTALL_DIR:-${1:-$HOME/.local/bin}}"
+
+mkdir -p "$install_dir" || die "failed to create directory: $install_dir"
+
+tmp=$(mktemp) || die "failed to create temp file"
+trap 'rm -f "$tmp"' EXIT
+
+curl -fsSL "$RAW_BASE/$SCRIPT_NAME" -o "$tmp" || die "failed to download $SCRIPT_NAME"
+
+mv "$tmp" "$install_dir/$SCRIPT_NAME" || die "failed to write to $install_dir/$SCRIPT_NAME"
+chmod +x "$install_dir/$SCRIPT_NAME" || die "failed to set executable permissions on $install_dir/$SCRIPT_NAME"
+
+echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -2,6 +2,7 @@
 
 install_script="$repo_root/install.sh"
 
+# setup_mock_curl creates a mock `curl` executable in the given directory; when `behavior` is `success` the mock writes a `#!/usr/bin/env bash` header to the file provided with `-o`, otherwise the mock exits with status 1.
 setup_mock_curl() {
   local mockdir="$1"
   local behavior="${2:-success}"
@@ -27,6 +28,7 @@ MOCK
   chmod +x "$mockdir/curl"
 }
 
+# cleanup_tmpdir removes the specified directory and all of its contents recursively.
 cleanup_tmpdir() {
   rm -rf "$1"
 }
@@ -42,6 +44,7 @@ test_names+=(
   test_install_curl_failure_stderr
 )
 
+# test_install_default_dir verifies that running the installer with an empty INSTALL_DIR installs an executable `gh-pr-context` into `$HOME/.local/bin`.
 test_install_default_dir() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -61,6 +64,7 @@ test_install_default_dir() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_custom_dir_arg verifies the installer places an executable `gh-pr-context` in the custom directory provided as the first argument.
 test_install_custom_dir_arg() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -79,6 +83,7 @@ test_install_custom_dir_arg() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_custom_dir_env_var verifies the installer creates an executable `gh-pr-context` in the directory specified by the `INSTALL_DIR` environment variable.
 test_install_custom_dir_env_var() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -97,6 +102,7 @@ test_install_custom_dir_env_var() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_env_var_takes_precedence_over_arg verifies that the INSTALL_DIR environment variable takes precedence over a positional argument by ensuring `gh-pr-context` is created in the directory specified by `INSTALL_DIR`.
 test_install_env_var_takes_precedence_over_arg() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -115,6 +121,7 @@ test_install_env_var_takes_precedence_over_arg() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_file_is_executable verifies the installer creates an executable `gh-pr-context` in a custom `INSTALL_DIR`.
 test_install_file_is_executable() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -131,6 +138,7 @@ test_install_file_is_executable() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_curl_failure_exits_nonzero ensures the installer exits with a non-zero status when the mocked `curl` fails.
 test_install_curl_failure_exits_nonzero() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -148,6 +156,7 @@ test_install_curl_failure_exits_nonzero() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_success_message verifies the installer prints a success message including the installed gh-pr-context path.
 test_install_success_message() {
   local tmpdir
   tmpdir=$(mktemp -d)
@@ -165,6 +174,7 @@ test_install_success_message() {
   cleanup_tmpdir "$tmpdir"
 }
 
+# test_install_curl_failure_stderr verifies that when `curl` fails the installer writes an `error:` message to stderr.
 test_install_curl_failure_stderr() {
   local tmpdir
   tmpdir=$(mktemp -d)

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env bash
+
+install_script="$repo_root/install.sh"
+
+setup_mock_curl() {
+  local mockdir="$1"
+  local behavior="${2:-success}"
+  mkdir -p "$mockdir"
+  if [ "$behavior" = "success" ]; then
+    cat > "$mockdir/curl" << 'MOCK'
+#!/usr/bin/env bash
+outfile=""
+for arg in "$@"; do
+  prev="${last:-}"
+  last="$arg"
+  if [ "$prev" = "-o" ]; then
+    outfile="$arg"
+  fi
+done
+if [ -n "$outfile" ]; then
+  echo "#!/usr/bin/env bash" > "$outfile"
+fi
+MOCK
+  else
+    printf '#!/usr/bin/env bash\nexit 1\n' > "$mockdir/curl"
+  fi
+  chmod +x "$mockdir/curl"
+}
+
+cleanup_tmpdir() {
+  rm -rf "$1"
+}
+
+test_names+=(
+  test_install_default_dir
+  test_install_custom_dir_arg
+  test_install_custom_dir_env_var
+  test_install_env_var_takes_precedence_over_arg
+  test_install_file_is_executable
+  test_install_curl_failure_exits_nonzero
+  test_install_success_message
+  test_install_curl_failure_stderr
+)
+
+test_install_default_dir() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local fake_home="$tmpdir/home"
+  mkdir -p "$fake_home"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local output
+  output=$(HOME="$fake_home" INSTALL_DIR="" PATH="$mockdir:$PATH" bash "$install_script" 2>&1)
+  local expected="$fake_home/.local/bin/gh-pr-context"
+  if [ -f "$expected" ] && [ -x "$expected" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: default dir - file not found or not executable at $expected"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_custom_dir_arg() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/my-bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local output
+  output=$(INSTALL_DIR="" PATH="$mockdir:$PATH" bash "$install_script" "$custom" 2>&1)
+  local expected="$custom/gh-pr-context"
+  if [ -f "$expected" ] && [ -x "$expected" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: custom dir arg - file not found or not executable at $expected"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_custom_dir_env_var() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/env-bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local output
+  output=$(INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" 2>&1)
+  local expected="$custom/gh-pr-context"
+  if [ -f "$expected" ] && [ -x "$expected" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: custom dir env var - file not found or not executable at $expected"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_env_var_takes_precedence_over_arg() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local envdir="$tmpdir/env-dir"
+  local argdir="$tmpdir/arg-dir"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local output
+  output=$(INSTALL_DIR="$envdir" PATH="$mockdir:$PATH" bash "$install_script" "$argdir" 2>&1)
+  if [ -f "$envdir/gh-pr-context" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: env var should be used when set (arg should be ignored)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_file_is_executable() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" >/dev/null 2>&1
+  if [ -x "$custom/gh-pr-context" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: installed file should be executable"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_curl_failure_exits_nonzero() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" failure
+  local exit_code=0
+  INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: curl failure should exit non-zero"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_success_message() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local output
+  output=$(INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" 2>&1)
+  if echo "$output" | grep -q "installed gh-pr-context to $custom/gh-pr-context"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: success message should contain installed path (got: $output)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+test_install_curl_failure_stderr() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" failure
+  local stderr
+  stderr=$(INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" 2>&1 >/dev/null) || true
+  if echo "$stderr" | grep -q "error:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: curl failure should output error to stderr (got: $stderr)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+: "${repo_root:?repo_root must be set by test harness}"
 install_script="$repo_root/install.sh"
 
 # setup_mock_curl creates a mock `curl` executable in the given directory; when `behavior` is `success` the mock writes a `#!/usr/bin/env bash` header to the file provided with `-o`, otherwise the mock exits with status 1.


### PR DESCRIPTION
## Summary

- **`install.sh`**: Curl-able installer that downloads `gh-pr-context` to `~/.local/bin/` (default). Supports custom directory via `INSTALL_DIR` env var or positional argument.
- **`.gitattributes`**: Forces LF line endings for shell scripts, fixing `set -euo pipefail` error on Windows/WSL caused by `core.autocrlf=true`.
- **`test/test_install.sh`**: 8 tests covering default dir, custom dir (arg & env var), env var precedence, executable permissions, curl failure exit code, success message, and error stderr.
- **`README.md`**: Added `INSTALL_DIR` env var install example.

## Acceptance Criteria (from #8)

- [x] `curl -fsSL <url> | bash` installs `gh-pr-context` to `~/.local/bin/`
- [x] Custom install directory is supported (arg + env var)
- [x] Installed script is executable
- [x] README includes install command and basic usage
- [x] Installer exits non-zero on failure with a clear error message

## Test Results

```
147 passed, 0 failed
```

## CodeRabbit

No findings.

Closes #8


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an installer script for easy setup of the tool into a chosen directory.

* **Documentation**
  * README formatting and whitespace normalized.

* **Tests**
  * Added tests verifying installer behavior, custom paths, executability and error handling.

* **Chores**
  * Enforced LF line endings for shell scripts to ensure consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->