### PR TITLE
fix: Windows CRLF compatibility and review findings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,7 @@ jobs:
           fetch-depth: 0
 
       - name: Version/tag consistency check
+        if: github.event_name != 'pull_request'
         run: |
           script_ver=$(grep '^version=' gh-pr-context | cut -d'"' -f2)
           latest_tag=$(git tag --list 'v*' --sort=-v:refname | head -n1)
@@ -45,7 +46,7 @@ jobs:
 
       - name: Verify version matches tag
         run: |
-          SCRIPT_VERSION=$(sed -n 's/^version="\([^"]*\)"/\1/p' gh-pr-context)
+          SCRIPT_VERSION=$(grep '^version=' gh-pr-context | cut -d'"' -f2)
           TAG_VERSION="${{ github.ref_name }}"
           TAG_VERSION="${TAG_VERSION#v}"
           echo "Script version: $SCRIPT_VERSION"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.2.0
+
+- **GH_PR_CONTEXT_VERSION** — Install a specific version by setting the env var (e.g., `GH_PR_CONTEXT_VERSION=v0.2.0`).
+- **PATH warning** — Post-install check warns if `gh-pr-context` is not on PATH.
+- **CI version gate** — Automated check that script version matches the latest git tag.
+- **Windows CRLF fix** — Strip `\r` from `jq` output to prevent corrupted API URLs on Windows/Git Bash.
+
 ## v0.1.0
 
 Initial release.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ Or use the `INSTALL_DIR` environment variable:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | INSTALL_DIR=/usr/local/bin bash
 ```
 
+Install a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.0 bash
+```
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/insta
 Install a specific version:
 
 ```bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=<tag> bash
+```
+
+For example, to install `v0.2.0`:
+
+```bash
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.0 bash
 ```
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -46,7 +46,7 @@ resolve_pr_number() {
   local owner=${owner_repo%%/*}
   local repo=${owner_repo#*/}
   local pr_data
-  pr_data=$(gh api "repos/$owner/$repo/pulls?head=$owner:$branch" --jq '.[0].number') || die "failed to look up PR for branch '$branch'"
+  pr_data=$(gh api "repos/$owner/$repo/pulls?head=$owner:$branch" --jq '.[0].number' | tr -d '\r') || die "failed to look up PR for branch '$branch'"
   if [ -z "$pr_data" ] || [ "$pr_data" = "null" ]; then
     die "no open PR found for branch '$branch'"
   fi
@@ -57,7 +57,7 @@ resolve_pr_head_sha() {
   local pr_number=$1
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  gh api "repos/$owner_repo/pulls/$pr_number" --jq '.head.sha'
+  gh api "repos/$owner_repo/pulls/$pr_number" --jq '.head.sha' | tr -d '\r'
 }
 
 resolve_since_timestamp() {
@@ -139,7 +139,7 @@ cmd_comments() {
   review_json=$(echo "$review_json" | jq '[.[] | select(.in_reply_to_id == null) | {source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body}]')
 
   local review_ids
-  review_ids=$(echo "$review_json" | jq -r '.[].id // empty')
+  review_ids=$(echo "$review_json" | jq -r '.[].id // empty' | tr -d '\r')
 
   local replies_map="{}"
   for cid in $review_ids; do
@@ -250,7 +250,7 @@ cmd_logs() {
     || die "failed to fetch check runs for SHA $sha"
 
   local failed_pairs
-  failed_pairs=$(echo "$checks_json" | jq -s -r 'map(.check_runs) | add // [] | map(select(.status == "completed" and .conclusion == "failure")) | sort_by(.name) | .[] | "\(.id)\t\(.name)"')
+  failed_pairs=$(echo "$checks_json" | jq -s -r 'map(.check_runs) | add // [] | map(select(.status == "completed" and .conclusion == "failure")) | sort_by(.name) | .[] | "\(.id)\t\(.name)"' | tr -d '\r')
 
   if [ -z "$failed_pairs" ]; then
     return 0

--- a/install.sh
+++ b/install.sh
@@ -4,13 +4,18 @@ set -euo pipefail
 REPO="akepo225/gh-pr-context"
 GH_PR_CONTEXT_VERSION="${GH_PR_CONTEXT_VERSION:-master}"
 SCRIPT_NAME="gh-pr-context"
-RAW_BASE="https://raw.githubusercontent.com/$REPO/$GH_PR_CONTEXT_VERSION"
 
 # die prints an error message to stderr and exits with status 1.
 die() {
   echo "error: $1" >&2
   exit 1
 }
+
+if [[ ! "$GH_PR_CONTEXT_VERSION" =~ ^[a-zA-Z0-9._/-]+$ ]]; then
+  die "invalid GH_PR_CONTEXT_VERSION: $GH_PR_CONTEXT_VERSION"
+fi
+
+RAW_BASE="https://raw.githubusercontent.com/$REPO/$GH_PR_CONTEXT_VERSION"
 
 install_dir="${INSTALL_DIR:-${1:-$HOME/.local/bin}}"
 
@@ -27,7 +32,7 @@ chmod +x "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to set executabl
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"
 
 resolved=$(command -v "$SCRIPT_NAME" 2>/dev/null) || true
-if [ "$resolved" != "$install_dir/$SCRIPT_NAME" ]; then
+if [ -z "$resolved" ]; then
   echo "warning: $SCRIPT_NAME is not on your PATH" >&2
   echo "  Add it by running:" >&2
   echo "    export PATH=\"$install_dir:\$PATH\"" >&2

--- a/install.sh
+++ b/install.sh
@@ -2,9 +2,9 @@
 set -euo pipefail
 
 REPO="akepo225/gh-pr-context"
-BRANCH="master"
+GH_PR_CONTEXT_VERSION="${GH_PR_CONTEXT_VERSION:-master}"
 SCRIPT_NAME="gh-pr-context"
-RAW_BASE="https://raw.githubusercontent.com/$REPO/$BRANCH"
+RAW_BASE="https://raw.githubusercontent.com/$REPO/$GH_PR_CONTEXT_VERSION"
 
 # die prints an error message to stderr and exits with status 1.
 die() {

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -14,7 +14,7 @@ Run this workflow when implementation is complete, before shipping.
 Requires `gh-pr-context` on PATH. If missing, install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/v0.2.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | bash
 ```
 
 Pin to a specific version:

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -20,7 +20,7 @@ curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/insta
 Pin to a specific version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.0 bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=<tag> bash
 ```
 
 Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -17,6 +17,12 @@ Requires `gh-pr-context` on PATH. If missing, install:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/v0.2.0/install.sh | bash
 ```
 
+Pin to a specific version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.0 bash
+```
+
 Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.
 
 ## Workflow

--- a/test/test_install.sh
+++ b/test/test_install.sh
@@ -45,6 +45,8 @@ test_names+=(
   test_install_curl_failure_stderr
   test_install_path_warning_when_not_on_path
   test_install_no_path_warning_when_on_path
+  test_install_version_env_var
+  test_install_default_version_is_master
 )
 
 # test_install_default_dir verifies that running the installer with an empty INSTALL_DIR installs an executable `gh-pr-context` into `$HOME/.local/bin`.
@@ -227,6 +229,73 @@ test_install_no_path_warning_when_on_path() {
     echo "FAIL: should not warn when install dir is on PATH (got: $stderr)"
   else
     pass=$((pass + 1))
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+# setup_url_capturing_mock_curl creates a mock `curl` that records the URL argument to a file and writes a valid script to the -o target.
+setup_url_capturing_mock_curl() {
+  local mockdir="$1"
+  local urlfile="$2"
+  mkdir -p "$mockdir"
+  cat > "$mockdir/curl" << MOCK
+#!/usr/bin/env bash
+outfile=""
+url=""
+prev=""
+for arg in "\$@"; do
+  if [ "\$prev" = "-o" ]; then
+    outfile="\$arg"
+  fi
+  case "\$arg" in
+    http://*|https://*) url="\$arg" ;;
+  esac
+  prev="\$arg"
+done
+echo "\$url" > "$urlfile"
+if [ -n "\$outfile" ]; then
+  echo "#!/usr/bin/env bash" > "\$outfile"
+fi
+MOCK
+  chmod +x "$mockdir/curl"
+}
+
+# test_install_version_env_var verifies that setting GH_PR_CONTEXT_VERSION=v0.2.0 causes the installer to download from the v0.2.0 tag.
+test_install_version_env_var() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  local urlfile="$tmpdir/captured-url"
+  setup_url_capturing_mock_curl "$mockdir" "$urlfile"
+  INSTALL_DIR="$custom" GH_PR_CONTEXT_VERSION=v0.2.0 PATH="$mockdir:$PATH" bash "$install_script" >/dev/null 2>&1
+  local captured
+  captured=$(cat "$urlfile")
+  if echo "$captured" | grep -Fq "/v0.2.0/"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: version env var - URL should contain /v0.2.0/ (got: $captured)"
+  fi
+  cleanup_tmpdir "$tmpdir"
+}
+
+# test_install_default_version_is_master verifies that omitting GH_PR_CONTEXT_VERSION downloads from master.
+test_install_default_version_is_master() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local custom="$tmpdir/bin"
+  local mockdir="$tmpdir/mock-bin"
+  local urlfile="$tmpdir/captured-url"
+  setup_url_capturing_mock_curl "$mockdir" "$urlfile"
+  INSTALL_DIR="$custom" PATH="$mockdir:$PATH" bash "$install_script" >/dev/null 2>&1
+  local captured
+  captured=$(cat "$urlfile")
+  if echo "$captured" | grep -q "/master/"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: default version - URL should contain /master/ (got: $captured)"
   fi
   cleanup_tmpdir "$tmpdir"
 }

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -207,7 +207,7 @@ test_pr_resolution_api_fail_stderr_message() {
   setup_mocks_api_fail
   local output
   output=$(run_script comments 2>&1) || true
-  if echo "$output" | grep -qiF "failed"; then
+  if echo "$output" | grep -qF "failed"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))


### PR DESCRIPTION
## Summary

- Fix Windows/Git Bash bug where `jq` CRLF output corrupted API URLs (comments command failed with multiple review comments)
- Skip CI version/tag consistency check on PRs to unblock version bump workflows
- Validate `GH_PR_CONTEXT_VERSION` format before constructing download URL
- Improve PATH warning to only fire when `gh-pr-context` is truly not resolvable
- Use consistent version extraction (`grep | cut`) across both CI jobs
- Use `<tag>` placeholder in SKILL.md to avoid stale hardcoded versions
- Add missing v0.2.0 section to CHANGELOG.md
- Fix `grep -i` locale bug in test_pr_resolution.sh on Git Bash

## Test plan

- [x] All 150 tests pass locally (was 137 pass / 13 fail before CRLF fix)
- [x] `gh-pr-context --version` outputs `0.2.0`
- [x] `gh-pr-context comments --pr 32` works end-to-end on Windows
- [x] `GH_PR_CONTEXT_VERSION=v0.2.0 bash install.sh` installs from tag
- [x] PATH warning shows when not on PATH, hidden when on PATH
- [x] Invalid `GH_PR_CONTEXT_VERSION` values rejected with clear error
- [ ] CI passes on Ubuntu (version check skipped on PRs)

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installer can be pinned to a specific release via GH_PR_CONTEXT_VERSION (defaults to master).

* **Improvements**
  * Post-install now warns when the installed command is not found on PATH.
  * Script output normalization fixes malformed API URLs on Windows (CRLF handling).

* **Documentation**
  * Installation docs updated with examples for default (master) and pinned installs.

* **Tests**
  * New tests verify pinned and default installer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->