### PR TITLE
feat: accept short SHAs and GitHub API fallback for --since

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- **Short SHA support** — `--since` now accepts 7-40 character hex SHAs (previously only 40-character SHAs).
+- **GitHub API fallback** — When a commit is not available locally, `--since` falls back to the GitHub API to resolve the timestamp.
+
 ## v0.2.0
 
 - **GH_PR_CONTEXT_VERSION** — Install a specific version by setting the env var (e.g., `GH_PR_CONTEXT_VERSION=v0.2.0`).

--- a/PRD.md
+++ b/PRD.md
@@ -40,7 +40,7 @@ The tool is a single bash script. Internally, it is organized into the following
 3. **`--since` Resolution Module** — Parses the `--since` flag value into an ISO 8601 timestamp used for filtering. Handles five cases:
    - Omitted → no filter (return all)
    - `last-commit` → resolve HEAD commit timestamp via `git log`
-   - 40-char hex SHA → resolve that commit's timestamp via `git log`
+   - 7-40 char hex SHA → resolve that commit's timestamp via `git log`, with GitHub API fallback
    - `YYYY-MM-DD` → treat as `YYYY-MM-DDT00:00:00Z`
    - `YYYY-MM-DDTHH:mm:ss` → treat as UTC
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -119,19 +119,22 @@ resolve_since_timestamp() {
   fi
   if echo "$since_input" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
     local expanded_sha
-    expanded_sha=$(git rev-parse "$since_input" 2>/dev/null) || die "ambiguous or unknown SHA: $since_input"
-    local epoch
-    if epoch=$(git log -1 --format=%ct "$expanded_sha" 2>/dev/null); then
-      echo "$epoch" | jq -Rr 'tonumber | todate'
-    else
-      local owner_repo
-      owner_repo=$(resolve_owner_repo) || die "unknown commit: $since_input"
-      local api_date
-      api_date=$(gh api "repos/$owner_repo/commits/$expanded_sha" --jq '.commit.committer.date' 2>/dev/null | tr -d '\r') \
-        || die "unknown commit: $since_input"
-      echo "$api_date" | jq -Rr 'fromdateiso8601 | todateiso8601' 2>/dev/null \
-        || die "unknown commit: $since_input"
+    expanded_sha=$(git rev-parse "$since_input" 2>/dev/null) || true
+    if [ -n "$expanded_sha" ]; then
+      local epoch
+      if epoch=$(git log -1 --format=%ct "$expanded_sha" 2>/dev/null); then
+        echo "$epoch" | jq -Rr 'tonumber | todate'
+        return
+      fi
     fi
+    local sha_for_api="${expanded_sha:-$since_input}"
+    local owner_repo
+    owner_repo=$(resolve_owner_repo) || die "unknown commit: $since_input"
+    local api_date
+    api_date=$(gh api "repos/$owner_repo/commits/$sha_for_api" --jq '.commit.committer.date' 2>/dev/null | tr -d '\r') \
+      || die "unknown commit: $since_input"
+    echo "$api_date" | jq -Rr 'fromdateiso8601 | todateiso8601' 2>/dev/null \
+      || die "unknown commit: $since_input"
     return
   fi
   if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -117,19 +117,30 @@ resolve_since_timestamp() {
     echo "$epoch" | jq -Rr 'tonumber | todate'
     return
   fi
-  if echo "$since_input" | grep -qE '^[0-9a-fA-F]{40}$'; then
+  if echo "$since_input" | grep -qE '^[0-9a-fA-F]{7,40}$'; then
+    local expanded_sha
+    expanded_sha=$(git rev-parse "$since_input" 2>/dev/null) || die "ambiguous or unknown SHA: $since_input"
     local epoch
-    epoch=$(git log -1 --format=%ct "$since_input" 2>/dev/null) || die "unknown commit: $since_input"
-    echo "$epoch" | jq -Rr 'tonumber | todate'
+    if epoch=$(git log -1 --format=%ct "$expanded_sha" 2>/dev/null); then
+      echo "$epoch" | jq -Rr 'tonumber | todate'
+    else
+      local owner_repo
+      owner_repo=$(resolve_owner_repo) || die "unknown commit: $since_input"
+      local api_date
+      api_date=$(gh api "repos/$owner_repo/commits/$expanded_sha" --jq '.commit.committer.date' 2>/dev/null | tr -d '\r') \
+        || die "unknown commit: $since_input"
+      echo "$api_date" | jq -Rr 'fromdateiso8601 | todateiso8601' 2>/dev/null \
+        || die "unknown commit: $since_input"
+    fi
     return
   fi
   if echo "$since_input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
     local ts="${since_input}T00:00:00Z"
     local rt
     rt=$(echo "$ts" | jq -R 'fromdateiso8601 | todateiso8601' 2>/dev/null) \
-      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+      || die "invalid --since value: $since_input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
     [ "$rt" = "\"$ts\"" ] \
-      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+      || die "invalid --since value: $since_input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
     echo "$ts"
     return
   fi
@@ -137,13 +148,13 @@ resolve_since_timestamp() {
     local ts="${since_input}Z"
     local rt
     rt=$(echo "$ts" | jq -R 'fromdateiso8601 | todateiso8601' 2>/dev/null) \
-      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+      || die "invalid --since value: $since_input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
     [ "$rt" = "\"$ts\"" ] \
-      || die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+      || die "invalid --since value: $since_input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
     echo "$ts"
     return
   fi
-  die "invalid --since value: $since_input (expected: last-commit, <40-char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+  die "invalid --since value: $since_input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
 }
 
 cmd_comments() {

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -16,6 +16,8 @@ setup_mocks() {
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "branch --show-current") echo "feature-branch" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      "rev-parse $KNOWN_SHA") echo "$KNOWN_SHA" ;;
+      "rev-parse $UNKNOWN_SHA") echo "$UNKNOWN_SHA" ;;
       "log -1 --format=%ct HEAD") echo "$MOCK_HEAD_EPOCH" ;;
       "log -1 --format=%ct $KNOWN_SHA") echo "$MOCK_SHA_EPOCH" ;;
       "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
