### PR TITLE
feat: add monitor status command for CI check state polling

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -66,6 +66,7 @@ usage() {
   echo "  comments   Fetch PR comments"
   echo "  status     Fetch CI check status"
   echo "  logs       Fetch logs for failed CI checks"
+  echo "  monitor    Poll for changes to CI status or comments"
   echo ""
   echo "options:"
   echo "  --pr <number>   PR number (auto-detected from branch if omitted)"
@@ -73,6 +74,27 @@ usage() {
   echo "  --all           Return all comments (default)"
   echo "  --version       Show version"
   echo "  -h, --help      Show this message"
+}
+
+usage_monitor() {
+  echo "usage: gh-pr-context monitor <sub-command> [options]"
+  echo ""
+  echo "sub-commands:"
+  echo "  status   Monitor CI check state changes"
+  echo ""
+  echo "options:"
+  echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
+  echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  -h, --help           Show this message"
+}
+
+usage_monitor_status() {
+  echo "usage: gh-pr-context monitor status [options]"
+  echo ""
+  echo "options:"
+  echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
+  echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  -h, --help           Show this message"
 }
 
 resolve_owner_repo() {
@@ -341,6 +363,138 @@ cmd_logs() {
   done <<< "$failed_pairs"
 }
 
+# capture_check_snapshot fetches check-runs for a given SHA via the GitHub API
+# and returns a normalized JSON array of {name, status, conclusion} objects
+# sorted by check name, suitable for diffing between poll cycles.
+capture_check_snapshot() {
+  local owner_repo=$1 sha=$2
+  local checks_json
+  checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \
+    || die "failed to fetch check runs for SHA $sha"
+  echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
+}
+
+# cmd_monitor_status polls the GitHub check-runs API at a configurable interval,
+# detecting state transitions (status/conclusion changes), new checks appearing,
+# checks disappearing, and new commits pushed to the PR. Prints terse `--- change`
+# notifications and exits 0 on change, exits 1 on error.
+cmd_monitor_status() {
+  local pr_number="" interval=30
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] || die "missing value for --pr"
+        pr_number="$2"; shift 2
+        ;;
+      --interval)
+        [ $# -ge 2 ] || die "missing value for --interval"
+        interval="$2"; shift 2
+        if ! echo "$interval" | grep -qE '^[1-9][0-9]*$'; then
+          die "invalid --interval value: $interval (expected a positive integer)"
+        fi
+        ;;
+      -h|--help) usage_monitor_status; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+
+  check_deps
+
+  if [ -z "$pr_number" ]; then
+    pr_number=$(resolve_pr_number)
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
+  local prev_sha
+  prev_sha=$(resolve_pr_head_sha "$pr_number") \
+    || die "failed to resolve head SHA for PR #$pr_number"
+
+  local prev_snapshot
+  prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha")
+
+  while true; do
+    sleep "$interval"
+
+    local cur_sha
+    if ! cur_sha=$(resolve_pr_head_sha "$pr_number" 2>&1); then
+      die "failed to re-resolve head SHA for PR #$pr_number"
+    fi
+
+    if [ "$cur_sha" != "$prev_sha" ]; then
+      echo "--- change"
+      echo "type: new-commit"
+      echo "sha: $cur_sha"
+      exit 0
+    fi
+
+    local cur_snapshot
+    if ! cur_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" 2>&1); then
+      die "failed to fetch check runs during poll"
+    fi
+
+    local changes
+    changes=$(printf '%s\n%s\n' "$prev_snapshot" "$cur_snapshot" | jq -s '
+      . as $snapshots |
+      ($snapshots[0]) as $old |
+      ($snapshots[1]) as $new |
+      (($old | map(.name)) + ($new | map(.name))) | unique | sort |
+      map(
+        . as $name |
+        ($old | map(select(.name == $name)) | first) as $o |
+        ($new | map(select(.name == $name)) | first) as $n |
+        if $o == null then
+          {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
+        elif $n == null then
+          {check: $name, from: $o.status, to: "absent", conclusion: null}
+        elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
+          {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
+        else
+          empty
+        end
+      )
+    ')
+
+    local change_count
+    change_count=$(echo "$changes" | jq 'length' | tr -d '\r')
+
+    if [ "$change_count" -gt 0 ]; then
+      echo "$changes" | jq -r '.[] |
+        "--- change\n" +
+        "type: status\n" +
+        "check: \(.check)\n" +
+        "from: \(.from)\n" +
+        "to: \(.to)" +
+        if (.conclusion != null and .to != "absent") then "\nconclusion: \(.conclusion)" else "" end'
+      exit 0
+    fi
+
+    prev_sha="$cur_sha"
+    prev_snapshot="$cur_snapshot"
+  done
+}
+
+# cmd_monitor is the top-level dispatcher for the monitor command, routing
+# sub-commands (status) to their handlers. Exits 1 with usage when no
+# sub-command is provided.
+cmd_monitor() {
+  if [ $# -eq 0 ]; then
+    usage_monitor >&2
+    exit 1
+  fi
+
+  local sub_command=$1
+  shift
+
+  case "$sub_command" in
+    status) cmd_monitor_status "$@" ;;
+    -h|--help) usage_monitor; exit 0 ;;
+    *) die "unknown monitor sub-command: $sub_command" ;;
+  esac
+}
+
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   if [ $# -eq 0 ]; then
     usage
@@ -354,6 +508,7 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
     comments) cmd_comments "$@" ;;
     status)   cmd_status "$@" ;;
     logs)     cmd_logs "$@" ;;
