### PR TITLE
fix: bump version to 0.2.0 and add CI version/tag consistency check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Version/tag consistency check
         run: |
           script_ver=$(grep '^version=' gh-pr-context | cut -d'"' -f2)
-          latest_tag=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
+          latest_tag=$(git tag --list 'v*' --sort=-v:refname | head -n1)
           if [ -n "$latest_tag" ]; then
             tag_ver="${latest_tag#v}"
             if [ "$script_ver" != "$tag_ver" ]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Version/tag consistency check
+        run: |
+          script_ver=$(grep '^version=' gh-pr-context | cut -d'"' -f2)
+          latest_tag=$(git describe --tags --match 'v*' --abbrev=0 2>/dev/null || echo "")
+          if [ -n "$latest_tag" ]; then
+            tag_ver="${latest_tag#v}"
+            if [ "$script_ver" != "$tag_ver" ]; then
+              echo "::error::Version mismatch: script=$script_ver, latest_tag=$tag_ver"
+              echo "Bump the version in gh-pr-context to match the tag, or delete the tag."
+              exit 1
+            fi
+          fi
+          echo "Version check passed: $script_ver"
 
       - name: Install dependencies
         run: sudo apt-get update && sudo apt-get install -y jq shellcheck

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,15 @@
+# gh-pr-context
+
+Bash CLI that fetches PR context (comments, CI status, failure logs) for LLM coding assistants.
+
+## Release Process
+
+When creating a new release:
+
+1. Bump `version="X.Y.Z"` in `gh-pr-context` (line 4)
+2. Add a `## vX.Y.Z` section to `CHANGELOG.md`
+3. Commit both changes
+4. Tag: `git tag vX.Y.Z`
+5. Push: `git push && git push --tags`
+
+The CI version/tag consistency check will fail if the script version doesn't match the latest tag.

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.1.0"
+version="0.2.0"
 
 die() {
   echo "error: $1" >&2

--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -14,7 +14,7 @@ Run this workflow when implementation is complete, before shipping.
 Requires `gh-pr-context` on PATH. If missing, install:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/v0.1.0/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/v0.2.0/install.sh | bash
 ```
 
 Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.


### PR DESCRIPTION
## Summary

- Bumps `version` in `gh-pr-context` from `0.1.0` to `0.2.0` to match the existing `v0.2.0` git tag
- Adds a CI step that fails if the script version doesn't match the latest `v*` tag, preventing future drift
- Adds `CLAUDE.md` with release process instructions for AI agents

Closes #26

## Test plan

- [x] `bash gh-pr-context --version` outputs `gh-pr-context 0.2.0`
- [x] No new test failures introduced (same 2 pre-existing failures on master)
- [ ] CI version/tag consistency check passes (script 0.2.0 matches tag v0.2.0)
- [ ] Existing CI steps (shellcheck, tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped tool version to 0.2.0

* **Documentation**
  * Added a release process guide with steps for updating version, changelog, and tagging
  * Updated installation/prerequisite instructions to reference v0.2.0
  * Documented CI-enforced version/tag consistency

* **Tests**
  * CI now validates that the declared version matches the latest git tag and fails on mismatch
<!-- end of auto-generated comment: release notes by coderabbit.ai -->