### PR TITLE
fix: quote YAML frontmatter to fix npx skills compatibility

### DIFF
--- a/skills/pr-qa-review/SKILL.md
+++ b/skills/pr-qa-review/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: pr-qa-review
-description: QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".
-compatibility: Requires gh-pr-context on PATH, gh (authenticated), jq, and bash
-allowed-tools: Bash(gh-pr-context:*) Bash(gh:*) Bash(jq:*) Bash(git:*)
+description: 'QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".'
+compatibility: 'Requires gh-pr-context on PATH, gh (authenticated), jq, and bash'
+allowed-tools: 'Bash(gh-pr-context:*) Bash(gh:*) Bash(jq:*) Bash(git:*)'
 ---
 
 # PR QA & Delivery Review


### PR DESCRIPTION
## Summary

- Quotes YAML frontmatter values in `skills/pr-qa-review/SKILL.md` that contain YAML-special characters (colons, asterisks, double quotes)
- Fixes `npx skills@latest add akepo225/gh-pr-context` failing with "No valid skills found"

## Root Cause

The unquoted `description` value contained `Triggers: "qa review"` which the YAML parser (`yaml` npm package) treated as a nested mapping (`BLOCK_AS_IMPLICIT_KEY` error). This caused `parseSkillMd()` in the skills CLI to fail parsing and return null.

```
YAMLParseError: Nested mappings are not allowed in compact mappings at line 3, column 14
```

## Changes

- `description`: Wrapped in single quotes to prevent `: "` from triggering nested mapping parsing
- `compatibility`: Wrapped in single quotes (defensive — contains colons)
- `allowed-tools`: Wrapped in single quotes to prevent bare `*` from being interpreted as YAML alias indicator

## Test plan

- [x] Verified the unquoted frontmatter fails YAML parsing: `YAMLParseError: Nested mappings are not allowed`
- [x] Verified the quoted frontmatter parses correctly: all fields extracted as strings
- [x] All existing tests pass (CLI tests, comments, logs, status, etc.)
- [ ] After merge: run `npx skills@latest add akepo225/gh-pr-context` to confirm end-to-end

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)