### PR TITLE
refactor: migrate test mocks to shell function overrides

### DIFF
--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 KNOWN_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 UNKNOWN_SHA="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 MOCK_HEAD_TS="2025-06-01T10:00:00Z"

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
 # setup_mocks sets up test mocks for `git` and `gh`: `git` returns a fixed repository URL or branch name for specific queries, and `gh` exits with status 1 by default.

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 HEAD_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 
 # setup_mocks_base defines mock `git` and `gh` functions for tests; the mock `git` returns a fixed repo URL for `remote get-url origin` and a fixed branch for `rev-parse --abbrev-ref HEAD`, while the mock `gh` exits with status 1 by default.

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 # setup_mocks_base sets up base mock implementations of `git` and `gh` for tests, where `git` returns a fixed origin URL or branch name and `gh` exits with failure.
 setup_mocks_base() {
   git() {

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 # setup_mocks_base defines test mocks for `git` and `gh`; `git` returns fixed values for repository URL and branch name for specific queries, and `gh` exits nonzero for any invocation.
 setup_mocks_base() {
   git() {

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 KNOWN_SHA="cccccccccccccccccccccccccccccccccccccccc"
 UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
 

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-PATH="$HOME/bin:$PATH"
-
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
 # setup_mocks defines mocked `git` and `gh` shell functions used by the test harness; `git` responds with fixed repo URL and branch values for known invocations and exits nonzero for others, while `gh` always exits nonzero.


### PR DESCRIPTION
## Summary

- Migrate all test mocks from PATH injection ($HOME/bin) to xport -f shell function overrides, making tests hermetic and independent of developer-local $HOME/bin contents
- Remove vestigial PATH="C:\Users\yvesa/bin:" lines from all 7 test files (dead code after the migration)
- Add docstrings to all test mock functions for discoverability

Closes #12