### PR TITLE
feat: add compatibility and allowed-tools to SKILL.md frontmatter

### DIFF
--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-qa-review
 description: QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".
-compatibility: Requires gh (authenticated), jq, and bash
+compatibility: Requires gh-pr-context on PATH, gh (authenticated), jq, and bash
 allowed-tools: Bash(gh:*) Bash(jq:*) Bash(git:*) Bash(bash:*)
 ---
 

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -2,7 +2,7 @@
 name: pr-qa-review
 description: QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".
 compatibility: Requires gh-pr-context on PATH, gh (authenticated), jq, and bash
-allowed-tools: Bash(gh:*) Bash(jq:*) Bash(git:*) Bash(bash:*)
+allowed-tools: Bash(gh-pr-context:*) Bash(gh:*) Bash(jq:*) Bash(git:*)
 ---
 
 # PR QA & Delivery Review

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -1,6 +1,8 @@
 ---
 name: pr-qa-review
 description: QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".
+compatibility: Requires gh (authenticated), jq, and bash
+allowed-tools: Bash(gh:*) Bash(jq:*) Bash(git:*) Bash(bash:*)
 ---
 
 # PR QA & Delivery Review


### PR DESCRIPTION
## Summary

Add optional Agent Skills spec fields to skills/pr-qa-review/SKILL.md frontmatter for better agent integration:

- **compatibility**: Declares runtime requirements (gh, jq, ash) so agents know upfront what the skill needs
- **llowed-tools**: Pre-approves gh, jq, git, and ash tool calls so supported agents can execute them without prompting

Both fields are optional per the [Agent Skills spec](https://agentskills.io/specification) but improve the skill experience across Claude Code, Codex, Cursor, Roo Code, and other compatible agents.

Refs #22

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated PR QA review docs to declare required tools (gh-pr-context, authenticated gh, jq, git, bash) and to state that those tools are invoked via Bash, providing clearer setup and execution guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->