@@ -92,7 +94,7 @@ setup_mocks_with_pr_and_replies() {
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES MOCK_HEAD_EPOCH MOCK_SHA_EPOCH KNOWN_SHA UNKNOWN_SHA
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -120,7 +120,7 @@ setup_mocks_logs_no_log() {
 run_script() {
   export -f git gh
   export _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT HEAD_SHA
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -85,7 +85,7 @@ setup_mocks_logs() {
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES _MOCK_CHECK_RUNS _MOCK_LOG_CONTENT _MOCK_REPLY_77 HEAD_SHA
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -70,7 +70,7 @@ setup_mocks_api_fail() {
 run_script() {
   export -f git gh
   export _MOCK_HEAD_SHA
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -63,7 +63,7 @@ run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES
   # _MOCK_REPLY_* vars are exported by setup_mocks_nesting
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -311,12 +311,15 @@ test_since_short_sha_format_is_iso8601() {
   fi
 }
 
-# test_since_short_sha_unknown_exits_nonzero verifies that an unknown 7-char SHA exits non-zero.
+# test_since_short_sha_unknown_exits_nonzero verifies that an unknown 7-char SHA exits non-zero (and not due to timeout).
 test_since_short_sha_unknown_exits_nonzero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" >/dev/null 2>&1 || exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
+  if [ "$exit_code" -eq 124 ]; then
+    fail=$((fail + 1))
+    echo "FAIL: test timed out (possible hang)"
+  elif [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
@@ -394,7 +397,7 @@ test_since_api_fallback_format_is_iso8601() {
   fi
 }
 
-# test_since_api_failure_exits_nonzero verifies that when both git log and gh api fail, the command exits non-zero.
+# test_since_api_failure_exits_nonzero verifies that when both git log and gh api fail, the command exits non-zero (and not due to timeout).
 test_since_api_failure_exits_nonzero() {
   setup_mocks
   gh() {
@@ -408,7 +411,10 @@ test_since_api_failure_exits_nonzero() {
   }
   local exit_code=0
   run_script comments --pr 42 --since "$API_SHA" >/dev/null 2>&1 || exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
+  if [ "$exit_code" -eq 124 ]; then
+    fail=$((fail + 1))
+    echo "FAIL: test timed out (possible hang)"
+  elif [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -2,6 +2,11 @@
 
 KNOWN_SHA="cccccccccccccccccccccccccccccccccccccccc"
 UNKNOWN_SHA="dddddddddddddddddddddddddddddddddddddddd"
+SHORT_SHA="ccccccc"
+UNKNOWN_SHORT_SHA="ddddddd"
+API_SHA="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+API_SHA_SHORT="eeeeeee"
+API_DATE="2025-07-04T12:00:00Z"
 
 HEAD_EPOCH="1742040000"
 SHA_EPOCH="1751587200"
@@ -13,9 +18,16 @@ setup_mocks() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+      "rev-parse $KNOWN_SHA") echo "$KNOWN_SHA" ;;
+      "rev-parse $SHORT_SHA") echo "$KNOWN_SHA" ;;
+      "rev-parse $UNKNOWN_SHA") echo "$UNKNOWN_SHA" ;;
+      "rev-parse $UNKNOWN_SHORT_SHA") exit 1 ;;
+      "rev-parse $API_SHA") echo "$API_SHA" ;;
+      "rev-parse $API_SHA_SHORT") echo "$API_SHA" ;;
       "log -1 --format=%ct HEAD") echo "$HEAD_EPOCH" ;;
       "log -1 --format=%ct $KNOWN_SHA") echo "$SHA_EPOCH" ;;
       "log -1 --format=%ct $UNKNOWN_SHA") exit 1 ;;
+      "log -1 --format=%ct $API_SHA") exit 1 ;;
       *) exit 1 ;;
     esac
   }
