### PR TITLE
feat: add pr-qa-review agent skill for LLM assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ An installable agent skill for LLM coding assistants is included in `skill/SKILL
 To install into your agent's skills directory:
 
 ```bash
-cp -r skill/ ~/.agents/skills/pr-qa-review/
+mkdir -p ~/.agents/skills/pr-qa-review && cp skill/SKILL.md ~/.agents/skills/pr-qa-review/SKILL.md
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -111,6 +111,16 @@ conclusion: failure
 | `YYYY-MM-DD` | Comments on or after that date (UTC) |
 | `YYYY-MM-DDTHH:mm:ss` | Comments on or after that datetime (UTC) |
 
+## Agent Skill
+
+An installable agent skill for LLM coding assistants is included in `skill/SKILL.md`. It provides a full QA & delivery review workflow that uses `gh-pr-context` to gather PR comments, CI status, and failed check logs before shipping.
+
+To install into your agent's skills directory:
+
+```bash
+cp -r skill/ ~/.agents/skills/pr-qa-review/
+```
+
 ## License
 
 MIT

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ conclusion: failure
 
 An installable agent skill for LLM coding assistants is included in `skill/SKILL.md`. It provides a full QA & delivery review workflow that uses `gh-pr-context` to gather PR comments, CI status, and failed check logs before shipping.
 
-To install into your agent's skills directory:
+To install into your agent's skills directory (run from the cloned repo root):
 
 ```bash
 mkdir -p ~/.agents/skills/pr-qa-review && cp skill/SKILL.md ~/.agents/skills/pr-qa-review/SKILL.md

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -47,7 +47,7 @@ Run these commands in the project directory (branch must have an open PR, or pas
 # All comments (review comments with nested replies + issue comments)
 gh-pr-context comments
 
-# Only new comments since your last push — most useful for iterative review
+# Only new comments since your latest commit (uses commit timestamp, not push time)
 gh-pr-context comments --since last-commit
 
 # CI check status

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: pr-qa-review
+description: QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".
+---
+
+# PR QA & Delivery Review
+
+Run this workflow when implementation is complete, before shipping.
+
+## Prerequisites
+
+Requires `gh-pr-context` on PATH. If missing, install:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | bash
+```
+
+Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.
+
+## Workflow
+
+### 1. Self-Review
+
+- Re-read the implementation plan and original issue. Verify every acceptance criterion is met.
+- Audit the diff for: bugs, typos, missing error handling, unhandled edge cases, hardcoded values, leftover debug code, incomplete TODOs.
+- Check documentation (README, inline docs, AGENTS.md) is up to date.
+- Verify no unintended files were modified or created.
+
+### 2. Integration & Dependency Check
+
+- Confirm all new dependencies are intentional and documented.
+- Verify imports, exports, and module boundaries are correct.
+- Ensure no breaking changes to existing interfaces.
+
+### 3. Runtime Verification
+
+- Run the full test suite. All tests must pass.
+- Run linting, typechecking, or static analysis defined in the project.
+- Exercise changed functionality manually or via integration tests where applicable.
+- Check container logs, server output, or browser console for errors if relevant.
+
+### 4. Gather PR Context
+
+Run these commands in the project directory (branch must have an open PR, or pass `--pr <number>`):
+
+```bash
+# All comments (review comments with nested replies + issue comments)
+gh-pr-context comments
+
+# Only new comments since your last push — most useful for iterative review
+gh-pr-context comments --since last-commit
+
+# CI check status
+gh-pr-context status
+
+# Logs for failed checks (no output if all pass)
+gh-pr-context logs
+```
+
+Read the output carefully. For each comment or failed check, determine if action is needed.
+
+**Output format reference:**
+
+- `--- review-comment` — Inline code review comment. Fields: `path`, `line`, `body`. Replies nested under `>>> reply`.
+- `--- issue-comment` — General PR comment. Fields: `author`, `created`, `body`. Flat, no replies.
+- `--- check` — CI check. Fields: `name`, `status`, optional `conclusion`.
+- `--- log` — Failed check log. Fields: `name`, log body. Truncated at 500 lines with `[truncated: N lines omitted]`.
+
+### 5. Fix All Findings
+
+Address every legitimate issue from steps 1–4. Dismiss only clearly false positives — explain dismissals in the commit message or PR description.
+
+### 6. Create a Pull Request (skip if PR already exists)
+
+- Do **not** push to `main`. Create a feature branch and open a PR.
+- Write a clear summary: what changed, why, and how it was tested.
+- Link the original issue.
+
+### 7. Monitor & Iterate
+
+- Re-run `gh-pr-context comments --since last-commit` after each push to catch new feedback.
+- Re-run `gh-pr-context status` and `gh-pr-context logs` to verify CI.
+- Evaluate each review comment. Implement only comments that provide substantial, grounded improvements.
+- Push fixes, wait for re-check, repeat until the PR is mergeable.

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -12,7 +12,7 @@ Run this workflow when implementation is complete, before shipping.
 Requires `gh-pr-context` on PATH. If missing, install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/v0.1.0/install.sh | bash
 ```
 
 Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.


### PR DESCRIPTION
## Summary

- Add `skill/SKILL.md` — an installable agent skill that provides a 7-step QA & delivery review workflow using `gh-pr-context` (self-review, integration check, runtime verification, gather PR context, fix findings, create PR, monitor & iterate)
- Update `README.md` with Agent Skill section and install instructions (`cp -r skill/ ~/.agents/skills/pr-qa-review/`)
- Skill includes install fallback (curl from master) if `gh-pr-context` is not on PATH
- No changes to the tool itself

## Test plan

- [x] All 147 existing tests pass
- [x] Skill follows standard structure (frontmatter with name/description, triggers in description, under 100 lines)
- [x] No hardcoded user paths — install uses public curl URL

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Agent Skill documentation introducing an installable LLM coding assistant with a QA & delivery review workflow.
  * Documents when to run the workflow, prerequisites (CLI tools/auth), installation steps, and frontmatter triggers.
  * Provides concrete commands to gather PR context, CI status and logs, expected output entry types, and log truncation rules.
  * Outlines a step-by-step self-review-to-delivery process and iteration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->