### PR TITLE
ci: add version-tag consistency gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,10 @@ jobs:
           TAG_VERSION="${TAG_VERSION#v}"
           echo "Script version: $SCRIPT_VERSION"
           echo "Tag version:    $TAG_VERSION"
+          if [ -z "$SCRIPT_VERSION" ]; then
+            echo "::error::Could not extract version from gh-pr-context"
+            exit 1
+          fi
           if [ "$SCRIPT_VERSION" != "$TAG_VERSION" ]; then
             echo "::error::Version mismatch: gh-pr-context reports '$SCRIPT_VERSION' but tag is '$TAG_VERSION'"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [master]
+    tags: ["v*"]
   pull_request:
 
 jobs:
@@ -19,3 +20,22 @@ jobs:
 
       - name: Tests
         run: bash test/run.sh
+
+  version-check:
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Verify version matches tag
+        run: |
+          SCRIPT_VERSION=$(sed -n 's/^version="\([^"]*\)"/\1/p' gh-pr-context)
+          TAG_VERSION="${{ github.ref_name }}"
+          TAG_VERSION="${TAG_VERSION#v}"
+          echo "Script version: $SCRIPT_VERSION"
+          echo "Tag version:    $TAG_VERSION"
+          if [ "$SCRIPT_VERSION" != "$TAG_VERSION" ]; then
+            echo "::error::Version mismatch: gh-pr-context reports '$SCRIPT_VERSION' but tag is '$TAG_VERSION'"
+            exit 1
+          fi
+          echo "Version check passed: $SCRIPT_VERSION == $TAG_VERSION"


### PR DESCRIPTION
## Summary

- Adds a `version-check` CI job that triggers on tag pushes matching `v*`
- Extracts `version=` from `gh-pr-context` and compares it to the git tag name
- Fails with a clear `::error::` annotation on mismatch
- Existing `lint-and-test` job is unchanged

Closes #29

## Test plan

- [ ] Push a tag like `v0.1.0` and verify the `version-check` job passes (matches current `version="0.1.0"`)
- [ ] Push a tag like `v9.9.9` and verify the `version-check` job fails with a clear mismatch error
- [ ] Verify existing `lint-and-test` job still runs on master pushes and PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Enhanced release pipeline: tag-triggered runs for versioned releases (e.g., v1.2.3) now include an automated version check that compares the release tag to the release metadata and fails the pipeline if the values are missing or do not match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->