+    monitor)  cmd_monitor "$@" ;;
     -h|--help) usage; exit 0 ;;
     --version) echo "gh-pr-context $version"; exit 0 ;;
     *) die "unknown command: $command" ;;

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -113,7 +113,7 @@ resolve_pr_number() {
   local owner=${owner_repo%%/*}
   local repo=${owner_repo#*/}
   local pr_data
-  pr_data=$(gh api "repos/$owner/$repo/pulls?head=$owner:$branch" --jq '.[0].number' | tr -d '\r') || die "failed to look up PR for branch '$branch'"
+  pr_data=$(gh api "repos/$owner/$repo/pulls?head=$owner:$branch" --paginate --jq '.[0].number' | tr -d '\r') || die "failed to look up PR for branch '$branch'"
   if [ -z "$pr_data" ] || [ "$pr_data" = "null" ]; then
     die "no open PR found for branch '$branch'"
   fi
@@ -124,7 +124,7 @@ resolve_pr_head_sha() {
   local pr_number=$1
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  gh api "repos/$owner_repo/pulls/$pr_number" --jq '.head.sha' | tr -d '\r'
+  gh api "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
 }
 
 resolve_since_timestamp() {
@@ -481,8 +481,7 @@ cmd_monitor_status() {
 # sub-command is provided.
 cmd_monitor() {
   if [ $# -eq 0 ]; then
-    usage_monitor >&2
-    exit 1
+    die "missing monitor sub-command (see 'gh-pr-context monitor --help')"
   fi
 
   local sub_command=$1

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -1,0 +1,432 @@
+#!/usr/bin/env bash
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+_MOCK_COUNTER_FILE=""
+
+# _mock_counter_next increments a file-based call counter and returns the new value,
+# enabling stateful mocks that return different responses on successive gh invocations.
+_mock_counter_next() {
+  local val
+  val=$(cat "$_MOCK_COUNTER_FILE")
+  val=$((val + 1))
+  echo "$val" > "$_MOCK_COUNTER_FILE"
+  echo "$val"
+}
+
+# setup_mocks defines mocked `git` and `sleep` shell functions used by the test harness;
+# `git` responds with fixed repo URL and branch values for known invocations and exits
+# nonzero for others; `sleep` is a no-op so polling tests complete instantly.
+setup_mocks() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  sleep() {
+    :
+  }
+}
+
+# setup_mocks_monitor_explicit_pr configures git/gh mocks and defines a stateful gh()
+# that returns HEAD_SHA for pulls/42 lookups, the first argument as the initial
+# check-runs JSON, and the second argument as the changed check-runs JSON on the
+# third gh invocation (simulating a state change between poll cycles).
+setup_mocks_monitor_explicit_pr() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--jq"*)
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# setup_mocks_monitor_sha_change configures git/gh mocks where the first SHA lookup
+# returns HEAD_SHA and subsequent lookups return NEW_SHA, simulating a new commit
+# pushed to the PR between poll cycles.
+setup_mocks_monitor_sha_change() {
+  _MOCK_INITIAL="${1:-}"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--jq"*)
+        if [ "$call_num" -le 1 ]; then
+          echo "$HEAD_SHA"
+        else
+          echo "$NEW_SHA"
+        fi
+        ;;
+      *"check-runs"*"--paginate"*)
+        echo "$_MOCK_INITIAL"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# setup_mocks_monitor_auto_detect configures git/gh mocks and defines gh to return
+# '42' for a pull lookup by head (auto-detect PR), return the HEAD SHA for pulls/42,
+# and return the first argument as initial check-runs and the second as changed
+# check-runs after three gh calls (accounting for the extra PR auto-detect call).
+setup_mocks_monitor_auto_detect() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo '42' ;;
+      *"pulls/42"*"--jq"*)
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 3 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# setup_mocks_monitor_no_pr sets up mocked git/gh commands where a pull request
+# lookup for the current head returns an empty result (simulating no open PR).
+setup_mocks_monitor_no_pr() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*) echo "" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# setup_mocks_monitor_api_failure configures git/gh mocks where the first two
+# check-runs calls succeed (returning the first argument) but the third call
+# exits with failure, simulating an API error during a poll cycle.
+setup_mocks_monitor_api_failure() {
+  _MOCK_INITIAL="$1"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--jq"*)
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          exit 1
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# run_script runs the target script in a subshell with the mocked git, gh, sleep,
+# and _mock_counter_next functions exported so the script sees the test-provided behavior.
+run_script() {
+  export -f git gh sleep _mock_counter_next
+  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
+# cleanup_mock_counter removes the temporary file-based counter used by stateful mocks.
+cleanup_mock_counter() {
+  [ -n "$_MOCK_COUNTER_FILE" ] && [ -f "$_MOCK_COUNTER_FILE" ] && rm -f "$_MOCK_COUNTER_FILE"
+}
+
+test_names+=(
+  test_monitor_status_single_check_change
+  test_monitor_status_multiple_changes_sorted
+  test_monitor_status_new_check_appearing
+  test_monitor_status_check_disappearing
+  test_monitor_status_sha_change
+  test_monitor_status_explicit_pr
+  test_monitor_status_auto_detect
+  test_monitor_status_no_pr_exits_nonzero
+  test_monitor_status_no_pr_stderr_message
+  test_monitor_status_api_failure_exits_nonzero
+  test_monitor_no_subcommand_exits_nonzero
+  test_monitor_help_exits_zero
+  test_monitor_status_help_exits_zero
+  test_monitor_status_unknown_option_exits_nonzero
+  test_monitor_status_missing_pr_value_exits_nonzero
+  test_monitor_status_missing_interval_value_exits_nonzero
+  test_monitor_status_invalid_interval_exits_nonzero
+  test_monitor_status_zero_interval_exits_nonzero
+  test_usage_lists_monitor
+)
+
+# test_monitor_status_single_check_change verifies that a single check transitioning
+# from in_progress to completed produces a --- change block with correct type, check,
+# from, to, and conclusion fields.
+test_monitor_status_single_check_change() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local output
+  output=$(run_script monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: completed" \
+    && echo "$output" | grep -qF "conclusion: success"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: single check change (output: $output)"
+  fi
+}
+
+# test_monitor_status_multiple_changes_sorted verifies that when multiple checks
+# change state in one poll cycle, the output lists them sorted alphabetically by
+# check name (Build before Test).
+test_monitor_status_multiple_changes_sorted() {
+  local initial='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"Test","status":"queued","conclusion":null}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local output
+  output=$(run_script monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  local first_check
+  first_check=$(echo "$output" | grep -m1 "check:" | sed 's/check: //' | tr -d '\r')
+  local second_check
+  second_check=$(echo "$output" | grep "check:" | sed 's/check: //' | tail -1 | tr -d '\r')
+  if [ "$first_check" = "Build" ] && [ "$second_check" = "Test" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: multiple changes not sorted (first=$first_check, second=$second_check, output: $output)"
+  fi
+}
+
+# test_monitor_status_new_check_appearing verifies that a check appearing between
+# polls (not in initial snapshot) reports from: absent with the new status.
+test_monitor_status_new_check_appearing() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"},{"name":"Lint","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local output
+  output=$(run_script monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF "check: Lint" \
+    && echo "$output" | grep -qF "from: absent" \
+    && echo "$output" | grep -qF "to: in_progress"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: new check appearing (output: $output)"
+  fi
+}
+
+# test_monitor_status_check_disappearing verifies that a check present in the initial
+# snapshot but missing in the next poll reports to: absent with the previous status.
+test_monitor_status_check_disappearing() {
+  local initial='{"total_count":2,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"},{"name":"Lint","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local output
+  output=$(run_script monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF "check: Lint" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: absent"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: check disappearing (output: $output)"
+  fi
+}
+
+# test_monitor_status_sha_change verifies that when the PR head SHA changes between
+# polls, the output reports type: new-commit with the new SHA value.
+test_monitor_status_sha_change() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_sha_change "$initial"
+  local output
+  output=$(run_script monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-commit" \
+    && echo "$output" | grep -qF "sha: $NEW_SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA change detection (output: $output)"
+  fi
+}
+
+# test_monitor_status_explicit_pr verifies that monitor status --pr 42 successfully
+# detects a change and exits 0 when targeting a specific PR number.
+test_monitor_status_explicit_pr() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local exit_code=0
+  run_script monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr 42 should succeed (exit: $exit_code)"
+  fi
+}
+
+# test_monitor_status_auto_detect verifies that omitting --pr triggers auto-detection
+# of the PR from the current branch and that the monitor still detects check changes.
+test_monitor_status_auto_detect() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_auto_detect "$initial" "$changed"
+  local output
+  output=$(run_script monitor status --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF "check: CI"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect PR should work (output: $output)"
+  fi
+}
+
+# test_monitor_status_no_pr_exits_nonzero verifies that running monitor status when
+# no open PR exists for the current branch exits with a non-zero status.
+test_monitor_status_no_pr_exits_nonzero() {
+  setup_mocks_monitor_no_pr
+  local exit_code=0
+  run_script monitor status --interval 1 >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR should exit non-zero"
+  fi
+}
+
+# test_monitor_status_no_pr_stderr_message verifies that the stderr output contains
+# "no open PR found" when no open PR is detected.
+test_monitor_status_no_pr_stderr_message() {
+  setup_mocks_monitor_no_pr
+  local output
+  output=$(run_script monitor status --interval 1 2>&1) || true
+  if echo "$output" | grep -qF "no open PR found"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR should mention 'no open PR found' (output: $output)"
+  fi
+}
+
+# test_monitor_status_api_failure_exits_nonzero verifies that an API failure during
+# a poll cycle causes the monitor to exit non-zero.
+test_monitor_status_api_failure_exits_nonzero() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_api_failure "$initial"
+  local exit_code=0
+  run_script monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+# test_monitor_no_subcommand_exits_nonzero verifies that running monitor with no
+# sub-command exits 1 with a usage message.
+test_monitor_no_subcommand_exits_nonzero() {
+  assert_exit 1 "monitor with no subcommand exits 1" bash "$script" monitor
+}
+
+# test_monitor_help_exits_zero verifies that monitor --help and monitor -h exit 0.
+test_monitor_help_exits_zero() {
+  assert_exit 0 "monitor --help exits 0" bash "$script" monitor --help
+  assert_exit 0 "monitor -h exits 0" bash "$script" monitor -h
+}
+
+# test_monitor_status_help_exits_zero verifies that monitor status --help and -h exit 0.
+test_monitor_status_help_exits_zero() {
+  assert_exit 0 "monitor status --help exits 0" bash "$script" monitor status --help
+  assert_exit 0 "monitor status -h exits 0" bash "$script" monitor status -h
+}
+
+# test_monitor_status_unknown_option_exits_nonzero verifies that passing an unknown
+# flag to monitor status exits 1.
+test_monitor_status_unknown_option_exits_nonzero() {
+  assert_exit 1 "monitor status unknown option exits 1" bash "$script" monitor status --bogus
+}
+
+# test_monitor_status_missing_pr_value_exits_nonzero verifies that --pr without a
+# value exits 1 with a clear error message.
+test_monitor_status_missing_pr_value_exits_nonzero() {
+  assert_exit 1 "monitor status --pr without value exits 1" bash "$script" monitor status --pr
+}
+
+# test_monitor_status_missing_interval_value_exits_nonzero verifies that --interval
+# without a value exits 1 with a clear error message.
+test_monitor_status_missing_interval_value_exits_nonzero() {
+  assert_exit 1 "monitor status --interval without value exits 1" bash "$script" monitor status --interval
+}
+
+# test_monitor_status_invalid_interval_exits_nonzero verifies that --interval with
+# a non-numeric value exits 1.
+test_monitor_status_invalid_interval_exits_nonzero() {
+  assert_exit 1 "monitor status --interval abc exits 1" bash "$script" monitor status --interval abc
+}
+
+# test_monitor_status_zero_interval_exits_nonzero verifies that --interval 0 is
+# rejected (zero is not a positive integer).
+test_monitor_status_zero_interval_exits_nonzero() {
+  assert_exit 1 "monitor status --interval 0 exits 1" bash "$script" monitor status --interval 0
+}
+
+# test_usage_lists_monitor verifies that the main --help output includes the monitor
+# command in the command listing.
+test_usage_lists_monitor() {
+  local output
+  output=$(bash "$script" --help 2>&1)
+  if echo "$output" | grep -qF "monitor"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: usage should list monitor command"
+  fi
+}

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -45,7 +45,7 @@ setup_mocks_monitor_explicit_pr() {
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
-      *"pulls/42"*"--jq"*)
+      *"pulls/42"*"--paginate"*"--jq"*)
         echo "$HEAD_SHA"
         ;;
       *"check-runs"*"--paginate"*)
@@ -72,7 +72,7 @@ setup_mocks_monitor_sha_change() {
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
-      *"pulls/42"*"--jq"*)
+      *"pulls/42"*"--paginate"*"--jq"*)
         if [ "$call_num" -le 1 ]; then
           echo "$HEAD_SHA"
         else
@@ -101,8 +101,8 @@ setup_mocks_monitor_auto_detect() {
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
-      *"pulls?head=acme:feature-branch"*) echo '42' ;;
-      *"pulls/42"*"--jq"*)
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo '42' ;;
+      *"pulls/42"*"--paginate"*"--jq"*)
         echo "$HEAD_SHA"
         ;;
       *"check-runs"*"--paginate"*)
