### PR TITLE
feat: add post-install PATH warning

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,8 @@ chmod +x "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to set executabl
 
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"
 
-if ! command -v "$SCRIPT_NAME" >/dev/null 2>&1; then
+resolved=$(command -v "$SCRIPT_NAME" 2>/dev/null) || true
+if [ "$resolved" != "$install_dir/$SCRIPT_NAME" ]; then
   echo "warning: $SCRIPT_NAME is not on your PATH" >&2
   echo "  Add it by running:" >&2
   echo "    export PATH=\"$install_dir:\$PATH\"" >&2

--- a/install.sh
+++ b/install.sh
@@ -25,3 +25,9 @@ mv "$tmp" "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to write to $in
 chmod +x "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to set executable permissions on $install_dir/$SCRIPT_NAME"
 
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"
+
+if ! command -v "$SCRIPT_NAME" >/dev/null 2>&1; then
+  echo "warning: $SCRIPT_NAME is not on your PATH" >&2
+  echo "  Add it by running:" >&2
+  echo "    export PATH=\"$install_dir:\$PATH\"" >&2
+fi

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -203,7 +203,7 @@ test_install_path_warning_when_not_on_path() {
   local mockdir="$tmpdir/mock-bin"
   setup_mock_curl "$mockdir" success
   local stderr
-  stderr=$(INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" 2>&1 >/dev/null) || true
+  stderr=$(INSTALL_DIR="$custom" PATH="$mockdir:/usr/bin:/bin" bash "$install_script" 2>&1 >/dev/null) || true
   if echo "$stderr" | grep -q "warning: gh-pr-context is not on your PATH"; then
     pass=$((pass + 1))
   else
@@ -221,7 +221,7 @@ test_install_no_path_warning_when_on_path() {
   local mockdir="$tmpdir/mock-bin"
   setup_mock_curl "$mockdir" success
   local stderr
-  stderr=$(INSTALL_DIR="$custom" PATH="$custom:$mockdir:$PATH" bash "$install_script" 2>&1 >/dev/null) || true
+  stderr=$(INSTALL_DIR="$custom" PATH="$custom:$mockdir:/usr/bin:/bin" bash "$install_script" 2>&1 >/dev/null) || true
   if echo "$stderr" | grep -q "warning: gh-pr-context is not on your PATH"; then
     fail=$((fail + 1))
     echo "FAIL: should not warn when install dir is on PATH (got: $stderr)"

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -43,6 +43,8 @@ test_names+=(
   test_install_curl_failure_exits_nonzero
   test_install_success_message
   test_install_curl_failure_stderr
+  test_install_path_warning_when_not_on_path
+  test_install_no_path_warning_when_on_path
 )
 
 # test_install_default_dir verifies that running the installer with an empty INSTALL_DIR installs an executable `gh-pr-context` into `$HOME/.local/bin`.
@@ -189,6 +191,42 @@ test_install_curl_failure_stderr() {
   else
     fail=$((fail + 1))
     echo "FAIL: curl failure should output error to stderr (got: $stderr)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+# test_install_path_warning_when_not_on_path verifies the installer warns when the install directory is not on PATH.
+test_install_path_warning_when_not_on_path() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local stderr
+  stderr=$(INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" 2>&1 >/dev/null) || true
+  if echo "$stderr" | grep -q "warning: gh-pr-context is not on your PATH"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: should warn when install dir is not on PATH (got: $stderr)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+# test_install_no_path_warning_when_on_path verifies no warning is printed when the install directory is on PATH.
+test_install_no_path_warning_when_on_path() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  setup_mock_curl "$mockdir" success
+  local stderr
+  stderr=$(INSTALL_DIR="$custom" PATH="$custom:$mockdir:$PATH" bash "$install_script" 2>&1 >/dev/null) || true
+  if echo "$stderr" | grep -q "warning: gh-pr-context is not on your PATH"; then
+    fail=$((fail + 1))
+    echo "FAIL: should not warn when install dir is on PATH (got: $stderr)"
+  else
+    pass=$((pass + 1))
   fi
   cleanup_tmpdir "$tmpdir"
 }


### PR DESCRIPTION
## Summary
- After a successful install, check if `gh-pr-context` is resolvable on PATH via `command -v`
- If not found, print a non-fatal warning to stderr with the install directory and a suggested `export PATH=...` command
- Addresses friction where Windows/Git Bash users install to `~/.local/bin` but the tool isn't immediately available

## Test plan
- [x] New test verifies warning is printed when install dir is not on PATH
- [x] New test verifies no warning when install dir is on PATH
- [x] All 10 install tests pass (8 existing + 2 new)
- [ ] Manual: run `bash install.sh` without `~/.local/bin` on PATH — warning appears
- [ ] Manual: run `bash install.sh` with `~/.local/bin` on PATH — no warning

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Installer now checks whether the installed tool is discoverable on PATH and, if not, emits a warning and prints a suggested export command to add the install directory to PATH.

* **Tests**
  * Added test cases to verify the installer emits the PATH warning when appropriate and does not emit it when the install directory is already on PATH.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->