@@ -24,6 +36,7 @@ setup_mocks() {
       *"pulls/42/comments"*) echo '[]' ;;
       *"issues/42/comments"*) echo '[]' ;;
       *"pulls/comments/42/replies"*) echo '[]' ;;
+      *commits/eeee*) echo '2025-07-04T12:00:00Z' ;;
       *) exit 1 ;;
     esac
   }
@@ -32,8 +45,8 @@ setup_mocks() {
 # run_script exports the mocked `git` and `gh` functions and related SHA/epoch variables, then executes the target script with the provided arguments and propagates its exit status.
 run_script() {
   export -f git gh
-  export KNOWN_SHA UNKNOWN_SHA HEAD_EPOCH SHA_EPOCH
-  bash "$script" "$@"
+  export KNOWN_SHA UNKNOWN_SHA SHORT_SHA UNKNOWN_SHORT_SHA API_SHA API_SHA_SHORT API_DATE HEAD_EPOCH SHA_EPOCH
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(
@@ -42,6 +55,14 @@ test_names+=(
   test_since_last_commit_format_is_iso8601
   test_since_known_sha_exits_zero
   test_since_known_sha_format_is_iso8601
+  test_since_short_sha_resolves_via_rev_parse
+  test_since_short_sha_format_is_iso8601
+  test_since_short_sha_unknown_exits_nonzero
+  test_since_short_sha_unknown_stderr_mentions_sha
+  test_since_api_fallback_exits_zero
+  test_since_api_fallback_format_is_iso8601
+  test_since_api_failure_exits_nonzero
+  test_since_api_failure_stderr_mentions_unknown_commit
   test_since_date_only_exits_zero
   test_since_date_only_appends_midnight_utc
   test_since_datetime_exits_zero
@@ -53,7 +74,6 @@ test_names+=(
   test_since_invalid_month_exits_nonzero
   test_since_invalid_day_exits_nonzero
   test_since_invalid_hour_exits_nonzero
-  test_since_short_sha_treated_as_invalid
 )
 
 # test_since_empty_resolves_to_empty verifies that invoking the comments command without a `--since` value exits with status 0.
@@ -256,8 +276,141 @@ test_since_invalid_hour_exits_nonzero() {
   assert_exit 1 "--since with hour 25 exits non-zero" bash "$script" comments --pr 42 --since "2025-01-01T25:00:00"
 }
 
-# test_since_short_sha_treated_as_invalid verifies that passing a 7-character SHA to `--since` causes the script to exit with code 1 and emits "invalid --since value" on stderr.
-test_since_short_sha_treated_as_invalid() {
-  assert_exit 1 "--since with 7-char sha exits non-zero" bash "$script" comments --pr 42 --since "abc1234"
-  assert_stderr_contains "--since 7-char sha emits invalid error" "invalid --since value" bash "$script" comments --pr 42 --since "abc1234"
+# test_since_short_sha_resolves_via_rev_parse verifies that a 7-char SHA matching a known commit resolves successfully.
+test_since_short_sha_resolves_via_rev_parse() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since "$SHORT_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <7-char sha> should exit 0 (exit: $exit_code)"
+  fi
+}
+
+# test_since_short_sha_format_is_iso8601 verifies that a short SHA produces a valid ISO-8601 timestamp that allows future comments through.
+test_since_short_sha_format_is_iso8601() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"bot"},"created_at":"2099-01-01T00:00:00Z","body":"future-short"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *) exit 1 ;;
+    esac
+  }
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since "$SHORT_SHA" 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future-short"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <short-sha> timestamp should be valid ISO-8601 (exit: $exit_code, output: $output)"
+  fi
+}
+
+# test_since_short_sha_unknown_exits_nonzero verifies that an unknown 7-char SHA exits non-zero.
+test_since_short_sha_unknown_exits_nonzero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <unknown-7-char-sha> should exit non-zero"
+  fi
+}
+
+# test_since_short_sha_unknown_stderr_mentions_sha verifies that a failed short SHA resolution mentions "ambiguous or unknown SHA".
+test_since_short_sha_unknown_stderr_mentions_sha() {
+  setup_mocks
+  local output
+  output=$(run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" 2>&1) || true
+  if echo "$output" | grep -qF "ambiguous or unknown SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <unknown-7-char-sha> should mention 'ambiguous or unknown SHA' (output: $output)"
+  fi
+}
+
+# test_since_api_fallback_exits_zero verifies that when git rev-parse succeeds but git log fails, the GitHub API fallback is used and the command exits 0.
+test_since_api_fallback_exits_zero() {
+  setup_mocks
+  local exit_code=0
+  run_script comments --pr 42 --since "$API_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <api-only-sha> should exit 0 via API fallback (exit: $exit_code)"
+  fi
+}
+
+# test_since_api_fallback_format_is_iso8601 verifies the API fallback produces a valid ISO-8601 timestamp by checking that a comment with a future created_at passes the filter.
+test_since_api_fallback_format_is_iso8601() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[{"user":{"login":"bot"},"created_at":"2099-01-01T00:00:00Z","body":"future-api"}]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *commits/eeee*) echo '2025-07-04T12:00:00Z' ;;
+      *) exit 1 ;;
+    esac
+  }
+  local output exit_code=0
+  output=$(run_script comments --pr 42 --since "$API_SHA" 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "future-api"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API fallback timestamp should be valid ISO-8601 and allow future comments through (exit: $exit_code, output: $output)"
+  fi
+}
+
+# test_since_api_failure_exits_nonzero verifies that when both git log and gh api fail, the command exits non-zero.
+test_since_api_failure_exits_nonzero() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *"commits/"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
+  local exit_code=0
+  run_script comments --pr 42 --since "$API_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <sha> should exit non-zero when both git log and API fail"
+  fi
+}
+
+# test_since_api_failure_stderr_mentions_unknown_commit verifies that when both local and API resolution fail, stderr mentions "unknown commit".
+test_since_api_failure_stderr_mentions_unknown_commit() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *"commits/"*) exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
+  local output
+  output=$(run_script comments --pr 42 --since "$API_SHA" 2>&1) || true
+  if echo "$output" | grep -qF "unknown commit"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should mention 'unknown commit' (output: $output)"
+  fi
 }

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -226,12 +226,15 @@ test_since_datetime_appends_z() {
   fi
 }
 