@@ -123,7 +123,7 @@ setup_mocks_monitor_no_pr() {
   setup_mocks
   gh() {
     case "$*" in
-      *"pulls?head=acme:feature-branch"*) echo "" ;;
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo "" ;;
       *) exit 1 ;;
     esac
   }
@@ -141,7 +141,7 @@ setup_mocks_monitor_api_failure() {
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
-      *"pulls/42"*"--jq"*)
+      *"pulls/42"*"--paginate"*"--jq"*)
         echo "$HEAD_SHA"
         ;;
       *"check-runs"*"--paginate"*)


### PR DESCRIPTION
## Summary

- Implements `gh-pr-context monitor status` — the tracer bullet for the monitor mode feature (#43)
- Polls the GitHub check-runs API at a configurable `--interval` (default 30s), detects state transitions, new/disappeared checks, and new commits pushed to the PR
- Prints terse `--- change` notifications in the established plain-text format and exits 0 on change, 1 on error

## What changed

- **`gh-pr-context`**: Added `cmd_monitor` (dispatcher), `cmd_monitor_status` (polling loop), `capture_check_snapshot` (helper), `usage_monitor`/`usage_monitor_status` (help text), updated main `usage()` and dispatch
- **`test/test_monitor_status.sh`**: New test file with 19 tests covering all acceptance criteria

## How tested

- 19 new tests in `test/test_monitor_status.sh` covering: single/multiple check changes, alphabetical sorting, new checks appearing, checks disappearing, SHA change detection, explicit/auto PR resolution, no-PR error, API failure error, CLI flag validation, help output, usage listing
- Tests use file-based stateful mocks to simulate API responses changing between poll cycles
- `sleep` is mocked as a no-op for instant test execution
- All existing tests pass with no regressions

## Acceptance criteria (#43)

- [x] `monitor status --pr 42 --interval 1` blocks until check changes, prints `--- change` with type/check/from/to/conclusion
- [x] Multiple check changes sorted alphabetically by check name
- [x] SHA re-resolution detects new commits → `type: new-commit`
- [x] Check disappearing → `to: absent`
- [x] New check appearing → `from: absent`
- [x] Default interval 30s when `--interval` omitted
- [x] `--pr 42` explicit; omitting auto-detects from branch
- [x] No open PR → exit 1 with "no open PR found"
- [x] API failure during poll → exit 1 with stderr
- [x] `monitor` no sub-command → exit 1 with usage
- [x] `monitor --help` / `monitor -h` → exit 0 with usage
- [x] `monitor status --help` → exit 0 with usage
- [x] Unknown flags → exit 1 with stderr
- [x] `usage()` updated to list monitor
- [x] All API calls use `--paginate`
- [x] Exit 0 on change, exit 1 on error
- [x] New test file passes, existing tests unaffected

Closes #43