### PR TITLE
refactor: migrate test mocks from PATH injection to shell function overrides

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -282,19 +282,21 @@ cmd_logs() {
   done <<< "$failed_pairs"
 }
 
-if [ $# -eq 0 ]; then
-  usage
-  exit 1
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  if [ $# -eq 0 ]; then
+    usage
+    exit 1
+  fi
+
+  command=$1
+  shift
+
+  case "$command" in
+    comments) cmd_comments "$@" ;;
+    status)   cmd_status "$@" ;;
+    logs)     cmd_logs "$@" ;;
+    -h|--help) usage; exit 0 ;;
+    --version) echo "gh-pr-context $version"; exit 0 ;;
+    *) die "unknown command: $command" ;;
+  esac
 fi
-
-command=$1
-shift
-
-case "$command" in
-  comments) cmd_comments "$@" ;;
-  status)   cmd_status "$@" ;;
-  logs)     cmd_logs "$@" ;;
-  -h|--help) usage; exit 0 ;;
-  --version) echo "gh-pr-context $version"; exit 0 ;;
-  *) die "unknown command: $command" ;;
-esac

--- a/test/run.sh
+++ b/test/run.sh
@@ -53,6 +53,7 @@ for test_file in "$script_dir"/test_*.sh; do
   for t in "${test_names[@]}"; do
     "$t"
   done
+  unset -f git gh 2>/dev/null || true
 done
 
 echo ""

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -10,6 +10,7 @@ MOCK_HEAD_EPOCH="1748772000"
 MOCK_SHA_EPOCH="1749988800"
 _MOCK_REPLY_IDS=""
 
+# setup_mocks defines in-process mock `git` and `gh` functions for tests that return deterministic repository metadata and commit timestamps; `git` responds to specific queries (remote URL, current branch, and commit epochs for known SHAs) and fails for unknown SHAs, while `gh` defaults to exiting with error.
 setup_mocks() {
   git() {
     case "$*" in
@@ -27,6 +28,7 @@ setup_mocks() {
   }
 }
 
+# _clear_reply_vars unsets any `_MOCK_REPLY_<id>` mock variables listed in `_MOCK_REPLY_IDS` and resets `_MOCK_REPLY_IDS` to an empty string.
 _clear_reply_vars() {
   for cid in $_MOCK_REPLY_IDS; do
     unset "_MOCK_REPLY_${cid}" 2>/dev/null || true
@@ -34,6 +36,7 @@ _clear_reply_vars() {
   _MOCK_REPLY_IDS=""
 }
 
+# setup_mocks_with_pr sets up mock git/gh behavior for a pull request and registers provided JSON payloads for review comments (first arg) and issue comments (second arg).
 setup_mocks_with_pr() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -52,6 +55,7 @@ setup_mocks_with_pr() {
   }
 }
 
+# setup_mocks_with_pr_and_replies sets up git/gh mock functions for a pull request: the first argument is the JSON array for review comments, the second is the JSON array for issue comments, and any additional arguments are reply specs in the form "<comment_id>:<json>" which are exported as _MOCK_REPLY_<comment_id> and tracked in _MOCK_REPLY_IDS.
 setup_mocks_with_pr_and_replies() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -84,6 +88,8 @@ setup_mocks_with_pr_and_replies() {
   }
 }
 
+# run_script runs the test script under the current mock environment.
+# It exports the mocked git/gh functions and the mock state variables, then invokes bash on $script with any provided arguments.
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES MOCK_HEAD_EPOCH MOCK_SHA_EPOCH KNOWN_SHA UNKNOWN_SHA
@@ -119,6 +125,7 @@ test_names+=(
   test_since_unknown_sha_stderr_message
 )
 
+# test_comments_empty_pr_no_output verifies that invoking `comments --pr 42` against a PR with no review or issue comments produces no output.
 test_comments_empty_pr_no_output() {
   setup_mocks_with_pr '[]' '[]'
   local output
@@ -131,6 +138,7 @@ test_comments_empty_pr_no_output() {
   fi
 }
 
+# test_comments_review_only verifies that a pull request review comment is rendered and includes the reviewer and the `review-comment` marker.
 test_comments_review_only() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]' '[]'
   local output
@@ -143,6 +151,7 @@ test_comments_review_only() {
   fi
 }
 
+# test_comments_issue_only sets up a PR with only an issue comment and verifies the `comments` command prints an `issue-comment` block containing author `bob`, incrementing pass or fail and printing a diagnostic on failure.
 test_comments_issue_only() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
   local output
@@ -155,6 +164,7 @@ test_comments_issue_only() {
   fi
 }
 
+# test_comments_sorted_by_date verifies that comments are listed in chronological order so an earlier issue comment appears before a later review comment.
 test_comments_sorted_by_date() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"review later"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T10:00:00Z","body":"issue earlier"}]'
@@ -171,6 +181,7 @@ test_comments_sorted_by_date() {
   fi
 }
 
+# test_comments_review_has_path_and_line sets up a mocked PR review with a file path and line number and asserts the comments command prints `path:` and `line:` in its output.
 test_comments_review_has_path_and_line() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":42,"body":"fix this"}]' '[]'
   local output
@@ -183,6 +194,7 @@ test_comments_review_has_path_and_line() {
   fi
 }
 
+# test_comments_issue_no_path_or_line verifies that issue comments produced for a PR do not include `path:` or `line:` fields.
 test_comments_issue_no_path_or_line() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"bob"},"created_at":"2025-01-01T10:00:00Z","body":"general comment"}]'
   local output
@@ -195,6 +207,7 @@ test_comments_issue_no_path_or_line() {
   fi
 }
 
+# test_comments_explicit_pr sets up mock PR comments and verifies that running `comments --pr 42` outputs the mocked author "alice", updating the pass or fail counters.
 test_comments_explicit_pr() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","body":"hello"}]'
   local output
@@ -212,6 +225,7 @@ test_comments_exits_zero_on_success() {
   assert_exit 0 "comments exits 0 on success" run_script comments --pr 42
 }
 
+# test_comments_multiline_body verifies that a review comment body with multiple lines is fully rendered in the command output.
 test_comments_multiline_body() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"line one\nline two"}]' '[]'
   local output
@@ -239,6 +253,7 @@ test_comments_multiple_review_sorted() {
   fi
 }
 
+# test_comments_review_with_replies verifies that the comments command prints a reply block for a review comment that has replies and includes the reply's author, body, and created timestamp.
 test_comments_review_with_replies() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
   local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
@@ -256,6 +271,7 @@ test_comments_review_with_replies() {
   fi
 }
 
+# test_comments_review_no_replies verifies that a review comment with no replies is displayed without a ">>> reply" block.
 test_comments_review_no_replies() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
   setup_mocks_with_pr_and_replies "$review_json" '[]'
@@ -269,6 +285,7 @@ test_comments_review_no_replies() {
   fi
 }
 
+# test_comments_mixed_replies verifies that a review with replies shows a reply block while another review without replies does not.
 test_comments_mixed_replies() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"has replies"},{"id":102,"user":{"login":"carol"},"created_at":"2025-01-01T09:00:00Z","path":"b.sh","line":2,"body":"no replies"}]'
   local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply here"}]'
@@ -287,6 +304,7 @@ test_comments_mixed_replies() {
   fi
 }
 
+# test_comments_issue_stays_flat verifies that issue comments remain flat (no `>>>` reply markers) even when review comments have replies.
 test_comments_issue_stays_flat() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
@@ -305,6 +323,7 @@ test_comments_issue_stays_flat() {
   fi
 }
 
+# test_comments_replies_sorted_under_parent verifies that replies to a review are sorted by `created_at` so the earliest reply is shown first.
 test_comments_replies_sorted_under_parent() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"later reply"},{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"earlier reply"}]'
@@ -321,6 +340,7 @@ test_comments_replies_sorted_under_parent() {
   fi
 }
 
+# test_comments_reply_in_main_response_not_duplicated ensures a reply that appears inline in the main review list and also via the replies endpoint is printed exactly once.
 test_comments_reply_in_main_response_not_duplicated() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":102,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline reply"}]'
   local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline reply"}]'
@@ -337,6 +357,7 @@ test_comments_reply_in_main_response_not_duplicated() {
   fi
 }
 
+# test_since_last_commit_filters_old verifies that running `comments --since last-commit` excludes comments older than the mocked HEAD commit while including comments whose timestamps are equal to or newer than the mocked HEAD.
 test_since_last_commit_filters_old() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-05-01T09:00:00Z","path":"a.sh","line":1,"body":"old comment"},{"user":{"login":"bob"},"created_at":"2025-07-01T10:00:00Z","path":"b.sh","line":2,"body":"new comment"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"exact match"}]'
@@ -353,6 +374,7 @@ test_since_last_commit_filters_old() {
   fi
 }
 
+# test_since_date_filters_old verifies that using `--since YYYY-MM-DD` excludes comments created before that date while including comments on or after it.
 test_since_date_filters_old() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-05-15T23:59:59Z","path":"a.sh","line":1,"body":"before date"},{"user":{"login":"bob"},"created_at":"2025-06-01T00:00:00Z","path":"b.sh","line":2,"body":"on date"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-15T12:00:00Z","body":"after date"}]'
@@ -369,6 +391,7 @@ test_since_date_filters_old() {
   fi
 }
 
+# test_since_datetime_filters_old verifies that comments before a specified ISO datetime are excluded and comments at or after that datetime are included.
 test_since_datetime_filters_old() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-06-01T09:59:59Z","path":"a.sh","line":1,"body":"before datetime"},{"user":{"login":"bob"},"created_at":"2025-06-01T10:00:00Z","path":"b.sh","line":2,"body":"exact datetime"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T12:00:00Z","body":"after datetime"}]'
@@ -385,6 +408,7 @@ test_since_datetime_filters_old() {
   fi
 }
 
+# test_since_sha_filters_old verifies that --since <SHA> filters out comments created before the commit timestamp corresponding to KNOWN_SHA while keeping comments at or after that timestamp.
 test_since_sha_filters_old() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-06-10T09:00:00Z","path":"a.sh","line":1,"body":"before sha"},{"user":{"login":"bob"},"created_at":"2025-06-20T10:00:00Z","path":"b.sh","line":2,"body":"after sha"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-15T12:00:00Z","body":"exact sha ts"}]'
@@ -401,6 +425,7 @@ test_since_sha_filters_old() {
   fi
 }
 
+# test_since_no_filter_returns_all verifies that when no `--since` filter is given the command returns all comments across reviews and issues.
 test_since_no_filter_returns_all() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"old"},{"user":{"login":"bob"},"created_at":"2025-12-01T10:00:00Z","path":"b.sh","line":2,"body":"new"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"mid"}]'
@@ -417,6 +442,7 @@ test_since_no_filter_returns_all() {
   fi
 }
 
+# test_since_all_overrides_since verifies that using --all causes all PR and issue comments to be returned even when a --since filter is provided.
 test_since_all_overrides_since() {
   local review_json='[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"old"},{"user":{"login":"bob"},"created_at":"2025-12-01T10:00:00Z","path":"b.sh","line":2,"body":"new"}]'
   local issue_json='[{"user":{"login":"carol"},"created_at":"2025-06-01T10:00:00Z","body":"mid"}]'
@@ -433,6 +459,7 @@ test_since_all_overrides_since() {
   fi
 }
 
+# test_since_last_commit_includes_equal verifies that comments with created_at exactly equal to the PR HEAD timestamp are included when filtering with --since last-commit.
 test_since_last_commit_includes_equal() {
   local issue_json="[{\"user\":{\"login\":\"alice\"},\"created_at\":\"$MOCK_HEAD_TS\",\"body\":\"exactly at HEAD ts\"}]"
   setup_mocks_with_pr '[]' "$issue_json"
@@ -446,6 +473,9 @@ test_since_last_commit_includes_equal() {
   fi
 }
 
+# test_since_filters_replies_too verifies that the `--since` option filters reply comments by their `created_at` timestamp.
+# It sets up a parent review with one old and one new reply, runs `comments --pr 42 --since 2025-06-01T00:00:00`,
+# and asserts that only the reply on/after the cutoff appears in the output.
 test_since_filters_replies_too() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"}]'
   local replies_data='[{"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","body":"old reply"},{"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","body":"new reply"}]'
@@ -461,6 +491,7 @@ test_since_filters_replies_too() {
   fi
 }
 
+# test_since_unknown_sha_exits_nonzero verifies that invoking `comments` with `--since` set to an unknown commit SHA causes the command to exit with a non-zero status.
 test_since_unknown_sha_exits_nonzero() {
   setup_mocks_with_pr '[]' '[]'
   local exit_code=0
@@ -473,6 +504,7 @@ test_since_unknown_sha_exits_nonzero() {
   fi
 }
 
+# test_since_unknown_sha_stderr_message tests that invoking comments with --since set to an unknown SHA emits an "unknown commit" message.
 test_since_unknown_sha_stderr_message() {
   setup_mocks_with_pr '[]' '[]'
   local output

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
 KNOWN_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 UNKNOWN_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -8,94 +8,86 @@ MOCK_HEAD_TS="2025-06-01T10:00:00Z"
 MOCK_SHA_TS="2025-06-15T12:00:00Z"
 MOCK_HEAD_EPOCH="1748772000"
 MOCK_SHA_EPOCH="1749988800"
+_MOCK_REPLY_IDS=""
 
 setup_mocks() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << GIT_EOF
-#!/usr/bin/env bash
-case "\$*" in
-  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
-  "branch --show-current") echo "feature-branch" ;;
-  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  "log -1 --format=%ct HEAD") echo "$MOCK_HEAD_EPOCH" ;;
-  "log -1 --format=%ct $KNOWN_SHA") echo "$MOCK_SHA_EPOCH" ;;
-  "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "branch --show-current") echo "feature-branch" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      "log -1 --format=%ct HEAD") echo "$MOCK_HEAD_EPOCH" ;;
+      "log -1 --format=%ct $KNOWN_SHA") echo "$MOCK_SHA_EPOCH" ;;
+      "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
+}
+
+_clear_reply_vars() {
+  for cid in $_MOCK_REPLY_IDS; do
+    unset "_MOCK_REPLY_${cid}" 2>/dev/null || true
+  done
+  _MOCK_REPLY_IDS=""
 }
 
 setup_mocks_with_pr() {
-  local pr_reviews="$1"
-  local pr_issues="$2"
+  _MOCK_PR_REVIEWS="$1"
+  _MOCK_PR_ISSUES="$2"
 
   setup_mocks
+  _clear_reply_vars
 
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '[{"number":42}]' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/42/comments\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"issues/42/comments\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_issues" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/comments/\"*\"/replies\"*)\n' >> "$mock_dir/gh"
-  printf '    echo "[]"\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '[{"number":42}]' ;;
+      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
+      *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_with_pr_and_replies() {
-  local pr_reviews="$1"
-  local pr_issues="$2"
+  _MOCK_PR_REVIEWS="$1"
+  _MOCK_PR_ISSUES="$2"
   shift 2
 
   setup_mocks
+  _clear_reply_vars
 
   local reply_spec cid rdata
   for reply_spec in "$@"; do
     cid="${reply_spec%%:*}"
     rdata="${reply_spec#*:}"
-    echo "$rdata" > "$mock_dir/replies_${cid}.json"
+    export "_MOCK_REPLY_${cid}=$rdata"
+    _MOCK_REPLY_IDS="$_MOCK_REPLY_IDS $cid"
   done
 
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '[{"number":42}]' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/42/comments\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"issues/42/comments\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_issues" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/comments/\"*\"/replies\"*)\n' >> "$mock_dir/gh"
-  cat >> "$mock_dir/gh" << 'REPLY_MOCK'
-    _cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-    _mdir=$(dirname "$0")
-    if [ -f "${_mdir}/replies_${_cid}.json" ]; then
-      cat "${_mdir}/replies_${_cid}.json"
-    else
-      echo "[]"
-    fi
-    ;;
-REPLY_MOCK
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '[{"number":42}]' ;;
+      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
+      *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
+      *"pulls/comments/"*"/replies"*)
+        local cid
+        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
+        local var="_MOCK_REPLY_${cid}"
+        echo "${!var:-[]}"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES MOCK_HEAD_EPOCH MOCK_SHA_EPOCH KNOWN_SHA UNKNOWN_SHA
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -131,7 +123,6 @@ test_comments_empty_pr_no_output() {
   setup_mocks_with_pr '[]' '[]'
   local output
   output=$(run_script comments --pr 42 2>&1) || true
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else
@@ -144,7 +135,6 @@ test_comments_review_only() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]' '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "review-comment" && echo "$output" | grep -qF "alice"; then
     pass=$((pass + 1))
   else
@@ -157,7 +147,6 @@ test_comments_issue_only() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "issue-comment" && echo "$output" | grep -qF "bob"; then
     pass=$((pass + 1))
   else
@@ -172,7 +161,6 @@ test_comments_sorted_by_date() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local first_author
   first_author=$(echo "$output" | grep -m1 "author:" | head -1 | sed 's/author: //')
   if [ "$first_author" = "bob" ]; then
@@ -187,7 +175,6 @@ test_comments_review_has_path_and_line() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":42,"body":"fix this"}]' '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -q "path: src/main.sh" && echo "$output" | grep -q "line: 42"; then
     pass=$((pass + 1))
   else
@@ -200,7 +187,6 @@ test_comments_issue_no_path_or_line() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"bob"},"created_at":"2025-01-01T10:00:00Z","body":"general comment"}]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -q "path:" || echo "$output" | grep -q "line:"; then
     fail=$((fail + 1))
     echo "FAIL: issue comment should not contain path or line fields"
