### PR TITLE
feat: add parse_duration() for --timeout support

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -8,6 +8,8 @@ die() {
   exit 1
 }
 
+# Parse a duration string (<number><s|m|h>) and output seconds.
+# Exits 1 on invalid input (empty, bare number, negative, non-numeric).
 parse_duration() {
   local input="${1:-}"
   if [ -z "$input" ]; then

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -8,6 +8,24 @@ die() {
   exit 1
 }
 
+parse_duration() {
+  local input="${1:-}"
+  if [ -z "$input" ]; then
+    die "invalid duration: (empty)"
+  fi
+  if [[ "$input" =~ ^([0-9]+)(s|m|h)$ ]]; then
+    local num="${BASH_REMATCH[1]}"
+    local suffix="${BASH_REMATCH[2]}"
+    case "$suffix" in
+      s) echo "$num" ;;
+      m) echo $((num * 60)) ;;
+      h) echo $((num * 3600)) ;;
+    esac
+  else
+    die "invalid duration: $input (expected <number><s|m|h>)"
+  fi
+}
+
 setup_git_env() {
   (git rev-parse --git-dir >/dev/null 2>&1) && return 0
 

--- a/test/test_duration.sh
+++ b/test/test_duration.sh
@@ -1,0 +1,150 @@
+#!/usr/bin/env bash
+
+source "$script"
+
+test_names+=(
+  test_parse_duration_seconds
+  test_parse_duration_minutes
+  test_parse_duration_hours
+  test_parse_duration_zero
+  test_parse_duration_multi_digit_seconds
+  test_parse_duration_large_hours
+  test_parse_duration_bare_number_exits_nonzero
+  test_parse_duration_negative_exits_nonzero
+  test_parse_duration_non_numeric_exits_nonzero
+  test_parse_duration_empty_exits_nonzero
+  test_parse_duration_bare_number_stderr
+  test_parse_duration_negative_stderr
+)
+
+test_parse_duration_seconds() {
+  local result
+  result=$(parse_duration "30s") || { fail=$((fail + 1)); echo "FAIL: 30s should exit 0"; return; }
+  if [ "$result" = "30" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 30s expected 30 got $result"
+  fi
+}
+
+test_parse_duration_minutes() {
+  local result
+  result=$(parse_duration "5m") || { fail=$((fail + 1)); echo "FAIL: 5m should exit 0"; return; }
+  if [ "$result" = "300" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 5m expected 300 got $result"
+  fi
+}
+
+test_parse_duration_hours() {
+  local result
+  result=$(parse_duration "1h") || { fail=$((fail + 1)); echo "FAIL: 1h should exit 0"; return; }
+  if [ "$result" = "3600" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 1h expected 3600 got $result"
+  fi
+}
+
+test_parse_duration_zero() {
+  local result
+  result=$(parse_duration "0s") || { fail=$((fail + 1)); echo "FAIL: 0s should exit 0"; return; }
+  if [ "$result" = "0" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 0s expected 0 got $result"
+  fi
+}
+
+test_parse_duration_multi_digit_seconds() {
+  local result
+  result=$(parse_duration "90s") || { fail=$((fail + 1)); echo "FAIL: 90s should exit 0"; return; }
+  if [ "$result" = "90" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 90s expected 90 got $result"
+  fi
+}
+
+test_parse_duration_large_hours() {
+  local result
+  result=$(parse_duration "100h") || { fail=$((fail + 1)); echo "FAIL: 100h should exit 0"; return; }
+  if [ "$result" = "360000" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: parse_duration 100h expected 360000 got $result"
+  fi
+}
+
+test_parse_duration_bare_number_exits_nonzero() {
+  local ec=0
+  (parse_duration "300") >/dev/null 2>&1 || ec=$?
+  if [ "$ec" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: bare number 300 should exit 1 got $ec"
+  fi
+}
+
+test_parse_duration_negative_exits_nonzero() {
+  local ec=0
+  (parse_duration "-5m") >/dev/null 2>&1 || ec=$?
+  if [ "$ec" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: negative -5m should exit 1 got $ec"
+  fi
+}
+
+test_parse_duration_non_numeric_exits_nonzero() {
+  local ec=0
+  (parse_duration "abc") >/dev/null 2>&1 || ec=$?
+  if [ "$ec" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: non-numeric abc should exit 1 got $ec"
+  fi
+}
+
+test_parse_duration_empty_exits_nonzero() {
+  local ec=0
+  (parse_duration "") >/dev/null 2>&1 || ec=$?
+  if [ "$ec" -eq 1 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty string should exit 1 got $ec"
+  fi
+}
+
+test_parse_duration_bare_number_stderr() {
+  local output
+  output=$(parse_duration "300" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "invalid duration"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: bare number stderr should contain 'invalid duration' got: $output"
+  fi
+}
+
+test_parse_duration_negative_stderr() {
+  local output
+  output=$(parse_duration "-5m" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "invalid duration"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: negative stderr should contain 'invalid duration' got: $output"
+  fi
+}

--- a/test/test_duration.sh
+++ b/test/test_duration.sh
@@ -21,6 +21,7 @@ test_names+=(
   test_parse_duration_negative_stderr
 )
 
+# Verify parse_duration "30s" outputs 30.
 test_parse_duration_seconds() {
   local result
   result=$(parse_duration "30s") || { fail=$((fail + 1)); echo "FAIL: 30s should exit 0"; return; }
@@ -32,6 +33,7 @@ test_parse_duration_seconds() {
   fi
 }
 
+# Verify parse_duration "5m" outputs 300.
 test_parse_duration_minutes() {
   local result
   result=$(parse_duration "5m") || { fail=$((fail + 1)); echo "FAIL: 5m should exit 0"; return; }
@@ -43,6 +45,7 @@ test_parse_duration_minutes() {
   fi
 }
 
+# Verify parse_duration "1h" outputs 3600.
 test_parse_duration_hours() {
   local result
   result=$(parse_duration "1h") || { fail=$((fail + 1)); echo "FAIL: 1h should exit 0"; return; }
@@ -54,6 +57,7 @@ test_parse_duration_hours() {
   fi
 }
 
+# Verify parse_duration "0s" outputs 0.
 test_parse_duration_zero() {
   local result
   result=$(parse_duration "0s") || { fail=$((fail + 1)); echo "FAIL: 0s should exit 0"; return; }
@@ -65,6 +69,7 @@ test_parse_duration_zero() {
   fi
 }
 
+# Verify parse_duration "90s" outputs 90.
 test_parse_duration_multi_digit_seconds() {
   local result
   result=$(parse_duration "90s") || { fail=$((fail + 1)); echo "FAIL: 90s should exit 0"; return; }
@@ -76,6 +81,7 @@ test_parse_duration_multi_digit_seconds() {
   fi
 }
 
+# Verify parse_duration "100h" outputs 360000.
 test_parse_duration_large_hours() {
   local result
   result=$(parse_duration "100h") || { fail=$((fail + 1)); echo "FAIL: 100h should exit 0"; return; }
@@ -87,6 +93,7 @@ test_parse_duration_large_hours() {
   fi
 }
 
+# Verify parse_duration rejects bare number "300" with exit 1.
 test_parse_duration_bare_number_exits_nonzero() {
   local ec=0
   (parse_duration "300") >/dev/null 2>&1 || ec=$?
@@ -98,6 +105,7 @@ test_parse_duration_bare_number_exits_nonzero() {
   fi
 }
 
+# Verify parse_duration rejects negative "-5m" with exit 1.
 test_parse_duration_negative_exits_nonzero() {
   local ec=0
   (parse_duration "-5m") >/dev/null 2>&1 || ec=$?
@@ -109,6 +117,7 @@ test_parse_duration_negative_exits_nonzero() {
   fi
 }
 
+# Verify parse_duration rejects non-numeric "abc" with exit 1.
 test_parse_duration_non_numeric_exits_nonzero() {
   local ec=0
   (parse_duration "abc") >/dev/null 2>&1 || ec=$?
@@ -120,6 +129,7 @@ test_parse_duration_non_numeric_exits_nonzero() {
   fi
 }
 
+# Verify parse_duration rejects empty string with exit 1.
 test_parse_duration_empty_exits_nonzero() {
   local ec=0
   (parse_duration "") >/dev/null 2>&1 || ec=$?
@@ -131,6 +141,7 @@ test_parse_duration_empty_exits_nonzero() {
   fi
 }
 
+# Verify bare number "300" produces stderr containing "invalid duration".
 test_parse_duration_bare_number_stderr() {
   local output
   output=$(parse_duration "300" 2>&1 >/dev/null) || true
@@ -142,6 +153,7 @@ test_parse_duration_bare_number_stderr() {
   fi
 }
 
+# Verify negative "-5m" produces stderr containing "invalid duration".
 test_parse_duration_negative_stderr() {
   local output
   output=$(parse_duration "-5m" 2>&1 >/dev/null) || true

--- a/test/test_duration.sh
+++ b/test/test_duration.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 source "$script"
+
+gh() { echo "unexpected gh call in test/test_duration.sh" >&2; return 1; }
+git() { echo "unexpected git call in test/test_duration.sh" >&2; return 1; }
 
 test_names+=(
   test_parse_duration_seconds

--- a/test/test_duration.sh
+++ b/test/test_duration.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-source "$script"
-
 gh() { echo "unexpected gh call in test/test_duration.sh" >&2; return 1; }
 git() { echo "unexpected git call in test/test_duration.sh" >&2; return 1; }
+
+source "$script"
 
 test_names+=(
   test_parse_duration_seconds


### PR DESCRIPTION
## Summary

- Add `parse_duration()` internal function that converts duration strings (`30s`, `5m`, `1h`) to seconds
- Rejects invalid inputs (bare numbers, negatives, non-numeric, empty) with `die()` for consistent error handling
- New test file `test/test_duration.sh` with 12 tests covering all acceptance criteria

## Acceptance criteria (all met)

- [x] `parse_duration "30s"` outputs `30`
- [x] `parse_duration "5m"` outputs `300`
- [x] `parse_duration "1h"` outputs `3600`
- [x] `parse_duration "300"` (bare number) exits 1 with stderr message
- [x] `parse_duration "-5m"` (negative) exits 1 with stderr message
- [x] `parse_duration "abc"` exits 1 with stderr message
- [x] `parse_duration ""` exits 1 with stderr message
- [x] New test file `test_duration.sh` passes in `test/run.sh`
- [x] Function is testable in isolation (source script, call directly)
- [x] Existing tests still pass

## Testing

12 new tests covering valid inputs (seconds, minutes, hours, zero, multi-digit, large), invalid inputs (bare number, negative, non-numeric, empty), and stderr message verification.

## How

Uses bash regex `^([0-9]+)(s|m|h)$` with `BASH_REMATCH` for extraction — handles all rejection cases in a single match. Placed after `die()` as a utility function.

Closes #42