-# test_since_unknown_sha_exits_nonzero verifies that running the script with --since set to an unknown commit SHA results in a non-zero exit status.
+# test_since_unknown_sha_exits_nonzero verifies that running the script with --since set to an unknown commit SHA results in a non-zero exit status (and not due to timeout).
 test_since_unknown_sha_exits_nonzero() {
   setup_mocks
   local exit_code=0
   run_script comments --pr 42 --since "$UNKNOWN_SHA" >/dev/null 2>&1 || exit_code=$?
-  if [ "$exit_code" -ne 0 ]; then
+  if [ "$exit_code" -eq 124 ]; then
+    fail=$((fail + 1))
+    echo "FAIL: test timed out (possible hang)"
+  elif [ "$exit_code" -ne 0 ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -60,6 +60,7 @@ test_names+=(
   test_since_short_sha_unknown_exits_nonzero
   test_since_short_sha_unknown_stderr_mentions_sha
   test_since_api_fallback_exits_zero
+  test_since_api_fallback_rev_parse_fails_exits_zero
   test_since_api_fallback_format_is_iso8601
   test_since_api_failure_exits_nonzero
   test_since_api_failure_stderr_mentions_unknown_commit
@@ -323,16 +324,16 @@ test_since_short_sha_unknown_exits_nonzero() {
   fi
 }
 
-# test_since_short_sha_unknown_stderr_mentions_sha verifies that a failed short SHA resolution mentions "ambiguous or unknown SHA".
+# test_since_short_sha_unknown_stderr_mentions_sha verifies that a failed short SHA resolution (both rev-parse and API fail) mentions "unknown commit".
 test_since_short_sha_unknown_stderr_mentions_sha() {
   setup_mocks
   local output
   output=$(run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" 2>&1) || true
-  if echo "$output" | grep -qF "ambiguous or unknown SHA"; then
+  if echo "$output" | grep -qF "unknown commit"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: --since <unknown-7-char-sha> should mention 'ambiguous or unknown SHA' (output: $output)"
+    echo "FAIL: --since <unknown-7-char-sha> should mention 'unknown commit' (output: $output)"
   fi
 }
 
@@ -346,6 +347,28 @@ test_since_api_fallback_exits_zero() {
   else
     fail=$((fail + 1))
     echo "FAIL: --since <api-only-sha> should exit 0 via API fallback (exit: $exit_code)"
+  fi
+}
+
+# test_since_api_fallback_rev_parse_fails_exits_zero verifies that when git rev-parse fails (e.g. shallow clone), the API fallback resolves the commit using the original SHA and exits 0.
+test_since_api_fallback_rev_parse_fails_exits_zero() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*) echo '[]' ;;
+      *"issues/42/comments"*) echo '[]' ;;
+      *"pulls/comments/42/replies"*) echo '[]' ;;
+      *commits/ddddd*) echo '2025-07-04T12:00:00Z' ;;
+      *) exit 1 ;;
+    esac
+  }
+  local exit_code=0
+  run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <short-sha-not-in-local> should exit 0 via API fallback (exit: $exit_code)"
   fi
 }
 