@@ -213,7 +199,6 @@ test_comments_explicit_pr() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","body":"hello"}]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "alice"; then
     pass=$((pass + 1))
   else
@@ -225,14 +210,12 @@ test_comments_explicit_pr() {
 test_comments_exits_zero_on_success() {
   setup_mocks_with_pr '[]' '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","body":"ok"}]'
   assert_exit 0 "comments exits 0 on success" run_script comments --pr 42
-  cleanup_mocks
 }
 
 test_comments_multiline_body() {
   setup_mocks_with_pr '[{"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"line one\nline two"}]' '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "line one" && echo "$output" | grep -qF "line two"; then
     pass=$((pass + 1))
   else
@@ -246,7 +229,6 @@ test_comments_multiple_review_sorted() {
   setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local first_author
   first_author=$(echo "$output" | grep -m1 "author:" | head -1 | sed 's/author: //')
   if [ "$first_author" = "alice" ]; then
@@ -263,7 +245,6 @@ test_comments_review_with_replies() {
   setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF ">>> reply" \
     && echo "$output" | grep -qF "author: bob" \
     && echo "$output" | grep -qF "body: done, fixed" \
@@ -280,7 +261,6 @@ test_comments_review_no_replies() {
   setup_mocks_with_pr_and_replies "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "review-comment" && ! echo "$output" | grep -qF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -295,7 +275,6 @@ test_comments_mixed_replies() {
   setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local alice_block carol_block
   alice_block=$(echo "$output" | sed -n '/author: alice/,/^---/p')
   carol_block=$(echo "$output" | sed -n '/author: carol/,/^---/p')
@@ -315,7 +294,6 @@ test_comments_issue_stays_flat() {
   setup_mocks_with_pr_and_replies "$review_json" "$issue_json" "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local issue_block
   issue_block=$(echo "$output" | sed -n '/--- issue-comment/,/^---/p')
   if echo "$issue_block" | grep -qF "bob" \
@@ -333,7 +311,6 @@ test_comments_replies_sorted_under_parent() {
   setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local first_reply_author
   first_reply_author=$(echo "$output" | grep -A1 ">>> reply" | grep "author:" | head -1 | sed 's/.*author: //')
   if [ "$first_reply_author" = "bob" ]; then
@@ -350,7 +327,6 @@ test_comments_reply_in_main_response_not_duplicated() {
   setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local reply_count
   reply_count=$(echo "$output" | grep -cF ">>> reply" || true)
   if [ "$reply_count" -eq 1 ]; then
@@ -367,7 +343,6 @@ test_since_last_commit_filters_old() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 --since last-commit 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol" \
     && ! echo "$output" | grep -qF "alice"; then
@@ -384,7 +359,6 @@ test_since_date_filters_old() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 --since 2025-06-01 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol" \
     && ! echo "$output" | grep -qF "alice"; then
@@ -401,7 +375,6 @@ test_since_datetime_filters_old() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 --since 2025-06-01T10:00:00 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol" \
     && ! echo "$output" | grep -qF "alice"; then
@@ -418,7 +391,6 @@ test_since_sha_filters_old() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 --since "$KNOWN_SHA" 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol" \
     && ! echo "$output" | grep -qF "alice"; then
@@ -435,7 +407,6 @@ test_since_no_filter_returns_all() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "alice" \
     && echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol"; then
@@ -452,7 +423,6 @@ test_since_all_overrides_since() {
   setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 --all --since 2025-12-01T00:00:00 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "alice" \
     && echo "$output" | grep -qF "bob" \
     && echo "$output" | grep -qF "carol"; then
@@ -468,7 +438,6 @@ test_since_last_commit_includes_equal() {
   setup_mocks_with_pr '[]' "$issue_json"
   local output
   output=$(run_script comments --pr 42 --since last-commit 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "alice"; then
     pass=$((pass + 1))
   else
@@ -483,7 +452,6 @@ test_since_filters_replies_too() {
   setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
   local output
   output=$(run_script comments --pr 42 --since 2025-06-01T00:00:00 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "carol" \
     && ! echo "$output" | grep -qF "old reply"; then
     pass=$((pass + 1))
@@ -497,7 +465,6 @@ test_since_unknown_sha_exits_nonzero() {
   setup_mocks_with_pr '[]' '[]'
   local exit_code=0
   run_script comments --pr 42 --since "$UNKNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -510,7 +477,6 @@ test_since_unknown_sha_stderr_message() {
   setup_mocks_with_pr '[]' '[]'
   local output
   output=$(run_script comments --pr 42 --since "$UNKNOWN_SHA" 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qF "unknown commit"; then
     pass=$((pass + 1))
   else

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -4,6 +4,7 @@ PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
+# setup_mocks sets up test mocks for `git` and `gh`: `git` returns a fixed repository URL or branch name for specific queries, and `gh` exits with status 1 by default.
 setup_mocks() {
   git() {
     case "$*" in
@@ -18,6 +19,7 @@ setup_mocks() {
   }
 }
 
+# setup_mocks_logs sets up git/gh mocks where `gh` returns `HEAD_SHA` for `pulls/42`, the first argument as the `check-runs` JSON, and the second argument as the logs content (args: 1 = check-runs JSON, 2 = log content).
 setup_mocks_logs() {
   _MOCK_CHECK_RUNS="$1"
   _MOCK_LOG_CONTENT="$2"
@@ -32,6 +34,7 @@ setup_mocks_logs() {
   }
 }
 
+# setup_mocks_logs_multi sets up base mocks, exports _MOCK_LOG_<job_id> variables for each provided job-id/log-content pair, and defines a gh() mock that returns the PR head SHA for pulls/42, the supplied check-runs JSON for check-runs requests, or the corresponding per-job log content for logs requests.
 setup_mocks_logs_multi() {
   _MOCK_CHECK_RUNS="$1"
   shift
@@ -59,6 +62,9 @@ setup_mocks_logs_multi() {
   }
 }
 
+# setup_mocks_logs_auto configures git and gh mock functions to simulate auto-detection of the pull request for the current branch and to serve provided check-run JSON and log content.
+# 
+# _MOCK_CHECK_RUNS is the JSON string that will be returned for check-run queries; _MOCK_LOG_CONTENT is the text that will be returned for log requests.
 setup_mocks_logs_auto() {
   _MOCK_CHECK_RUNS="$1"
   _MOCK_LOG_CONTENT="$2"
@@ -74,6 +80,7 @@ setup_mocks_logs_auto() {
   }
 }
 
+# setup_mocks_logs_no_pr sets up base mocks and overrides gh to return an empty response for the PR lookup query (simulating no matching pull request).
 setup_mocks_logs_no_pr() {
   setup_mocks
   gh() {
@@ -84,6 +91,7 @@ setup_mocks_logs_no_pr() {
   }
 }
 
+# setup_mocks_logs_sha_fails sets up mocked git/gh behavior where PR auto-detection returns `42` but the subsequent pull request SHA lookup fails.
 setup_mocks_logs_sha_fails() {
   setup_mocks
   gh() {
@@ -95,6 +103,7 @@ setup_mocks_logs_sha_fails() {
   }
 }
 
+# setup_mocks_logs_no_log sets up git/gh mocks where `gh` returns `HEAD_SHA` for pulls/42, returns the provided check-runs JSON for check-runs, and exits with status 1 when logs are requested.
 setup_mocks_logs_no_log() {
   _MOCK_CHECK_RUNS="$1"
   setup_mocks
@@ -108,6 +117,7 @@ setup_mocks_logs_no_log() {
   }
 }
 
+# run_script exports the mocked `git`/`gh` functions and mock variables, then invokes the target script with the provided arguments.
 run_script() {
   export -f git gh
   export _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT HEAD_SHA
@@ -133,6 +143,7 @@ test_names+=(
   test_logs_log_fetch_fails_shows_placeholder
 )
 
+# test_logs_failed_check_shows_log verifies that a failed check's log block, including the check name and its log content, appears in the command output.
 test_logs_failed_check_shows_log() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log_content="Running tests...\nTest failed: expected 200 got 500"
@@ -150,6 +161,7 @@ test_logs_failed_check_shows_log() {
   fi
 }
 
+# test_logs_all_passing_no_output verifies that when all check runs conclude with "success", running the `logs` command produces no output.
 test_logs_all_passing_no_output() {
   local check_runs='{"total_count":2,"check_runs":[{"id":111,"name":"Build","status":"completed","conclusion":"success"},{"id":222,"name":"Test","status":"completed","conclusion":"success"}]}'
   setup_mocks_logs "$check_runs" "should not appear"
@@ -163,6 +175,7 @@ test_logs_all_passing_no_output() {
   fi
 }
 
+# test_logs_multiple_failures verifies that `logs --pr` outputs two log blocks (one per failed check) and includes each check's `name`.
 test_logs_multiple_failures() {
   local check_runs='{"total_count":2,"check_runs":[{"id":222,"name":"Test","status":"completed","conclusion":"failure"},{"id":111,"name":"Build","status":"completed","conclusion":"failure"}]}'
   setup_mocks_logs_multi "$check_runs" 111 "build error at line 5" 222 "test assertion failed"
@@ -180,6 +193,7 @@ test_logs_multiple_failures() {
   fi
 }
 
+# test_logs_explicit_pr verifies that when an explicit PR number is provided, failing check run logs (including the check name) are printed.
 test_logs_explicit_pr() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log_content="error in CI"
@@ -194,6 +208,7 @@ test_logs_explicit_pr() {
   fi
 }
 
+# test_logs_auto_detect verifies that running `logs` without `--pr` auto-detects the PR and prints the failing check's logs.
 test_logs_auto_detect() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log_content="error in CI"
@@ -208,6 +223,7 @@ test_logs_auto_detect() {
   fi
 }
 
+# test_logs_truncation_at_500_lines verifies that when a job log exceeds 500 lines, the reported output contains at most 500 content lines (excluding headers) and includes a "[truncated:" notice.
 test_logs_truncation_at_500_lines() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log_content
@@ -225,6 +241,7 @@ test_logs_truncation_at_500_lines() {
   fi
 }
 
+# test_logs_truncation_notice_format verifies that the logs command includes the "[truncated: 100 lines omitted]" notice when a job's log exceeds 500 lines.
 test_logs_truncation_notice_format() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log_content
@@ -255,6 +272,7 @@ test_logs_under_500_no_truncation() {
   fi
 }
 
+# test_logs_no_pr_found_exits_nonzero adds a test that verifies `logs` exits with a non-zero status when no pull request is found.
 test_logs_no_pr_found_exits_nonzero() {
   setup_mocks_logs_no_pr
   local exit_code=0
@@ -287,6 +305,7 @@ test_logs_missing_pr_value_stderr_message() {
   assert_stderr_contains "logs --pr without value gives clear message" "missing value for --pr" bash "$script" logs --pr
 }
 
+# test_logs_empty_pr_value_exits_nonzero asserts that invoking `logs --pr ""` exits with a nonzero status.
 test_logs_empty_pr_value_exits_nonzero() {
   assert_exit 1 "logs --pr empty exits non-zero" bash "$script" logs --pr ""
 }
@@ -309,6 +328,7 @@ test_logs_help_exits_zero() {
   assert_exit 0 "logs -h exits 0" bash "$script" logs -h
 }
 
+# test_logs_log_fetch_fails_shows_placeholder verifies that when fetching a job's logs fails the `logs` command prints a log placeholder and includes the job name.
 test_logs_log_fetch_fails_shows_placeholder() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   setup_mocks_logs_no_log "$check_runs"

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -1,151 +1,117 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
 setup_mocks() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << 'GIT_EOF'
-#!/usr/bin/env bash
-case "$*" in
-  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
-  "branch --show-current") echo "feature-branch" ;;
-  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "branch --show-current") echo "feature-branch" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
 }
 
 setup_mocks_logs() {
-  local check_runs="$1"
-  local log_content="$2"
-
+  _MOCK_CHECK_RUNS="$1"
+  _MOCK_LOG_CONTENT="$2"
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"logs"*)\n' >> "$mock_dir/gh"
-  printf "    printf '%%s' '%s'\n" "$log_content" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_logs_multi() {
-  local check_runs="$1"
+  _MOCK_CHECK_RUNS="$1"
   shift
-
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-
   local idx=0
   while [ $# -gt 0 ]; do
     local job_id="$1"
     local log_content="$2"
     shift 2
-    printf '  *"jobs/%s/logs"*)\n' "$job_id" >> "$mock_dir/gh"
-    printf "    printf '%%s' '%s'\n" "$log_content" >> "$mock_dir/gh"
-    printf '    ;;\n' >> "$mock_dir/gh"
+    export "_MOCK_LOG_${job_id}=$log_content"
     idx=$((idx + 1))
   done
-
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *"logs"*)
+        local jid
+        jid=$(echo "$*" | sed -E 's/.*jobs\/([0-9]+)\/logs.*/\1/')
+        local var="_MOCK_LOG_${jid}"
+        printf '%s' "${!var}"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_logs_auto() {
-  local check_runs="$1"
-  local log_content="$2"
-
+  _MOCK_CHECK_RUNS="$1"
+  _MOCK_LOG_CONTENT="$2"
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head=acme:feature-branch"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"logs"*)\n' >> "$mock_dir/gh"
-  printf "    printf '%%s' '%s'\n" "$log_content" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '42' ;;
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_logs_no_pr() {
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head=acme:feature-branch"*)\n' >> "$mock_dir/gh"
-  printf '    echo ""\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo "" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_logs_sha_fails() {
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head=acme:feature-branch"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n' >> "$mock_dir/gh"
-  printf '    exit 1\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '42' ;;
+      *"pulls/42"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_logs_no_log() {
-  local check_runs="$1"
-
+  _MOCK_CHECK_RUNS="$1"
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *"logs"*)\n' >> "$mock_dir/gh"
-  printf '    exit 1\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *"logs"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT HEAD_SHA
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -173,7 +139,6 @@ test_logs_failed_check_shows_log() {
   setup_mocks_logs "$check_runs" "$log_content"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF -- "--- log" \
     && echo "$output" | grep -qF "name: CI" \
     && echo "$output" | grep -qF "Running tests..." \
@@ -190,7 +155,6 @@ test_logs_all_passing_no_output() {
   setup_mocks_logs "$check_runs" "should not appear"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else
@@ -204,7 +168,6 @@ test_logs_multiple_failures() {
   setup_mocks_logs_multi "$check_runs" 111 "build error at line 5" 222 "test assertion failed"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   local log_count
   log_count=$(echo "$output" | grep -c -- "--- log")
   if [ "$log_count" -eq 2 ] \
@@ -223,7 +186,6 @@ test_logs_explicit_pr() {
   setup_mocks_logs "$check_runs" "$log_content"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "name: CI"; then
     pass=$((pass + 1))
   else
@@ -238,7 +200,6 @@ test_logs_auto_detect() {
   setup_mocks_logs_auto "$check_runs" "$log_content"
   local output
   output=$(run_script logs 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "name: CI"; then
     pass=$((pass + 1))
   else
@@ -254,7 +215,6 @@ test_logs_truncation_at_500_lines() {
   setup_mocks_logs "$check_runs" "$log_content"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   local content_lines
   content_lines=$(echo "$output" | grep -v -e "--- log" -e "name:" -e "truncated" | grep -c .)
   if [ "$content_lines" -le 500 ] && echo "$output" | grep -qF "[truncated:"; then
@@ -272,7 +232,6 @@ test_logs_truncation_notice_format() {
   setup_mocks_logs "$check_runs" "$log_content"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "[truncated: 100 lines omitted]"; then
     pass=$((pass + 1))
   else
@@ -288,7 +247,6 @@ test_logs_under_500_no_truncation() {
   setup_mocks_logs "$check_runs" "$log_content"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -q "truncated"; then
     pass=$((pass + 1))
   else
@@ -301,7 +259,6 @@ test_logs_no_pr_found_exits_nonzero() {
   setup_mocks_logs_no_pr
   local exit_code=0
   run_script logs >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -314,7 +271,6 @@ test_logs_sha_lookup_failure() {
   setup_mocks_logs_sha_fails
   local output
   output=$(run_script logs 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qF "failed to resolve head SHA"; then
     pass=$((pass + 1))
   else
@@ -336,10 +292,10 @@ test_logs_empty_pr_value_exits_nonzero() {
 }
 
 test_logs_unknown_option_exits_nonzero() {
-  setup_mocks
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  setup_mocks_logs "$check_runs" ""
   local exit_code=0
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" logs --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
+  run_script logs --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -358,7 +314,6 @@ test_logs_log_fetch_fails_shows_placeholder() {
   setup_mocks_logs_no_log "$check_runs"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF -- "--- log" \
     && echo "$output" | grep -qF "name: CI" \
     && echo "$output" | grep -qF "[log not available]"; then

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -1,109 +1,85 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
-# setup_mocks_base creates a temporary mock directory and installs a minimal git mock that returns a fixed remote URL and branch name.
 setup_mocks_base() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << 'GIT_EOF'
-#!/usr/bin/env bash
-case "$*" in
-  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
-  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
 }
 
-# setup_mocks_comments creates a mock `gh` in $mock_dir (calls setup_mocks_base) that echoes the provided JSON for `pulls/42/comments` and `issues/42/comments` and returns `[]` for `pulls/comments/*/replies`; parameters: `pr_reviews` — JSON to echo for `pulls/42/comments`, `pr_issues` — JSON to echo for `issues/42/comments`.
 setup_mocks_comments() {
-  local pr_reviews="$1" pr_issues="$2"
+  _MOCK_PR_REVIEWS="$1"
+  _MOCK_PR_ISSUES="$2"
   setup_mocks_base
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
-  printf '    ;;\n'                      >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'  >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_issues"  >> "$mock_dir/gh"
-  printf '    ;;\n'                      >> "$mock_dir/gh"
-  printf '  *"pulls/comments/"*"/replies"*)\n' >> "$mock_dir/gh"
-  printf '    echo "[]"\n'              >> "$mock_dir/gh"
-  printf '    ;;\n'                     >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'            >> "$mock_dir/gh"
-  printf 'esac\n'                      >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
+      *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_comments_with_reply creates a temporary mock environment, writes the provided reply JSON to replies_77.json, and installs a mock `gh` that returns the given PR review comments, empty issue comments, and serves per-comment reply JSON (by comment id) for tests.
 setup_mocks_comments_with_reply() {
-  local pr_reviews="$1" reply_json="$2"
+  _MOCK_PR_REVIEWS="$1"
+  _MOCK_REPLY_77="$2"
   setup_mocks_base
-  echo "$reply_json" > "$mock_dir/replies_77.json"
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_reviews" >> "$mock_dir/gh"
-  printf '    ;;\n'                      >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'  >> "$mock_dir/gh"
-  printf "    echo '[]'\n"              >> "$mock_dir/gh"
-  printf '    ;;\n'                      >> "$mock_dir/gh"
-  printf '  *"pulls/comments/"*"/replies"*)\n' >> "$mock_dir/gh"
-  cat >> "$mock_dir/gh" << 'RMOCK'
-    _cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-    _d=$(dirname "$0")
-    [ -f "${_d}/replies_${_cid}.json" ] && cat "${_d}/replies_${_cid}.json" || echo "[]"
-    ;;
-RMOCK
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n'           >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
+      *"issues/42/comments"*) echo '[]' ;;
+      *"pulls/comments/"*"/replies"*)
+        local cid
+        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
+        local var="_MOCK_REPLY_${cid}"
+        echo "${!var:-[]}"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_status creates a temporary mock environment and writes a mock `gh` executable that returns the fixed HEAD SHA for `pulls/42` and echoes the provided `check_runs` JSON when invoked with `check-runs`.
 setup_mocks_status() {
-  local check_runs="$1"
+  _MOCK_CHECK_RUNS="$1"
   setup_mocks_base
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n'                   >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA"          >> "$mock_dir/gh"
-  printf '    ;;\n'                             >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n'                 >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs"        >> "$mock_dir/gh"
-  printf '    ;;\n'                             >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                    >> "$mock_dir/gh"
-  printf 'esac\n'                              >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_logs creates a temporary mock directory and an executable `gh` that returns the fixed HEAD_SHA for `pulls/42`, the provided `check_runs` JSON for check-run queries, and the given `log_content` for `logs` requests.
 setup_mocks_logs() {
-  local check_runs="$1" log_content="$2"
+  _MOCK_CHECK_RUNS="$1"
+  _MOCK_LOG_CONTENT="$2"
   setup_mocks_base
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42"*)\n'                   >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA"          >> "$mock_dir/gh"
-  printf '    ;;\n'                             >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n'                 >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs"        >> "$mock_dir/gh"
-  printf '    ;;\n'                             >> "$mock_dir/gh"
-  printf '  *"logs"*)\n'                        >> "$mock_dir/gh"
-  printf "    printf '%%s' '%s'\n" "$log_content" >> "$mock_dir/gh"
-  printf '    ;;\n'                             >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                    >> "$mock_dir/gh"
-  printf 'esac\n'                              >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# run_script runs the target script with the mock directory prepended to PATH so the mock executables override real tools.
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-# cleanup_mocks removes the temporary mock directory used for test mocks.
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT _MOCK_REPLY_77 HEAD_SHA
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -127,13 +103,11 @@ test_names+=(
   test_fmt_all_passing_logs_no_output
 )
 
-# test_fmt_review_comment_delimiter verifies that formatted review comments begin with `--- review-comment` on a line by itself.
 test_fmt_review_comment_delimiter() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qxF -- "--- review-comment"; then
     pass=$((pass + 1))
   else
@@ -142,13 +116,11 @@ test_fmt_review_comment_delimiter() {
   fi
 }
 
-# test_fmt_review_comment_field_order tests that review comment fields appear in the order author→created→path→line→body in the formatted comments output.
 test_fmt_review_comment_field_order() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local author_n created_n path_n line_n body_n
   author_n=$(echo "$output"  | grep -n "^author:"  | head -1 | cut -d: -f1)
   created_n=$(echo "$output" | grep -n "^created:" | head -1 | cut -d: -f1)
@@ -166,13 +138,11 @@ test_fmt_review_comment_field_order() {
   fi
 }
 
-# test_fmt_review_comment_no_raw_json ensures formatted review comment output contains no raw JSON-like characters (`[`, `{`) at the start of any line.
 test_fmt_review_comment_no_raw_json() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -qP '^\s*[\[{]'; then
     pass=$((pass + 1))
   else
@@ -181,13 +151,11 @@ test_fmt_review_comment_no_raw_json() {
   fi
 }
 
-# test_fmt_review_comment_no_trailing_whitespace_on_fields checks that formatted field lines (author, created, path, line, body, name, status, conclusion) do not end with trailing whitespace.
 test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local bad_lines
   bad_lines=$(echo "$output" | grep -P '^(author|created|path|line|body|name|status|conclusion):.*\s+$' || true)
   if [ -z "$bad_lines" ]; then
@@ -198,13 +166,11 @@ test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   fi
 }
 
-# test_fmt_issue_comment_delimiter verifies that running `comments --pr` emits a line containing only `--- issue-comment` for issue comments.
 test_fmt_issue_comment_delimiter() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
   setup_mocks_comments '[]' "$issue"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qxF -- "--- issue-comment"; then
     pass=$((pass + 1))
   else
@@ -213,13 +179,11 @@ test_fmt_issue_comment_delimiter() {
   fi
 }
 
-# test_fmt_issue_comment_fields_present verifies that issue comment output contains `author`, `created`, and `body` fields.
 test_fmt_issue_comment_fields_present() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello world"}]'
   setup_mocks_comments '[]' "$issue"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "author: bob" \
     && echo "$output" | grep -qF "created: 2025-01-01T11:00:00Z" \
     && echo "$output" | grep -qF "body: hello world"; then
@@ -230,13 +194,11 @@ test_fmt_issue_comment_fields_present() {
   fi
 }
 
-# test_fmt_issue_comment_no_path_line ensures issue comment output contains no lines beginning with `path:` or `line:`.
 test_fmt_issue_comment_no_path_line() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello"}]'
   setup_mocks_comments '[]' "$issue"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -qE "^path:|^line:"; then
     pass=$((pass + 1))
   else
@@ -245,13 +207,11 @@ test_fmt_issue_comment_no_path_line() {
   fi
 }
 
-# test_fmt_issue_comment_no_raw_json verifies that issue comment output does not contain lines beginning with JSON delimiters (`[` or `{`), ensuring no raw JSON is printed.
 test_fmt_issue_comment_no_raw_json() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hi"}]'
   setup_mocks_comments '[]' "$issue"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -qP '^\s*[\[{]'; then
     pass=$((pass + 1))
   else
@@ -260,14 +220,12 @@ test_fmt_issue_comment_no_raw_json() {
   fi
 }
 
-# test_fmt_reply_marker verifies that a reply is rendered using exactly the line '>>> reply' on its own line.
 test_fmt_reply_marker() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"a reply"}]'
   setup_mocks_comments_with_reply "$review" "$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qxF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -276,14 +234,12 @@ test_fmt_reply_marker() {
   fi
 }
 
-# test_fmt_reply_fields verifies that a reply block in the formatted comments output includes `author`, `created`, and `body` fields.
 test_fmt_reply_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","body":"the reply body"}]'
   setup_mocks_comments_with_reply "$review" "$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "author: replyauthor" \
     && echo "$output" | grep -qF "created: 2025-03-15T09:00:00Z" \
     && echo "$output" | grep -qF "body: the reply body"; then
@@ -294,13 +250,11 @@ test_fmt_reply_fields() {
   fi
 }
 
-# test_fmt_check_completed_delimiter_and_fields verifies that a completed check run produces a `--- check` delimiter and includes `name:`, `status: completed`, and `conclusion: success` in the formatter output.
 test_fmt_check_completed_delimiter_and_fields() {
   local checks='{"total_count":1,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$checks"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qxF -- "--- check" \
     && echo "$output" | grep -qF "name: Build" \
     && echo "$output" | grep -qF "status: completed" \
@@ -312,13 +266,11 @@ test_fmt_check_completed_delimiter_and_fields() {
   fi
 }
 
-# test_fmt_check_non_completed_no_conclusion_field verifies that a non-completed check outputs its `status` and omits any `conclusion:` field.
 test_fmt_check_non_completed_no_conclusion_field() {
   local checks='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
   setup_mocks_status "$checks"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "status: queued" && ! echo "$output" | grep -qF "conclusion:"; then
     pass=$((pass + 1))
   else
@@ -327,13 +279,11 @@ test_fmt_check_non_completed_no_conclusion_field() {
   fi
 }
 
-# test_fmt_check_no_raw_json asserts that the `status --pr` output contains no lines beginning with raw JSON characters (`[` or `{`).
 test_fmt_check_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"failure"}]}'
   setup_mocks_status "$checks"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -qP '^\s*[\[{]'; then
     pass=$((pass + 1))
   else
@@ -342,14 +292,12 @@ test_fmt_check_no_raw_json() {
   fi
 }
 
-# test_fmt_log_delimiter_and_name verifies that logs output includes the '--- log' delimiter and a `name:` field for a check run.
 test_fmt_log_delimiter_and_name() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"Test Suite","status":"completed","conclusion":"failure"}]}'
   local log="line one\nline two"
   setup_mocks_logs "$checks" "$log"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qxF -- "--- log" && echo "$output" | grep -qF "name: Test Suite"; then
     pass=$((pass + 1))
   else
@@ -358,14 +306,12 @@ test_fmt_log_delimiter_and_name() {
   fi
 }
 
-# test_fmt_log_no_raw_json verifies that `logs --pr` header lines (`--- log` and `name:`) do not contain raw JSON-like characters such as `[` or `{`.
 test_fmt_log_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log="error: build failed"
   setup_mocks_logs "$checks" "$log"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   local header_lines
   header_lines=$(echo "$output" | grep -E "^(--- log|name:)")
   if ! echo "$header_lines" | grep -qP '[\[{]'; then
@@ -376,12 +322,10 @@ test_fmt_log_no_raw_json() {
   fi
 }
 
-# test_fmt_empty_comments_produces_no_output verifies that when PR review comments and issue comments are empty the formatter produces no output.
 test_fmt_empty_comments_produces_no_output() {
   setup_mocks_comments '[]' '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else
@@ -390,13 +334,11 @@ test_fmt_empty_comments_produces_no_output() {
   fi
 }
 
-# test_fmt_empty_checks_produces_no_output verifies that running `status --pr` produces no output when the repository has zero check runs.
 test_fmt_empty_checks_produces_no_output() {
   local checks='{"total_count":0,"check_runs":[]}'
   setup_mocks_status "$checks"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else
@@ -405,13 +347,11 @@ test_fmt_empty_checks_produces_no_output() {
   fi
 }
 
-# test_fmt_all_passing_logs_no_output verifies that when all check runs conclude with success, the `logs --pr` command produces no output.
 test_fmt_all_passing_logs_no_output() {
   local checks='{"total_count":2,"check_runs":[{"id":1,"name":"A","status":"completed","conclusion":"success"},{"id":2,"name":"B","status":"completed","conclusion":"success"}]}'
   setup_mocks_logs "$checks" "should not appear"
   local output
   output=$(run_script logs --pr 42 2>&1)
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -4,6 +4,7 @@ PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
+# setup_mocks_base defines mock `git` and `gh` functions for tests; the mock `git` returns a fixed repo URL for `remote get-url origin` and a fixed branch for `rev-parse --abbrev-ref HEAD`, while the mock `gh` exits with status 1 by default.
 setup_mocks_base() {
   git() {
     case "$*" in
@@ -17,6 +18,7 @@ setup_mocks_base() {
   }
 }
 
+# setup_mocks_comments sets mock PR review and issue comment payloads and defines a gh() mock that returns the first argument for pulls/42/comments, the second for issues/42/comments, and an empty array for pull comment replies.
 setup_mocks_comments() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -31,6 +33,7 @@ setup_mocks_comments() {
   }
 }
 
+# setup_mocks_comments_with_reply sets up mock `git`/`gh` functions and configures `gh` to return the provided PR review JSON, an empty issues list, and per-comment reply JSON (second argument is stored as `_MOCK_REPLY_77`).
 setup_mocks_comments_with_reply() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_REPLY_77="$2"
@@ -50,6 +53,8 @@ setup_mocks_comments_with_reply() {
   }
 }
 
+# setup_mocks_status defines git/gh mock functions for status-related API calls and stores the provided check-runs payload.
+# The first argument is the JSON/string payload to be returned for `check-runs` API calls; calls matching `pulls/42` return `HEAD_SHA`.
 setup_mocks_status() {
   _MOCK_CHECK_RUNS="$1"
   setup_mocks_base
@@ -62,6 +67,7 @@ setup_mocks_status() {
   }
 }
 
+# setup_mocks_logs configures mock payloads and defines a gh() function that returns the pull SHA for pulls/42 requests, the provided check-runs JSON for check-runs requests, or the provided log content for logs requests.
 setup_mocks_logs() {
   _MOCK_CHECK_RUNS="$1"
   _MOCK_LOG_CONTENT="$2"
@@ -76,6 +82,7 @@ setup_mocks_logs() {
   }
 }
 
+# run_script exports mock `git` and `gh` functions and mock payload variables, then invokes the target script stored in `$script` with the provided arguments.
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT _MOCK_REPLY_77 HEAD_SHA
@@ -103,6 +110,7 @@ test_names+=(
   test_fmt_all_passing_logs_no_output
 )
 
+# test_fmt_review_comment_delimiter checks that formatted review comments begin with a standalone line containing '--- review-comment'.
 test_fmt_review_comment_delimiter() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -116,6 +124,7 @@ test_fmt_review_comment_delimiter() {
   fi
 }
 
+# test_fmt_review_comment_field_order tests that the formatted review-comment output lists fields in the order author → created → path → line → body.
 test_fmt_review_comment_field_order() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -138,6 +147,7 @@ test_fmt_review_comment_field_order() {
   fi
 }
 
+# test_fmt_review_comment_no_raw_json ensures review comment output contains no raw JSON or array/object tokens at the start of any line.
 test_fmt_review_comment_no_raw_json() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -151,6 +161,7 @@ test_fmt_review_comment_no_raw_json() {
   fi
 }
 
+# test_fmt_review_comment_no_trailing_whitespace_on_fields checks that lines starting with author, created, path, line, body, name, status, or conclusion do not end with trailing whitespace.
 test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/app.sh","line":5,"body":"fix this"}]'
   setup_mocks_comments "$review" '[]'
@@ -166,6 +177,7 @@ test_fmt_review_comment_no_trailing_whitespace_on_fields() {
   fi
 }
 
+# test_fmt_issue_comment_delimiter verifies that issue comments output begins with a line containing only '--- issue-comment'.
 test_fmt_issue_comment_delimiter() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'
   setup_mocks_comments '[]' "$issue"
@@ -179,6 +191,7 @@ test_fmt_issue_comment_delimiter() {
   fi
 }
 
+# test_fmt_issue_comment_fields_present verifies that the formatted issue comment output includes `author`, `created`, and `body` fields.
 test_fmt_issue_comment_fields_present() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello world"}]'
   setup_mocks_comments '[]' "$issue"
@@ -194,6 +207,7 @@ test_fmt_issue_comment_fields_present() {
   fi
 }
 
+# test_fmt_issue_comment_no_path_line ensures issue comment output does not include `path:` or `line:` fields.
 test_fmt_issue_comment_no_path_line() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hello"}]'
   setup_mocks_comments '[]' "$issue"
@@ -207,6 +221,7 @@ test_fmt_issue_comment_no_path_line() {
   fi
 }
 
+# test_fmt_issue_comment_no_raw_json ensures issue comment output contains no raw JSON/array/object tokens at the start of any line.
 test_fmt_issue_comment_no_raw_json() {
   local issue='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"hi"}]'
   setup_mocks_comments '[]' "$issue"
@@ -220,6 +235,7 @@ test_fmt_issue_comment_no_raw_json() {
   fi
 }
 
+# test_fmt_reply_marker verifies that a reply comment is emitted with a single-line ">>> reply" marker.
 test_fmt_reply_marker() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"a reply"}]'
@@ -234,6 +250,7 @@ test_fmt_reply_marker() {
   fi
 }
 
+# test_fmt_reply_fields verifies that a reply block contains the `author`, `created`, and `body` fields.
 test_fmt_reply_fields() {
   local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","body":"the reply body"}]'
@@ -250,6 +267,7 @@ test_fmt_reply_fields() {
   fi
 }
 
+# test_fmt_check_completed_delimiter_and_fields verifies the `status` subcommand emits a `--- check` delimiter and includes `name`, `status`, and `conclusion` fields for a completed check run.
 test_fmt_check_completed_delimiter_and_fields() {
   local checks='{"total_count":1,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$checks"
@@ -266,6 +284,7 @@ test_fmt_check_completed_delimiter_and_fields() {
   fi
 }
 
+# test_fmt_check_non_completed_no_conclusion_field verifies that a queued check run's formatted output contains a `status:` line and does not include a `conclusion:` field.
 test_fmt_check_non_completed_no_conclusion_field() {
   local checks='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
   setup_mocks_status "$checks"
@@ -279,6 +298,7 @@ test_fmt_check_non_completed_no_conclusion_field() {
   fi
 }
 
+# test_fmt_check_no_raw_json verifies that the `status` subcommand's output does not contain raw JSON array/object tokens (`[`, `{`) at the start of any line.
 test_fmt_check_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"failure"}]}'
   setup_mocks_status "$checks"
@@ -292,6 +312,7 @@ test_fmt_check_no_raw_json() {
   fi
 }
 
+# test_fmt_log_delimiter_and_name verifies that the `logs` command emits a `--- log` delimiter and includes the `name: Test Suite` field for a failed completed check run with logs.
 test_fmt_log_delimiter_and_name() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"Test Suite","status":"completed","conclusion":"failure"}]}'
   local log="line one\nline two"
@@ -306,6 +327,7 @@ test_fmt_log_delimiter_and_name() {
   fi
 }
 
+# test_fmt_log_no_raw_json verifies that header lines produced by the `logs` command (lines starting with '--- log' or 'name:') do not contain raw JSON or array/object tokens.
 test_fmt_log_no_raw_json() {
   local checks='{"total_count":1,"check_runs":[{"id":99,"name":"CI","status":"completed","conclusion":"failure"}]}'
   local log="error: build failed"
@@ -322,6 +344,7 @@ test_fmt_log_no_raw_json() {
   fi
 }
 
+# test_fmt_empty_comments_produces_no_output verifies that when both PR review comments and issue comments are empty the target script produces no output.
 test_fmt_empty_comments_produces_no_output() {
   setup_mocks_comments '[]' '[]'
   local output
@@ -347,6 +370,7 @@ test_fmt_empty_checks_produces_no_output() {
   fi
 }
 
+# test_fmt_all_passing_logs_no_output verifies that when all check runs conclude "success" the `logs` subcommand produces no output.
 test_fmt_all_passing_logs_no_output() {
   local checks='{"total_count":2,"check_runs":[{"id":1,"name":"A","status":"completed","conclusion":"success"},{"id":2,"name":"B","status":"completed","conclusion":"success"}]}'
   setup_mocks_logs "$checks" "should not appear"

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -1,98 +1,71 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
-# setup_mocks_base creates a temporary mock directory and installs a mock git executable that returns a fixed remote URL for "remote get-url origin" and a fixed branch name for "rev-parse --abbrev-ref HEAD".
 setup_mocks_base() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << 'GIT_EOF'
-#!/usr/bin/env bash
-case "$*" in
-  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
-  "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
 }
 
-# setup_mocks_auto_detect creates mock `git` and `gh` executables in the temporary mock directory that simulate auto-detection of an open pull request (PR 99) and return canned responses for PR details, comments, issue comments, and check-runs.
 setup_mocks_auto_detect() {
   setup_mocks_base
-  local head_sha="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head=acme:my-feature"*)\n'         >> "$mock_dir/gh"
-  printf "    echo '99'\n"                              >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"pulls/99/comments"*)\n'                  >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"issues/99/comments"*)\n'                 >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"pulls/99"*)\n'                           >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$head_sha"                 >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n'                         >> "$mock_dir/gh"
-  printf '    echo '"'"'{"total_count":0,"check_runs":[]}'"'"'\n' >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
-  printf 'esac\n'                                     >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  _MOCK_HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:my-feature"*) echo '99' ;;
+      *"pulls/99/comments"*) echo '[]' ;;
+      *"issues/99/comments"*) echo '[]' ;;
+      *"pulls/99"*) echo "$_MOCK_HEAD_SHA" ;;
+      *"check-runs"*) echo '{"total_count":0,"check_runs":[]}' ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_explicit_pr creates temporary mock git and gh commands where gh returns data for PR 55 (a fixed head SHA, empty comments, and empty check-runs) and fails with an error if PR auto-detection is attempted.
 setup_mocks_explicit_pr() {
   setup_mocks_base
-  local head_sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head="*)\n'                        >> "$mock_dir/gh"
-  printf '    echo "SHOULD NOT BE CALLED" >&2; exit 1\n' >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"pulls/55/comments"*)\n'                  >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"issues/55/comments"*)\n'                 >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                             >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"pulls/55"*)\n'                           >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$head_sha"                 >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *"check-runs"*)\n'                         >> "$mock_dir/gh"
-  printf '    echo '"'"'{"total_count":0,"check_runs":[]}'"'"'\n' >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
-  printf 'esac\n'                                     >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  _MOCK_HEAD_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  gh() {
+    case "$*" in
+      *"pulls?head="*) echo "SHOULD NOT BE CALLED" >&2; exit 1 ;;
+      *"pulls/55/comments"*) echo '[]' ;;
+      *"issues/55/comments"*) echo '[]' ;;
+      *"pulls/55"*) echo "$_MOCK_HEAD_SHA" ;;
+      *"check-runs"*) echo '{"total_count":0,"check_runs":[]}' ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_no_pr creates mock `git` and `gh` executables in `$mock_dir`; the `gh` mock returns an empty response for `pulls?head=acme:my-feature` (simulating no open PR) and exits with status 1 for any other invocation.
 setup_mocks_no_pr() {
   setup_mocks_base
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls?head=acme:my-feature"*)\n'         >> "$mock_dir/gh"
-  printf '    echo ""\n'                               >> "$mock_dir/gh"
-  printf '    ;;\n'                                    >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                           >> "$mock_dir/gh"
-  printf 'esac\n'                                     >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:my-feature"*) echo "" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# setup_mocks_api_fail creates mock environment and places a `gh` mock that immediately exits with status 1 to simulate API failures.
 setup_mocks_api_fail() {
   setup_mocks_base
-  printf '#!/usr/bin/env bash\nexit 1\n' > "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    exit 1
+  }
 }
 
-# run_script executes the target script under test with the mock directory prepended to PATH, forwarding all arguments.
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-# cleanup_mocks removes the temporary mock directory created by the setup functions.
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_HEAD_SHA
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -108,12 +81,10 @@ test_names+=(
   test_pr_resolution_api_fail_stderr_message
 )
 
-# test_pr_resolution_auto_detect_comments verifies that auto-detection resolves to pull request 99 and that running the `comments` subcommand exits successfully, updating the global pass/fail counters and printing a failure message on error.
 test_pr_resolution_auto_detect_comments() {
   setup_mocks_auto_detect
   local exit_code=0
   run_script comments >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -122,12 +93,10 @@ test_pr_resolution_auto_detect_comments() {
   fi
 }
 
-# test_pr_resolution_auto_detect_status verifies that auto-detect finds PR 99 and the `status` subcommand exits successfully.
 test_pr_resolution_auto_detect_status() {
   setup_mocks_auto_detect
   local exit_code=0
   run_script status >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -136,12 +105,10 @@ test_pr_resolution_auto_detect_status() {
   fi
 }
 
-# test_pr_resolution_auto_detect_logs runs the `logs` subcommand with auto-detected PR mocks and increments `pass` on success or `fail` and prints a failure message on non-zero exit.
 test_pr_resolution_auto_detect_logs() {
   setup_mocks_auto_detect
   local exit_code=0
   run_script logs >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -150,12 +117,10 @@ test_pr_resolution_auto_detect_logs() {
   fi
 }
 
-# test_pr_resolution_explicit_pr_skips_autodetect_comments verifies that invoking the script's `comments` subcommand with an explicit `--pr` uses the provided PR and does not trigger auto-detection.
 test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   setup_mocks_explicit_pr
   local output exit_code=0
   output=$(run_script comments --pr 55 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
     pass=$((pass + 1))
   else
@@ -164,12 +129,10 @@ test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   fi
 }
 
-# test_pr_resolution_explicit_pr_skips_autodetect_status verifies that providing `--pr` prevents auto-detection when running the `status` subcommand; it increments `pass` on success or `fail` and prints a failure message containing the exit code and captured output.
 test_pr_resolution_explicit_pr_skips_autodetect_status() {
   setup_mocks_explicit_pr
   local output exit_code=0
   output=$(run_script status --pr 55 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
     pass=$((pass + 1))
   else
@@ -178,12 +141,10 @@ test_pr_resolution_explicit_pr_skips_autodetect_status() {
   fi
 }
 
-# test_pr_resolution_explicit_pr_skips_autodetect_logs verifies that running the script's `logs` subcommand with `--pr 55` does not invoke auto-detection (output must not contain "SHOULD NOT BE CALLED") and increments the `pass` or `fail` counters accordingly.
 test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   setup_mocks_explicit_pr
   local output exit_code=0
   output=$(run_script logs --pr 55 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && ! echo "$output" | grep -qF "SHOULD NOT BE CALLED"; then
     pass=$((pass + 1))
   else
@@ -192,12 +153,10 @@ test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   fi
 }
 
-# test_pr_resolution_no_pr_found_exits_nonzero verifies that the target script exits with a non-zero status when no open pull request is found.
 test_pr_resolution_no_pr_found_exits_nonzero() {
   setup_mocks_no_pr
   local exit_code=0
   run_script comments >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -206,12 +165,10 @@ test_pr_resolution_no_pr_found_exits_nonzero() {
   fi
 }
 
-# test_pr_resolution_no_pr_found_stderr_message verifies that when no open PR exists the script writes "no open PR found" to stderr.
 test_pr_resolution_no_pr_found_stderr_message() {
   setup_mocks_no_pr
   local output
   output=$(run_script comments 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qF "no open PR found"; then
     pass=$((pass + 1))
   else
@@ -220,12 +177,10 @@ test_pr_resolution_no_pr_found_stderr_message() {
   fi
 }
 
-# test_pr_resolution_api_fail_exits_nonzero Verifies that when the mocked GitHub CLI fails, invoking the script's `comments` command exits with a non-zero status; increments `pass` on non-zero, otherwise increments `fail` and prints a failure message.
 test_pr_resolution_api_fail_exits_nonzero() {
   setup_mocks_api_fail
   local exit_code=0
   run_script comments >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -234,12 +189,10 @@ test_pr_resolution_api_fail_exits_nonzero() {
   fi
 }
 
-# test_pr_resolution_api_fail_stderr_message verifies that when the GitHub API returns an error the script prints a failure message containing "failed" (case-insensitive) and updates the pass/fail counters.
 test_pr_resolution_api_fail_stderr_message() {
   setup_mocks_api_fail
   local output
   output=$(run_script comments 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qiF "failed"; then
     pass=$((pass + 1))
   else

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -2,6 +2,7 @@
 
 PATH="$HOME/bin:$PATH"
 
+# setup_mocks_base sets up base mock implementations of `git` and `gh` for tests, where `git` returns a fixed origin URL or branch name and `gh` exits with failure.
 setup_mocks_base() {
   git() {
     case "$*" in
@@ -15,6 +16,7 @@ setup_mocks_base() {
   }
 }
 
+# setup_mocks_auto_detect sets up base git/gh mocks, sets _MOCK_HEAD_SHA to a fixed SHA, and overrides gh() to simulate auto-detection of PR 99 by returning the PR number, empty comments, the PR head SHA, and an empty check-runs response.
 setup_mocks_auto_detect() {
   setup_mocks_base
   _MOCK_HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
@@ -30,6 +32,7 @@ setup_mocks_auto_detect() {
   }
 }
 
+# setup_mocks_explicit_pr sets up mocked git and gh functions for tests that use an explicit PR number (55), providing a fixed head SHA, returning empty comment lists and check-run metadata, and failing if auto-detect (`pulls?head=`) is invoked.
 setup_mocks_explicit_pr() {
   setup_mocks_base
   _MOCK_HEAD_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -45,6 +48,7 @@ setup_mocks_explicit_pr() {
   }
 }
 
+# setup_mocks_no_pr sets up base mocks and overrides gh to simulate "no open PR" by returning an empty string for pull requests queried by head and exiting non-zero for any other gh calls.
 setup_mocks_no_pr() {
   setup_mocks_base
   gh() {
@@ -55,6 +59,7 @@ setup_mocks_no_pr() {
   }
 }
 
+# setup_mocks_api_fail configures base mocks and overrides `gh` to always fail, simulating a GitHub CLI/API failure.
 setup_mocks_api_fail() {
   setup_mocks_base
   gh() {
@@ -62,6 +67,7 @@ setup_mocks_api_fail() {
   }
 }
 
+# run_script exports mocked git and gh functions and _MOCK_HEAD_SHA into the environment and invokes the target script with the provided arguments.
 run_script() {
   export -f git gh
   export _MOCK_HEAD_SHA
@@ -81,6 +87,7 @@ test_names+=(
   test_pr_resolution_api_fail_stderr_message
 )
 
+# test_pr_resolution_auto_detect_comments verifies that auto-detect resolves PR 99 and that running `comments` succeeds; it updates the global `pass`/`fail` counters and prints a failure message with the exit code when it fails.
 test_pr_resolution_auto_detect_comments() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -93,6 +100,7 @@ test_pr_resolution_auto_detect_comments() {
   fi
 }
 
+# test_pr_resolution_auto_detect_status runs the `status` command with auto-detect mocks, expects the PR to be resolved to 99, and updates the global `pass`/`fail` counters (prints a failure message if the command exits non-zero).
 test_pr_resolution_auto_detect_status() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -105,6 +113,7 @@ test_pr_resolution_auto_detect_status() {
   fi
 }
 
+# test_pr_resolution_auto_detect_logs verifies that auto-detect resolves PR 99 for the logs command and increments the global pass or fail counter based on the command's exit status.
 test_pr_resolution_auto_detect_logs() {
   setup_mocks_auto_detect
   local exit_code=0
@@ -117,6 +126,7 @@ test_pr_resolution_auto_detect_logs() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_comments verifies that providing --pr 55 prevents auto-detection when running the comments command and updates the global pass/fail counters, printing a diagnostic on failure.
 test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -129,6 +139,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_comments() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_status verifies that providing `--pr 55` prevents auto-detection and succeeds when running the `status` command.
 test_pr_resolution_explicit_pr_skips_autodetect_status() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -141,6 +152,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_status() {
   fi
 }
 
+# test_pr_resolution_explicit_pr_skips_autodetect_logs ensures an explicit --pr argument prevents auto-detection when invoking the logs command and updates global pass/fail counters, printing a diagnostic message on failure.
 test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   setup_mocks_explicit_pr
   local output exit_code=0
@@ -153,6 +165,7 @@ test_pr_resolution_explicit_pr_skips_autodetect_logs() {
   fi
 }
 
+# test_pr_resolution_no_pr_found_exits_nonzero verifies that the script exits with a non-zero status when no open PR is found.
 test_pr_resolution_no_pr_found_exits_nonzero() {
   setup_mocks_no_pr
   local exit_code=0
@@ -165,6 +178,7 @@ test_pr_resolution_no_pr_found_exits_nonzero() {
   fi
 }
 
+# test_pr_resolution_no_pr_found_stderr_message checks that the comments command emits the literal "no open PR found" when no open PR is found.
 test_pr_resolution_no_pr_found_stderr_message() {
   setup_mocks_no_pr
   local output
@@ -177,6 +191,7 @@ test_pr_resolution_no_pr_found_stderr_message() {
   fi
 }
 
+# test_pr_resolution_api_fail_exits_nonzero verifies that when the GitHub API fails, running `comments` exits with a non-zero status and the test harness updates the pass/fail counters accordingly.
 test_pr_resolution_api_fail_exits_nonzero() {
   setup_mocks_api_fail
   local exit_code=0
@@ -189,6 +204,7 @@ test_pr_resolution_api_fail_exits_nonzero() {
   fi
 }
 
+# test_pr_resolution_api_fail_stderr_message checks that invoking comments when the GitHub API fails prints a message containing "failed" and updates the pass/fail counters.
 test_pr_resolution_api_fail_stderr_message() {
   setup_mocks_api_fail
   local output

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -1,67 +1,65 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
-# setup_mocks_base creates a temporary mock directory and installs an executable mock `git` that returns a fixed repo URL for `remote get-url origin` and a fixed branch for `rev-parse --abbrev-ref HEAD`, exiting with status 1 for any other invocation.
 setup_mocks_base() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << 'GIT_EOF'
-#!/usr/bin/env bash
-case "$*" in
-  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
-  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
 }
 
-# setup_mocks_nesting creates a temporary mock environment (mock `git` and `gh` CLIs) and per-comment reply JSON fixtures for testing comment/reply nesting; it accepts `pr_reviews` and `pr_issues` JSON strings followed by zero or more `"<cid>:<json>"` reply_spec arguments and writes `replies_<cid>.json`, then installs a `gh` mock that returns the provided data for pulls/42/comments, issues/42/comments, and pulls/comments/<id>/replies.
+_MOCK_REPLY_IDS=""
+
+_clear_reply_vars() {
+  for cid in $_MOCK_REPLY_IDS; do
+    unset "_MOCK_REPLY_${cid}" 2>/dev/null || true
+  done
+  _MOCK_REPLY_IDS=""
+}
+
 setup_mocks_nesting() {
-  local pr_reviews="$1"
-  local pr_issues="$2"
+  _MOCK_PR_REVIEWS="$1"
+  _MOCK_PR_ISSUES="$2"
   shift 2
 
   setup_mocks_base
+  _clear_reply_vars
 
   local reply_spec cid rdata
   for reply_spec in "$@"; do
     cid="${reply_spec%%:*}"
     rdata="${reply_spec#*:}"
-    echo "$rdata" > "$mock_dir/replies_${cid}.json"
+    export "_MOCK_REPLY_${cid}=$rdata"
+    _MOCK_REPLY_IDS="$_MOCK_REPLY_IDS $cid"
   done
 
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'                >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_reviews"              >> "$mock_dir/gh"
-  printf '    ;;\n'                                   >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'               >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$pr_issues"               >> "$mock_dir/gh"
-  printf '    ;;\n'                                   >> "$mock_dir/gh"
-  printf '  *"pulls/comments/"*"/replies"*)\n'       >> "$mock_dir/gh"
-  cat >> "$mock_dir/gh" << 'REPLY_MOCK'
-    _cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-    _mdir=$(dirname "$0")
-    if [ -f "${_mdir}/replies_${_cid}.json" ]; then
-      cat "${_mdir}/replies_${_cid}.json"
-    else
-      echo "[]"
-    fi
-    ;;
-REPLY_MOCK
-  printf '  *) exit 1 ;;\n'                          >> "$mock_dir/gh"
-  printf 'esac\n'                                    >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
+      *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
+      *"pulls/comments/"*"/replies"*)
+        local cid
+        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
+        local var="_MOCK_REPLY_${cid}"
+        echo "${!var:-[]}"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# run_script executes the target script with the mock directory placed first in PATH, passing through all arguments.
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-# cleanup_mocks removes the temporary mock directory created for test mocks.
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES
+  # _MOCK_REPLY_* vars are exported by setup_mocks_nesting
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -78,15 +76,12 @@ test_names+=(
   test_nesting_multiple_replies_under_one_parent
 )
 
-# test_nesting_reply_block_present verifies that a review comment with a nested reply produces a reply block containing the literal ">>> reply" marker.
-# Mocks a single review comment and its reply, runs `comments --pr 42`, and increments the global `pass`/`fail` counters based on whether the marker appears in the output.
 test_nesting_reply_block_present() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
   setup_mocks_nesting "$review" '[]' "10:$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -95,14 +90,12 @@ test_nesting_reply_block_present() {
   fi
 }
 
-# test_nesting_reply_appears_after_parent verifies that the reply marker ">>> reply" appears after its parent review comment in the script output.
 test_nesting_reply_appears_after_parent() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
   setup_mocks_nesting "$review" '[]' "10:$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local parent_line reply_line
   parent_line=$(echo "$output" | grep -n "body: parent comment" | cut -d: -f1)
   reply_line=$(echo "$output" | grep -n ">>> reply" | cut -d: -f1)
@@ -114,14 +107,12 @@ test_nesting_reply_appears_after_parent() {
   fi
 }
 
-# test_nesting_reply_uses_marker verifies that a nested review reply is rendered with the ">>> reply" marker.
 test_nesting_reply_uses_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
   setup_mocks_nesting "$review" '[]' "10:$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -130,14 +121,12 @@ test_nesting_reply_uses_marker() {
   fi
 }
 
-# test_nesting_reply_contains_author_created_body verifies that a reply's rendered block includes the `author`, `created`, and `body` fields.
 test_nesting_reply_contains_author_created_body() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
   local reply='[{"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","body":"reply body text"}]'
   setup_mocks_nesting "$review" '[]' "10:$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "author: replyuser" \
     && echo "$output" | grep -qF "created: 2025-06-01T08:00:00Z" \
     && echo "$output" | grep -qF "body: reply body text"; then
@@ -148,7 +137,6 @@ test_nesting_reply_contains_author_created_body() {
   fi
 }
 
-# test_nesting_in_reply_to_id_not_top_level ensures a review comment that has an `in_reply_to_id` is not rendered as a top-level `review-comment` block when running `comments --pr 42`.
 test_nesting_in_reply_to_id_not_top_level() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
@@ -158,7 +146,6 @@ test_nesting_in_reply_to_id_not_top_level() {
   setup_mocks_nesting "$review" '[]' "10:$reply"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local block_count
   block_count=$(echo "$output" | grep -c "^--- review-comment" || true)
   if [ "$block_count" -eq 1 ]; then
@@ -169,13 +156,11 @@ test_nesting_in_reply_to_id_not_top_level() {
   fi
 }
 
-# test_nesting_no_replies_no_marker verifies that a review comment without replies does not produce the ">>> reply" marker in the script output.
 test_nesting_no_replies_no_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"lone parent"}]'
   setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if ! echo "$output" | grep -qF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -184,13 +169,11 @@ test_nesting_no_replies_no_marker() {
   fi
 }
 
-# test_nesting_issue_comment_no_reply_marker verifies that issue-level comments are rendered without the '>>> reply' marker.
 test_nesting_issue_comment_no_reply_marker() {
   local issue='[{"user":{"login":"carol"},"created_at":"2025-01-01T10:00:00Z","body":"issue-level comment"}]'
   setup_mocks_nesting '[]' "$issue"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "issue-comment" && ! echo "$output" | grep -qF ">>> reply"; then
     pass=$((pass + 1))
   else
@@ -199,7 +182,6 @@ test_nesting_issue_comment_no_reply_marker() {
   fi
 }
 
-# test_nesting_multiple_parents_independent_replies verifies that two separate review comments each render their own independent replies and updates the global pass/fail counters.
 test_nesting_multiple_parents_independent_replies() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -210,7 +192,6 @@ test_nesting_multiple_parents_independent_replies() {
   setup_mocks_nesting "$review" '[]' "10:$reply10" "20:$reply20"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "reply to A" && echo "$output" | grep -qF "reply to B"; then
     pass=$((pass + 1))
   else
@@ -219,7 +200,6 @@ test_nesting_multiple_parents_independent_replies() {
   fi
 }
 
-# test_nesting_reply_only_under_correct_parent verifies that a reply is rendered only under its corresponding parent review comment and not under other parent comment blocks.
 test_nesting_reply_only_under_correct_parent() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -229,7 +209,6 @@ test_nesting_reply_only_under_correct_parent() {
   setup_mocks_nesting "$review" '[]' "10:$reply10"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local parent_b_section
   parent_b_section=$(echo "$output" | sed -n '/body: parent B/,/^---/p')
   if echo "$output" | grep -qF "only for A" && ! echo "$parent_b_section" | grep -qF ">>> reply"; then
@@ -240,7 +219,6 @@ test_nesting_reply_only_under_correct_parent() {
   fi
 }
 
-# test_nesting_replies_sorted_chronologically verifies that replies for a review comment are rendered in ascending order by `created_at`, so the oldest reply appears first.
 test_nesting_replies_sorted_chronologically() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[
@@ -251,7 +229,6 @@ test_nesting_replies_sorted_chronologically() {
   setup_mocks_nesting "$review" '[]' "10:$replies"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local first_reply_body
   first_reply_body=$(echo "$output" | grep -A3 ">>> reply" | grep "body:" | head -1 | sed 's/body: //')
   if [ "$first_reply_body" = "first" ]; then
@@ -262,7 +239,6 @@ test_nesting_replies_sorted_chronologically() {
   fi
 }
 
-# test_nesting_multiple_replies_under_one_parent verifies that two separate replies to a single review comment produce two distinct `>>> reply` markers in the script output.
 test_nesting_multiple_replies_under_one_parent() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[
@@ -272,7 +248,6 @@ test_nesting_multiple_replies_under_one_parent() {
   setup_mocks_nesting "$review" '[]' "10:$replies"
   local output
   output=$(run_script comments --pr 42 2>&1)
-  cleanup_mocks
   local reply_count
   reply_count=$(echo "$output" | grep -c ">>> reply" || true)
   if [ "$reply_count" -eq 2 ]; then

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -2,6 +2,7 @@
 
 PATH="$HOME/bin:$PATH"
 
+# setup_mocks_base defines test mocks for `git` and `gh`; `git` returns fixed values for repository URL and branch name for specific queries, and `gh` exits nonzero for any invocation.
 setup_mocks_base() {
   git() {
     case "$*" in
@@ -17,6 +18,7 @@ setup_mocks_base() {
 
 _MOCK_REPLY_IDS=""
 
+# _clear_reply_vars unsets all per-reply `_MOCK_REPLY_<id>` variables and clears the `_MOCK_REPLY_IDS` list.
 _clear_reply_vars() {
   for cid in $_MOCK_REPLY_IDS; do
     unset "_MOCK_REPLY_${cid}" 2>/dev/null || true
@@ -24,6 +26,8 @@ _clear_reply_vars() {
   _MOCK_REPLY_IDS=""
 }
 
+# setup_mocks_nesting sets up shell mocks and exports mock PR review, issue, and per-comment reply data used by nesting tests.
+# The first argument is PR review JSON, the second is issue comment JSON, and remaining arguments are reply specs of the form `cid:rdata` which are exported as `_MOCK_REPLY_<cid>`.
 setup_mocks_nesting() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -55,6 +59,7 @@ setup_mocks_nesting() {
   }
 }
 
+# run_script exports mock git/gh functions and mock data variables, then invokes the target script with any provided arguments.
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES
@@ -76,6 +81,7 @@ test_names+=(
   test_nesting_multiple_replies_under_one_parent
 )
 
+# test_nesting_reply_block_present verifies that when a PR review comment has a nested reply, the script output includes the ">>> reply" marker.
 test_nesting_reply_block_present() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
@@ -107,6 +113,8 @@ test_nesting_reply_appears_after_parent() {
   fi
 }
 
+# test_nesting_reply_uses_marker verifies that a nested reply is rendered with the '>>> reply' marker in the script output.
+# Sets up one review and one reply, runs the script for the PR, and passes only if the output contains ">>> reply".
 test_nesting_reply_uses_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
   local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
@@ -137,6 +145,7 @@ test_nesting_reply_contains_author_created_body() {
   fi
 }
 
+# test_nesting_in_reply_to_id_not_top_level ensures a review comment with `in_reply_to_id` is treated as a child and does not produce a separate top-level `review-comment` block in the script output.
 test_nesting_in_reply_to_id_not_top_level() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
@@ -156,6 +165,7 @@ test_nesting_in_reply_to_id_not_top_level() {
   fi
 }
 
+# test_nesting_no_replies_no_marker checks that a single review comment with no replies does not produce the reply marker '>>> reply' in the script output.
 test_nesting_no_replies_no_marker() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"lone parent"}]'
   setup_mocks_nesting "$review" '[]'
@@ -169,6 +179,7 @@ test_nesting_no_replies_no_marker() {
   fi
 }
 
+# test_nesting_issue_comment_no_reply_marker verifies that issue-level comments are shown as `issue-comment` and never include the `>>> reply` marker.
 test_nesting_issue_comment_no_reply_marker() {
   local issue='[{"user":{"login":"carol"},"created_at":"2025-01-01T10:00:00Z","body":"issue-level comment"}]'
   setup_mocks_nesting '[]' "$issue"
@@ -182,6 +193,7 @@ test_nesting_issue_comment_no_reply_marker() {
   fi
 }
 
+# test_nesting_multiple_parents_independent_replies verifies that two separate review comments each include their own replies by asserting the output contains both reply bodies.
 test_nesting_multiple_parents_independent_replies() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -200,6 +212,7 @@ test_nesting_multiple_parents_independent_replies() {
   fi
 }
 
+# test_nesting_reply_only_under_correct_parent verifies that a reply is rendered only beneath its matching parent review comment and not under other review comments.
 test_nesting_reply_only_under_correct_parent() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
@@ -219,6 +232,7 @@ test_nesting_reply_only_under_correct_parent() {
   fi
 }
 
+# test_nesting_replies_sorted_chronologically verifies that replies attached to a review are emitted in ascending order by `created_at` (earliest reply appears first).
 test_nesting_replies_sorted_chronologically() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[
@@ -239,6 +253,7 @@ test_nesting_replies_sorted_chronologically() {
   fi
 }
 
+# test_nesting_multiple_replies_under_one_parent verifies that two reply blocks are rendered under a single parent review comment; increments `pass` if exactly two `>>> reply` markers are found, otherwise increments `fail` and prints a FAIL message with the captured output.
 test_nesting_multiple_replies_under_one_parent() {
   local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
   local replies='[

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
 KNOWN_SHA="cccccccccccccccccccccccccccccccccccccccc"
 UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
@@ -8,45 +8,31 @@ UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
 HEAD_EPOCH="1742040000"
 SHA_EPOCH="1751587200"
 
-# setup_mocks creates a temporary directory, writes mock `git` and `gh` executables into it (assigned to `$mock_dir`), and makes them executable for use in tests.
 setup_mocks() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << GIT_EOF
-#!/usr/bin/env bash
-case "\$*" in
-  "remote get-url origin")       echo "https://github.com/acme/widgets.git" ;;
-  "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
-  "log -1 --format=%ct HEAD")    echo "$HEAD_EPOCH" ;;
-  "log -1 --format=%ct $KNOWN_SHA") echo "$SHA_EPOCH" ;;
-  "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'           >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'          >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
-  printf 'esac\n'                               >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+      "log -1 --format=%ct HEAD") echo "$HEAD_EPOCH" ;;
+      "log -1 --format=%ct $KNOWN_SHA") echo "$SHA_EPOCH" ;;
+      "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
-# run_script runs the target script with the mock directory prepended to PATH and forwards all arguments.
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-# cleanup_mocks removes the temporary mock directory created by setup_mocks.
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export KNOWN_SHA UNKNOWN_SHA HEAD_EPOCH SHA_EPOCH
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -69,12 +55,10 @@ test_names+=(
   test_since_short_sha_treated_as_invalid
 )
 
-# test_since_empty_resolves_to_empty verifies that running `comments --pr 42` without a `--since` argument exits with status 0.
 test_since_empty_resolves_to_empty() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -83,12 +67,10 @@ test_since_empty_resolves_to_empty() {
   fi
 }
 
-# test_since_last_commit_exits_zero verifies that running `comments --pr 42 --since last-commit` exits with status 0; it sets up mocks, runs the command, tears down mocks, increments `pass` on success or `fail` and prints a failure message including the exit code on error.
 test_since_last_commit_exits_zero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since last-commit >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -97,25 +79,18 @@ test_since_last_commit_exits_zero() {
   fi
 }
 
-# test_since_last_commit_format_is_iso8601 verifies that `--since last-commit` is treated as an ISO-8601 timestamp, allowing comments with future `created_at` values to appear and the command to exit successfully.
 test_since_last_commit_format_is_iso8601() {
   setup_mocks
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
-  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
-  printf "    echo '[{\"user\":{\"login\":\"bot\"},\"created_at\":\"2099-01-01T00:00:00Z\",\"body\":\"future\"}]'\n" >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
-  printf 'esac\n'                                >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"bot"},"created_at":"2099-01-01T00:00:00Z","body":"future"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
   local output exit_code=0
   output=$(run_script comments --pr 42 --since last-commit 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future"; then
     pass=$((pass + 1))
   else
@@ -124,12 +99,10 @@ test_since_last_commit_format_is_iso8601() {
   fi
 }
 
-# test_since_known_sha_exits_zero verifies that invoking the `comments --pr 42 --since "$KNOWN_SHA"` command exits with status 0.
 test_since_known_sha_exits_zero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since "$KNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -138,25 +111,18 @@ test_since_known_sha_exits_zero() {
   fi
 }
 
-# test_since_known_sha_format_is_iso8601 verifies that using a known commit SHA with --since accepts ISO-8601 timestamps and allows comments with a matching future `created_at` to appear in the command output.
 test_since_known_sha_format_is_iso8601() {
   setup_mocks
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
-  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
-  printf "    echo '[{\"user\":{\"login\":\"bot\"},\"created_at\":\"2099-01-01T00:00:00Z\",\"body\":\"future\"}]'\n" >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
-  printf 'esac\n'                                >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"bot"},"created_at":"2099-01-01T00:00:00Z","body":"future"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
   local output exit_code=0
   output=$(run_script comments --pr 42 --since "$KNOWN_SHA" 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future"; then
     pass=$((pass + 1))
   else
@@ -165,12 +131,10 @@ test_since_known_sha_format_is_iso8601() {
   fi
 }
 
-# test_since_date_only_exits_zero verifies that invoking the CLI with a date-only `--since` value (YYYY-MM-DD) for PR 42 exits with status 0.
 test_since_date_only_exits_zero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since 2025-06-15 >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -179,25 +143,18 @@ test_since_date_only_exits_zero() {
   fi
 }
 
-# test_since_date_only_appends_midnight_utc verifies that a date-only `--since` value is treated as midnight UTC and that comments with a `created_at` timestamp at that instant are included in the command output.
 test_since_date_only_appends_midnight_utc() {
   setup_mocks
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
-  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
-  printf "    echo '[{\"user\":{\"login\":\"alice\"},\"created_at\":\"2025-06-15T00:00:00Z\",\"body\":\"on midnight\"}]'\n" >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
-  printf 'esac\n'                                >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"alice"},"created_at":"2025-06-15T00:00:00Z","body":"on midnight"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
   local output exit_code=0
   output=$(run_script comments --pr 42 --since 2025-06-15 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "on midnight"; then
     pass=$((pass + 1))
   else
@@ -206,13 +163,10 @@ test_since_date_only_appends_midnight_utc() {
   fi
 }
 
-# test_since_datetime_exits_zero verifies that running `comments --pr 42 --since 2025-06-15T08:30:00` exits with status 0.
-# It sets up mock `git`/`gh` binaries, runs the command capturing the exit code, updates the `pass`/`fail` counters, and cleans up mocks.
 test_since_datetime_exits_zero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since 2025-06-15T08:30:00 >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ]; then
     pass=$((pass + 1))
   else
@@ -221,25 +175,18 @@ test_since_datetime_exits_zero() {
   fi
 }
 
-# test_since_datetime_appends_z tests that a --since datetime without a trailing `Z` is interpreted as UTC and that comments with the exact resulting timestamp are included in the command output.
 test_since_datetime_appends_z() {
   setup_mocks
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *"pulls/42/comments"*)\n'            >> "$mock_dir/gh"
-  printf '    echo '"'"'[]'"'"'\n'               >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"issues/42/comments"*)\n'           >> "$mock_dir/gh"
-  printf "    echo '[{\"user\":{\"login\":\"bob\"},\"created_at\":\"2025-06-15T08:30:00Z\",\"body\":\"exact ts\"}]'\n" >> "$mock_dir/gh"
-  printf '    ;;\n'                               >> "$mock_dir/gh"
-  printf '  *"pulls/comments/42/replies"*)\n'   >> "$mock_dir/gh"
-  printf "    echo '[]'\n"                       >> "$mock_dir/gh"
-  printf '    ;;\n'                              >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n'                     >> "$mock_dir/gh"
-  printf 'esac\n'                                >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"bob"},"created_at":"2025-06-15T08:30:00Z","body":"exact ts"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
   local output exit_code=0
   output=$(run_script comments --pr 42 --since 2025-06-15T08:30:00 2>&1) || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "exact ts"; then
     pass=$((pass + 1))
   else
@@ -248,12 +195,10 @@ test_since_datetime_appends_z() {
   fi
 }
 
-# test_since_unknown_sha_exits_nonzero verifies that running `comments --pr 42 --since <unknown SHA>` results in a non-zero exit status.
 test_since_unknown_sha_exits_nonzero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since "$UNKNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -262,12 +207,10 @@ test_since_unknown_sha_exits_nonzero() {
   fi
 }
 
-# test_since_unknown_sha_stderr_mentions_unknown_commit runs the comments command with `--since` set to an unknown SHA and verifies the output contains the literal substring "unknown commit".
 test_since_unknown_sha_stderr_mentions_unknown_commit() {
   setup_mocks
   local output
   output=$(run_script comments --pr 42 --since "$UNKNOWN_SHA" 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qF "unknown commit"; then
     pass=$((pass + 1))
   else
@@ -276,32 +219,26 @@ test_since_unknown_sha_stderr_mentions_unknown_commit() {
   fi
 }
 
-# test_since_invalid_format_exits_nonzero asserts that invoking the `comments` command with `--since` set to an arbitrary non-date string exits with a non-zero status.
 test_since_invalid_format_exits_nonzero() {
   assert_exit 1 "--since with arbitrary string exits non-zero" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
-# test_since_invalid_format_stderr_message checks that providing a malformed --since value causes the command to emit "invalid --since value" to stderr.
 test_since_invalid_format_stderr_message() {
   assert_stderr_contains "--since invalid format error message" "invalid --since value" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
-# test_since_invalid_month_exits_nonzero verifies that providing `--since` with an invalid month (`13`) causes the command to exit with a non-zero status.
 test_since_invalid_month_exits_nonzero() {
   assert_exit 1 "--since with month 13 exits non-zero" bash "$script" comments --pr 42 --since "2025-13-01"
 }
 
-# test_since_invalid_day_exits_nonzero asserts that invoking comments with --since "2025-01-32" exits with a non-zero status.
 test_since_invalid_day_exits_nonzero() {
   assert_exit 1 "--since with day 32 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-32"
 }
 
-# test_since_invalid_hour_exits_nonzero verifies that invoking comments --pr 42 with --since "2025-01-01T25:00:00" exits with a non-zero status.
 test_since_invalid_hour_exits_nonzero() {
   assert_exit 1 "--since with hour 25 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-01T25:00:00"
 }
 
-# test_since_short_sha_treated_as_invalid verifies that passing a 7-character SHA to `--since` causes the command to exit non-zero and emits "invalid --since value" on stderr.
 test_since_short_sha_treated_as_invalid() {
   assert_exit 1 "--since with 7-char sha exits non-zero" bash "$script" comments --pr 42 --since "abc1234"
   assert_stderr_contains "--since 7-char sha emits invalid error" "invalid --since value" bash "$script" comments --pr 42 --since "abc1234"

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -8,6 +8,7 @@ UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
 HEAD_EPOCH="1742040000"
 SHA_EPOCH="1751587200"
 
+# setup_mocks defines mocked `git` and `gh` shell functions that return deterministic responses for a small set of calls used by the tests.
 setup_mocks() {
   git() {
     case "$*" in
@@ -29,6 +30,7 @@ setup_mocks() {
   }
 }
 
+# run_script exports the mocked `git` and `gh` functions and related SHA/epoch variables, then executes the target script with the provided arguments and propagates its exit status.
 run_script() {
   export -f git gh
   export KNOWN_SHA UNKNOWN_SHA HEAD_EPOCH SHA_EPOCH
@@ -55,6 +57,7 @@ test_names+=(
   test_since_short_sha_treated_as_invalid
 )
 
+# test_since_empty_resolves_to_empty verifies that invoking the comments command without a `--since` value exits with status 0.
 test_since_empty_resolves_to_empty() {
   setup_mocks
   local exit_code=0
@@ -67,6 +70,7 @@ test_since_empty_resolves_to_empty() {
   fi
 }
 
+# test_since_last_commit_exits_zero verifies that invoking `comments --pr 42 --since last-commit` exits successfully and updates the `pass`/`fail` counters.
 test_since_last_commit_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -79,6 +83,7 @@ test_since_last_commit_exits_zero() {
   fi
 }
 
+# test_since_last_commit_format_is_iso8601 verifies that a timestamp resolved for last-commit is formatted as ISO-8601 and accepted by the script (comments with future timestamps are included).
 test_since_last_commit_format_is_iso8601() {
   setup_mocks
   gh() {
@@ -99,6 +104,7 @@ test_since_last_commit_format_is_iso8601() {
   fi
 }
 
+# test_since_known_sha_exits_zero verifies that running the script with `--since` set to a known commit SHA exits with status 0.
 test_since_known_sha_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -111,6 +117,7 @@ test_since_known_sha_exits_zero() {
   fi
 }
 
+# test_since_known_sha_format_is_iso8601 verifies that when --since is given a known commit SHA the script emits an ISO-8601 timestamp accepted by the API and thus includes comments with a future `created_at` value.
 test_since_known_sha_format_is_iso8601() {
   setup_mocks
   gh() {
@@ -131,6 +138,7 @@ test_since_known_sha_format_is_iso8601() {
   fi
 }
 
+# test_since_date_only_exits_zero verifies that running the script with a date-only `--since` value (YYYY-MM-DD) exits with status 0.
 test_since_date_only_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -143,6 +151,7 @@ test_since_date_only_exits_zero() {
   fi
 }
 
+# test_since_date_only_appends_midnight_utc verifies that a date-only `--since` value (YYYY-MM-DD) is treated as midnight UTC and that comments with `created_at` equal to that timestamp are included.
 test_since_date_only_appends_midnight_utc() {
   setup_mocks
   gh() {
@@ -163,6 +172,7 @@ test_since_date_only_appends_midnight_utc() {
   fi
 }
 
+# test_since_datetime_exits_zero verifies that passing a date-time without a timezone (YYYY-MM-DDTHH:mm:ss) to `--since` causes the script to exit with status 0.
 test_since_datetime_exits_zero() {
   setup_mocks
   local exit_code=0
@@ -175,6 +185,7 @@ test_since_datetime_exits_zero() {
   fi
 }
 
+# test_since_datetime_appends_z verifies that a datetime without a trailing "Z" is treated as UTC (appending "Z") so the script includes comments whose created_at matches that exact timestamp.
 test_since_datetime_appends_z() {
   setup_mocks
   gh() {
@@ -195,6 +206,7 @@ test_since_datetime_appends_z() {
   fi
 }
 
+# test_since_unknown_sha_exits_nonzero verifies that running the script with --since set to an unknown commit SHA results in a non-zero exit status.
 test_since_unknown_sha_exits_nonzero() {
   setup_mocks
   local exit_code=0
@@ -207,6 +219,7 @@ test_since_unknown_sha_exits_nonzero() {
   fi
 }
 
+# test_since_unknown_sha_stderr_mentions_unknown_commit verifies that running the script with --since set to an unknown commit SHA writes "unknown commit" to stderr.
 test_since_unknown_sha_stderr_mentions_unknown_commit() {
   setup_mocks
   local output
@@ -219,26 +232,32 @@ test_since_unknown_sha_stderr_mentions_unknown_commit() {
   fi
 }
 
+# test_since_invalid_format_exits_nonzero verifies that supplying a non-date string to --since causes the script to exit with status 1.
 test_since_invalid_format_exits_nonzero() {
   assert_exit 1 "--since with arbitrary string exits non-zero" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
+# test_since_invalid_format_stderr_message verifies that providing an invalid `--since` value prints "invalid --since value" to stderr.
 test_since_invalid_format_stderr_message() {
   assert_stderr_contains "--since invalid format error message" "invalid --since value" bash "$script" comments --pr 42 --since "not-a-date-at-all"
 }
 
+# test_since_invalid_month_exits_nonzero verifies that invoking the script with `--since "2025-13-01"` causes it to exit with a non-zero status.
 test_since_invalid_month_exits_nonzero() {
   assert_exit 1 "--since with month 13 exits non-zero" bash "$script" comments --pr 42 --since "2025-13-01"
 }
 
+# test_since_invalid_day_exits_nonzero verifies that passing `--since "2025-01-32"` causes the script to exit with status 1.
 test_since_invalid_day_exits_nonzero() {
   assert_exit 1 "--since with day 32 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-32"
 }
 
+# test_since_invalid_hour_exits_nonzero verifies that invoking the script with --since "2025-01-01T25:00:00" causes the command to exit with status 1.
 test_since_invalid_hour_exits_nonzero() {
   assert_exit 1 "--since with hour 25 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-01T25:00:00"
 }
 
+# test_since_short_sha_treated_as_invalid verifies that passing a 7-character SHA to `--since` causes the script to exit with code 1 and emits "invalid --since value" on stderr.
 test_since_short_sha_treated_as_invalid() {
   assert_exit 1 "--since with 7-char sha exits non-zero" bash "$script" comments --pr 42 --since "abc1234"
   assert_stderr_contains "--since 7-char sha emits invalid error" "invalid --since value" bash "$script" comments --pr 42 --since "abc1234"

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -4,6 +4,7 @@ PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
+# setup_mocks defines mocked `git` and `gh` shell functions used by the test harness; `git` responds with fixed repo URL and branch values for known invocations and exits nonzero for others, while `gh` always exits nonzero.
 setup_mocks() {
   git() {
     case "$*" in
@@ -18,6 +19,7 @@ setup_mocks() {
   }
 }
 
+# setup_mocks_status sets up git and gh mock functions and configures `gh` to return `HEAD_SHA` for "pulls/42" requests and the provided check-runs JSON when "check-runs" is requested (first argument is the mock check-runs payload).
 setup_mocks_status() {
   _MOCK_CHECK_RUNS="$1"
   setup_mocks
@@ -30,6 +32,7 @@ setup_mocks_status() {
   }
 }
 
+# setup_mocks_status_auto configures git/gh mocks and defines gh to: return '42' for a pull lookup by head (auto-detect PR), return the HEAD SHA for pulls/42, and echo the first argument as the check-runs JSON; any other gh invocation exits with status 1.
 setup_mocks_status_auto() {
   _MOCK_CHECK_RUNS="$1"
   setup_mocks
@@ -43,6 +46,7 @@ setup_mocks_status_auto() {
   }
 }
 
+# setup_mocks_status_no_pr sets up mocked git and gh commands where a pull request lookup for the current head returns an empty result (simulating no open PR), and all other gh invocations fail.
 setup_mocks_status_no_pr() {
   setup_mocks
   gh() {
@@ -53,6 +57,7 @@ setup_mocks_status_no_pr() {
   }
 }
 
+# setup_mocks_status_paginated configures mock git/gh behavior and defines a gh() that returns the head SHA for `pulls/42` and prints the two paginated `check-runs` responses provided as its first and second arguments.
 setup_mocks_status_paginated() {
   _MOCK_PAGE1="$1"
   _MOCK_PAGE2="$2"
@@ -66,6 +71,7 @@ setup_mocks_status_paginated() {
   }
 }
 
+# setup_mocks_status_sha_fails sets up git and gh mocks where a PR number is found but the pull details lookup fails, simulating a HEAD SHA resolution error.
 setup_mocks_status_sha_fails() {
   setup_mocks
   gh() {
@@ -77,6 +83,7 @@ setup_mocks_status_sha_fails() {
   }
 }
 
+# run_script runs the target script in a subshell with the mocked `git` and `gh` functions and mock variables exported so the script sees the test-provided behavior.
 run_script() {
   export -f git gh
   export _MOCK_CHECK_RUNS _MOCK_PAGE1 _MOCK_PAGE2 HEAD_SHA
@@ -103,6 +110,7 @@ test_names+=(
   test_status_sha_lookup_failure_stderr_message
 )
 
+# test_status_completed_check verifies that `status --pr 42` prints a completed check run with its name, status, and conclusion.
 test_status_completed_check() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$check_runs"
@@ -119,6 +127,7 @@ test_status_completed_check() {
   fi
 }
 
+# test_status_in_progress_omits_conclusion verifies that a check run with status in_progress is printed without a `conclusion:` line and increments the `pass` or `fail` counters accordingly.
 test_status_in_progress_omits_conclusion() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null}]}'
   setup_mocks_status "$check_runs"
@@ -133,6 +142,7 @@ test_status_in_progress_omits_conclusion() {
   fi
 }
 
+# test_status_queued_omits_conclusion checks that when a check run has status 'queued' the script's status output includes 'status: queued' and does not include any 'conclusion:' line.
 test_status_queued_omits_conclusion() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"Lint","status":"queued","conclusion":null}]}'
   setup_mocks_status "$check_runs"
@@ -147,6 +157,7 @@ test_status_queued_omits_conclusion() {
   fi
 }
 
+# test_status_sorted_by_name verifies that check runs are listed sorted by name so the first `name:` line is `Alpha`.
 test_status_sorted_by_name() {
   local check_runs='{"total_count":2,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"},{"name":"Alpha","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$check_runs"
@@ -162,6 +173,7 @@ test_status_sorted_by_name() {
   fi
 }
 
+# test_status_explicit_pr verifies that running `status --pr 42` prints the check run details for the specified PR (expects a `CI` check with `status: completed` and `conclusion: success`).
 test_status_explicit_pr() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$check_runs"
@@ -175,6 +187,7 @@ test_status_explicit_pr() {
   fi
 }
 
+# test_status_auto_detect verifies that the status command auto-detects the pull request from the current branch and outputs the check run status.
 test_status_auto_detect() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   setup_mocks_status_auto "$check_runs"
@@ -188,12 +201,14 @@ test_status_auto_detect() {
   fi
 }
 
+# test_status_exits_zero ensures the status command exits with 0 when all check runs conclude successfully.
 test_status_exits_zero() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$check_runs"
   assert_exit 0 "status exits 0 on success" run_script status --pr 42
 }
 
+# test_status_no_pr_found_exits_nonzero verifies that invoking the script's `status` command when no open PR exists exits with a non-zero status.
 test_status_no_pr_found_exits_nonzero() {
   setup_mocks_status_no_pr
   local exit_code=0
@@ -206,6 +221,7 @@ test_status_no_pr_found_exits_nonzero() {
   fi
 }
 
+# test_status_no_pr_found_stderr_message verifies that running `status` when no open PR is found writes "no open PR found" to stderr (and counts the test as pass/fail accordingly).
 test_status_no_pr_found_stderr_message() {
   setup_mocks_status_no_pr
   local output
@@ -231,6 +247,7 @@ test_status_empty_checks() {
   fi
 }
 
+# test_status_multiple_conclusions verifies the status command outputs each conclusion value when multiple completed check runs have differing conclusions.
 test_status_multiple_conclusions() {
   local check_runs='{"total_count":3,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"},{"name":"Deploy","status":"completed","conclusion":"cancelled"}]}'
   setup_mocks_status "$check_runs"
@@ -246,6 +263,7 @@ test_status_multiple_conclusions() {
   fi
 }
 
+# test_status_unknown_option_exits_nonzero verifies that running the `status` command with an unrecognized option causes the script to exit with a non-zero status.
 test_status_unknown_option_exits_nonzero() {
   local check_runs='{"total_count":0,"check_runs":[]}'
   setup_mocks_status "$check_runs"
@@ -259,6 +277,7 @@ test_status_unknown_option_exits_nonzero() {
   fi
 }
 
+# test_status_missing_pr_value_exits_nonzero asserts that invoking the script's `status` command with `--pr` but no value exits with status 1.
 test_status_missing_pr_value_exits_nonzero() {
   assert_exit 1 "status --pr without value exits non-zero" bash "$script" status --pr
 }
@@ -272,6 +291,7 @@ test_status_help_exits_zero() {
   assert_exit 0 "status -h exits 0" bash "$script" status -h
 }
 
+# test_status_paginated_merges_all_checks verifies that the status command merges paginated check-run responses and includes check runs from all returned pages.
 test_status_paginated_merges_all_checks() {
   local page1='{"total_count":3,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"}]}'
   local page2='{"total_count":3,"check_runs":[{"name":"Alpha","status":"completed","conclusion":"failure"}]}'
@@ -287,6 +307,7 @@ test_status_paginated_merges_all_checks() {
   fi
 }
 
+# test_status_sha_lookup_failure_stderr_message verifies that a failed head SHA lookup causes the status command to emit "failed to resolve head SHA" and that the test harness records the failure or pass accordingly.
 test_status_sha_lookup_failure_stderr_message() {
   setup_mocks_status_sha_fails
   local output

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -1,96 +1,86 @@
 #!/usr/bin/env bash
 
-ORIGINAL_PATH="$HOME/bin:$PATH"
+PATH="$HOME/bin:$PATH"
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
 setup_mocks() {
-  mock_dir=$(mktemp -d)
-  cat > "$mock_dir/git" << GIT_EOF
-#!/usr/bin/env bash
-case "\$*" in
-  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
-  "branch --show-current") echo "feature-branch" ;;
-  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-  *) exit 1 ;;
-esac
-GIT_EOF
-  chmod +x "$mock_dir/git"
+  git() {
+    case "$*" in
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "branch --show-current") echo "feature-branch" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    exit 1
+  }
 }
 
 setup_mocks_status() {
-  local check_runs="$1"
-
+  _MOCK_CHECK_RUNS="$1"
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_status_auto() {
-  local check_runs="$1"
-
+  _MOCK_CHECK_RUNS="$1"
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$check_runs" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '42' ;;
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_status_no_pr() {
   setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
-  printf '    echo ""\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo "" ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 setup_mocks_status_paginated() {
-  local page1="$1"
-  local page2="$2"
-
+  _MOCK_PAGE1="$1"
+  _MOCK_PAGE2="$2"
   setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*) printf '%s\n' "$_MOCK_PAGE1" "$_MOCK_PAGE2" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
 
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" "$HEAD_SHA" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"check-runs\"*)\n' >> "$mock_dir/gh"
-  printf "    printf '%%s\\n' '%s' '%s'\n" "$page1" "$page2" >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
+setup_mocks_status_sha_fails() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '42' ;;
+      *"pulls/42"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
 }
 
 run_script() {
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" "$@"
-}
-
-cleanup_mocks() {
-  rm -rf "$mock_dir"
+  export -f git gh
+  export _MOCK_CHECK_RUNS _MOCK_PAGE1 _MOCK_PAGE2 HEAD_SHA
+  bash "$script" "$@"
 }
 
 test_names+=(
@@ -118,7 +108,6 @@ test_status_completed_check() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF -- "--- check" \
     && echo "$output" | grep -qF "name: CI" \
     && echo "$output" | grep -qF "status: completed" \
@@ -135,7 +124,6 @@ test_status_in_progress_omits_conclusion() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "status: in_progress" \
     && ! echo "$output" | grep -qF "conclusion:"; then
     pass=$((pass + 1))
@@ -150,7 +138,6 @@ test_status_queued_omits_conclusion() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "status: queued" \
     && ! echo "$output" | grep -qF "conclusion:"; then
     pass=$((pass + 1))
@@ -165,7 +152,6 @@ test_status_sorted_by_name() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   local first_name
   first_name=$(echo "$output" | grep -m1 "name:" | sed 's/name: //')
   if [ "$first_name" = "Alpha" ]; then
@@ -181,7 +167,6 @@ test_status_explicit_pr() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "name: CI"; then
     pass=$((pass + 1))
   else
@@ -195,7 +180,6 @@ test_status_auto_detect() {
   setup_mocks_status_auto "$check_runs"
   local output
   output=$(run_script status 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "name: CI"; then
     pass=$((pass + 1))
   else
@@ -208,14 +192,12 @@ test_status_exits_zero() {
   local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   setup_mocks_status "$check_runs"
   assert_exit 0 "status exits 0 on success" run_script status --pr 42
-  cleanup_mocks
 }
 
 test_status_no_pr_found_exits_nonzero() {
   setup_mocks_status_no_pr
   local exit_code=0
   run_script status >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
@@ -224,12 +206,23 @@ test_status_no_pr_found_exits_nonzero() {
   fi
 }
 
+test_status_no_pr_found_stderr_message() {
+  setup_mocks_status_no_pr
+  local output
+  output=$(run_script status 2>&1) || true
+  if echo "$output" | grep -qF "no open PR found"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR found should mention 'no open PR found' (output: $output)"
+  fi
+}
+
 test_status_empty_checks() {
   local check_runs='{"total_count":0,"check_runs":[]}'
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if [ -z "$output" ]; then
     pass=$((pass + 1))
   else
@@ -243,7 +236,6 @@ test_status_multiple_conclusions() {
   setup_mocks_status "$check_runs"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "conclusion: success" \
     && echo "$output" | grep -qF "conclusion: failure" \
     && echo "$output" | grep -qF "conclusion: cancelled"; then
@@ -255,28 +247,15 @@ test_status_multiple_conclusions() {
 }
 
 test_status_unknown_option_exits_nonzero() {
-  setup_mocks
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  setup_mocks_status "$check_runs"
   local exit_code=0
-  PATH="$mock_dir:$ORIGINAL_PATH" bash "$script" status --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
-  cleanup_mocks
+  run_script status --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
   if [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
     echo "FAIL: unknown option should exit non-zero"
-  fi
-}
-
-test_status_no_pr_found_stderr_message() {
-  setup_mocks_status_no_pr
-  local output
-  output=$(run_script status 2>&1) || true
-  cleanup_mocks
-  if echo "$output" | grep -qF "no open PR found"; then
-    pass=$((pass + 1))
-  else
-    fail=$((fail + 1))
-    echo "FAIL: no PR found should mention 'no open PR found' (output: $output)"
   fi
 }
 
@@ -299,7 +278,6 @@ test_status_paginated_merges_all_checks() {
   setup_mocks_status_paginated "$page1" "$page2"
   local output
   output=$(run_script status --pr 42 2>&1)
-  cleanup_mocks
   if echo "$output" | grep -qF "name: Alpha" \
     && echo "$output" | grep -qF "name: Zebra"; then
     pass=$((pass + 1))
@@ -309,26 +287,10 @@ test_status_paginated_merges_all_checks() {
   fi
 }
 
-setup_mocks_status_sha_fails() {
-  setup_mocks
-
-  printf '#!/usr/bin/env bash\ncase "$*" in\n' > "$mock_dir/gh"
-  printf '  *\"pulls?head=acme:feature-branch\"*)\n' >> "$mock_dir/gh"
-  printf "    echo '%s'\n" '42' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *\"pulls/42\"*)\n' >> "$mock_dir/gh"
-  printf '    exit 1\n' >> "$mock_dir/gh"
-  printf '    ;;\n' >> "$mock_dir/gh"
-  printf '  *) exit 1 ;;\n' >> "$mock_dir/gh"
-  printf 'esac\n' >> "$mock_dir/gh"
-  chmod +x "$mock_dir/gh"
-}
-
 test_status_sha_lookup_failure_stderr_message() {
   setup_mocks_status_sha_fails
   local output
   output=$(run_script status 2>&1) || true
-  cleanup_mocks
   if echo "$output" | grep -qF "failed to resolve head SHA"; then
     pass=$((pass + 1))
   else


### PR DESCRIPTION
## Summary

- Add `BASH_SOURCE` guard to dispatch block in `gh-pr-context` so the script can be safely sourced without triggering `exit` calls
- Replace PATH-injected mock executables (temp dirs with executable stubs) with shell function overrides using `export -f git gh` + `bash "$script"` in 7 test files
- Export all variables referenced inside exported functions (`HEAD_SHA`, `HEAD_EPOCH`, `KNOWN_SHA`, etc.) to prevent unbound variable errors under `set -u`
- Add `unset -f git gh` cleanup in `run.sh` after each test file to prevent cross-file function leakage
- Net reduction of ~310 lines (removed mktemp/file/chmod/cleanup infrastructure)

## Design Decision

The CodeRabbit plan suggested sourcing the script inside a subshell and calling `cmd_*` directly. This did not work because `die()` uses `exit 1` inside command substitutions (e.g., `since_ref=$(resolve_since_timestamp "$2")`), and `exit` only exits the `$()`, not the enclosing `()` subshell. The `export -f` approach achieves the same mock injection while preserving correct exit behavior.

## Test plan

- [x] All 147 tests pass (`bash test/run.sh`)
- [x] `test_cli.sh` (direct `bash "$script"` invocation) unaffected — no mocks used
- [x] `test_install.sh` (out of scope) unchanged and passing
- [x] No leftover debug files, TODOs, or FIXMEs
- [x] `grep` scan confirms no `mktemp`, `cleanup_mocks`, `ORIGINAL_PATH`, or `mock_dir` in migrated files

Closes #12


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Script no longer executes when imported/sourced; behaves the same when run directly (help/version unchanged).

* **Tests**
  * Overhauled test harness to use in-process mocks for more reliable, faster tests.
  * Improved cleanup to remove mocked command artifacts and reset mock state.

* **Refactor**
  * Simplified mocking lifecycle and removed temporary-file based mock plumbing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->