### PR TITLE
fix: gracefully handle 404 when fetching review comment replies

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -137,13 +137,15 @@ cmd_comments() {
   local replies_map="{}"
   for cid in $review_ids; do
     local replies_raw
-    replies_raw=$(gh api "repos/$owner_repo/pulls/comments/$cid/replies" --paginate) \
-      || die "failed to fetch replies for comment $cid"
+    replies_raw=$(gh api "repos/$owner_repo/pulls/comments/$cid/replies" --paginate 2>/dev/null) || replies_raw="[]"
     if [ -n "$since_ref" ]; then
       replies_raw=$(echo "$replies_raw" | jq --arg since "$since_ref" '[.[] | select(.created_at >= $since)]')
     fi
     local reply_fields
     reply_fields=$(echo "$replies_raw" | jq '[.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created)')
+    if [ "$reply_fields" = "[]" ] || [ -z "$reply_fields" ]; then
+      continue
+    fi
     replies_map=$(echo "$replies_map" | jq --arg cid "$cid" --argjson replies "$reply_fields" '. + {($cid): $replies}')
   done
 


### PR DESCRIPTION
## Summary

- The GitHub API returns HTTP 404 for the `/pulls/comments/{id}/replies` endpoint when a review comment has no replies
- The previous code used `|| die `` which crashed on any PR with comments that lack replies
- This fix falls back to `[]` on API failure and skips comments with no replies instead of terminating

## Testing

- All 147 unit tests pass
- All 23 live integration tests pass against real PRs (#9, #10, #11, #13, #15, #16)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling for fetching review comment reply threads—the system now gracefully defaults to showing no replies instead of exiting unexpectedly when issues occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->