--- a/test/test_since_resolution.sh
+++ b/test/test_since_resolution.sh
@@ -61,6 +61,7 @@ test_names+=(
   test_since_short_sha_unknown_stderr_mentions_sha
   test_since_api_fallback_exits_zero
   test_since_api_fallback_rev_parse_fails_exits_zero
+  test_since_api_fallback_rev_parse_full_sha_fails_exits_zero
   test_since_api_fallback_format_is_iso8601
   test_since_api_failure_exits_nonzero
   test_since_api_failure_stderr_mentions_unknown_commit
@@ -333,9 +334,12 @@ test_since_short_sha_unknown_exits_nonzero() {
 # test_since_short_sha_unknown_stderr_mentions_sha verifies that a failed short SHA resolution (both rev-parse and API fail) mentions "unknown commit".
 test_since_short_sha_unknown_stderr_mentions_sha() {
   setup_mocks
-  local output
-  output=$(run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" 2>&1) || true
-  if echo "$output" | grep -qF "unknown commit"; then
+  local exit_code=0 output
+  output=$(run_script comments --pr 42 --since "$UNKNOWN_SHORT_SHA" 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 124 ]; then
+    fail=$((fail + 1))
+    echo "FAIL: test timed out (possible hang)"
+  elif echo "$output" | grep -qF "unknown commit"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
@@ -375,6 +379,28 @@ test_since_api_fallback_rev_parse_fails_exits_zero() {
   else
     fail=$((fail + 1))
     echo "FAIL: --since <short-sha-not-in-local> should exit 0 via API fallback (exit: $exit_code)"
+  fi
+}
+
+# test_since_api_fallback_rev_parse_full_sha_fails_exits_zero verifies that a full 40-char SHA not present locally (rev-parse fails) falls back to the GitHub API and exits 0.
+test_since_api_fallback_rev_parse_full_sha_fails_exits_zero() {
+  setup_mocks
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+      "rev-parse $API_SHA") exit 1 ;;
+      *) exit 1 ;;
+    esac
+  }
+  local exit_code=0
+  run_script comments --pr 42 --since "$API_SHA" >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since <full-sha-not-in-local> should exit 0 via API fallback (exit: $exit_code)"
   fi
 }
 
@@ -437,9 +463,12 @@ test_since_api_failure_stderr_mentions_unknown_commit() {
       *) exit 1 ;;
     esac
   }
-  local output
-  output=$(run_script comments --pr 42 --since "$API_SHA" 2>&1) || true
-  if echo "$output" | grep -qF "unknown commit"; then
+  local exit_code=0 output
+  output=$(run_script comments --pr 42 --since "$API_SHA" 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 124 ]; then
+    fail=$((fail + 1))
+    echo "FAIL: test timed out (possible hang)"
+  elif echo "$output" | grep -qF "unknown commit"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))

--- a/test/test_status.sh
+++ b/test/test_status.sh
@@ -86,7 +86,7 @@ setup_mocks_status_sha_fails() {
 run_script() {
   export -f git gh
   export _MOCK_CHECK_RUNS _MOCK_PAGE1 _MOCK_PAGE2 HEAD_SHA
-  bash "$script" "$@"
+  timeout 15 bash "$script" "$@" </dev/null
 }
 
 test_names+=(


### PR DESCRIPTION
## Summary

- `--since` now accepts 7-40 character hex SHAs (previously only 40-char)
- When a commit isn't available locally (shallow clone, different fork), falls back to the GitHub API (`repos/{owner}/{repo}/commits/{sha}`) to resolve the timestamp
- Adds timeout and stdin redirect to all test harness `run_script()` functions to prevent test hangs

## Test plan

- [x] 161/161 existing + new tests pass (`bash test/run.sh`)
- [x] New tests: short SHA resolves locally, produces ISO-8601 output, unknown short SHA exits non-zero with correct error message
- [x] New tests: API fallback succeeds when git log fails, produces valid ISO-8601, exits non-zero when both git and API fail
- [x] 6-char SHAs still rejected (existing tests unchanged)
- [x] 40-char SHAs still work (existing tests unchanged)
- [ ] Manual: `gh-pr-context comments --pr <PR> --since <7-char-sha>` resolves correctly
- [ ] Manual: SHA from non-local branch resolves via API fallback

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `--since` flag now accepts short commit SHAs (7–40 characters)
  * Falls back to the GitHub API to resolve timestamps when commits aren’t available locally

* **Documentation**
  * Updated product doc and changelog to reflect expanded SHA support and fallback behavior

* **Tests**
  * Expanded coverage for short-SHA resolution, API fallback, and failure cases
  * Improved test reliability with deterministic fixtures, timeouts, and stdin redirection
<!-- end of auto-generated comment: release notes by coderabbit.ai -->