### PR TITLE
feat: add --timeout support to monitor status command

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -105,6 +105,7 @@ usage_monitor() {
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
   echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
   echo "  -h, --help           Show this message"
 }
 
@@ -114,6 +115,7 @@ usage_monitor_status() {
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
   echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
   echo "  -h, --help           Show this message"
 }
 
@@ -397,9 +399,9 @@ capture_check_snapshot() {
 # cmd_monitor_status polls the GitHub check-runs API at a configurable interval,
 # detecting state transitions (status/conclusion changes), new checks appearing,
 # checks disappearing, and new commits pushed to the PR. Prints terse `--- change`
-# notifications and exits 0 on change, exits 1 on error.
+# notifications and exits 0 on change, exits 1 on error, exits 2 on timeout.
 cmd_monitor_status() {
-  local pr_number="" interval=30
+  local pr_number="" interval=30 timeout_input="" timeout_secs=""
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -413,6 +415,11 @@ cmd_monitor_status() {
         if ! echo "$interval" | grep -qE '^[1-9][0-9]*$'; then
           die "invalid --interval value: $interval (expected a positive integer)"
         fi
+        ;;
+      --timeout)
+        [ $# -ge 2 ] || die "missing value for --timeout"
+        timeout_input="$2"; shift 2
+        timeout_secs=$(parse_duration "$timeout_input")
         ;;
       -h|--help) usage_monitor_status; exit 0 ;;
       *) die "unknown option: $1" ;;
@@ -435,6 +442,7 @@ cmd_monitor_status() {
   local prev_snapshot
   prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha")
 
+  SECONDS=0
   while true; do
     sleep "$interval"
 
@@ -493,6 +501,11 @@ cmd_monitor_status() {
 
     prev_sha="$cur_sha"
     prev_snapshot="$cur_snapshot"
+
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
   done
 }
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -458,6 +458,11 @@ cmd_monitor_status() {
     fi
     sleep "$sleep_for"
 
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
     local cur_sha
     if ! cur_sha=$(resolve_pr_head_sha "$pr_number" 2>&1); then
       die "failed to re-resolve head SHA for PR #$pr_number"
@@ -513,11 +518,6 @@ cmd_monitor_status() {
 
     prev_sha="$cur_sha"
     prev_snapshot="$cur_snapshot"
-
-    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
-      echo "monitor timed out after $timeout_input" >&2
-      exit 2
-    fi
   done
 }
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.2.3"
+version="0.2.4"
 
 die() {
   echo "error: $1" >&2

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -444,7 +444,19 @@ cmd_monitor_status() {
 
   SECONDS=0
   while true; do
-    sleep "$interval"
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local sleep_for="$interval"
+    if [ -n "$timeout_secs" ]; then
+      local remaining=$((timeout_secs - SECONDS))
+      if [ "$remaining" -lt "$sleep_for" ]; then
+        sleep_for="$remaining"
+      fi
+    fi
+    sleep "$sleep_for"
 
     local cur_sha
     if ! cur_sha=$(resolve_pr_head_sha "$pr_number" 2>&1); then

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -551,13 +551,27 @@ test_monitor_status_no_timeout_preserves_behavior() {
 # test_monitor_status_missing_timeout_value_exits_nonzero verifies that --timeout
 # without a value exits 1 with a clear error message.
 test_monitor_status_missing_timeout_value_exits_nonzero() {
-  assert_exit 1 "monitor status --timeout without value exits 1" bash "$script" monitor status --timeout
+  local output exit_code=0
+  output=$(bash "$script" monitor status --timeout 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --timeout"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected exit 1 and 'missing value for --timeout' (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_invalid_timeout_exits_nonzero verifies that --timeout with
-# an invalid value exits 1.
+# an invalid value exits 1 with an "invalid duration" error message.
 test_monitor_status_invalid_timeout_exits_nonzero() {
-  assert_exit 1 "monitor status --timeout abc exits 1" bash "$script" monitor status --timeout abc
+  local output exit_code=0
+  output=$(bash "$script" monitor status --timeout abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid duration"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected exit 1 and 'invalid duration' (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_help_shows_timeout verifies that monitor status --help

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -156,6 +156,36 @@ setup_mocks_monitor_api_failure() {
   }
 }
 
+# setup_mocks_monitor_no_change configures git/gh mocks where data never changes,
+# suitable for timeout tests. Does NOT mock sleep so SECONDS advances in real time.
+setup_mocks_monitor_no_change() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        echo '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# run_script_with_real_sleep runs the script with mocked git/gh but real sleep,
+# so SECONDS-based timeout tests work correctly.
+run_script_with_real_sleep() {
+  export -f git gh _mock_counter_next
+  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
 # run_script runs the target script in a subshell with the mocked git, gh, sleep,
 # and _mock_counter_next functions exported so the script sees the test-provided behavior.
 run_script() {
@@ -189,6 +219,14 @@ test_names+=(
   test_monitor_status_invalid_interval_exits_nonzero
   test_monitor_status_zero_interval_exits_nonzero
   test_usage_lists_monitor
+  test_monitor_status_timeout_exits_two
+  test_monitor_status_timeout_stderr_message
+  test_monitor_status_timeout_minutes
+  test_monitor_status_timeout_hours
+  test_monitor_status_no_timeout_preserves_behavior
+  test_monitor_status_missing_timeout_value_exits_nonzero
+  test_monitor_status_invalid_timeout_exits_nonzero
+  test_monitor_status_help_shows_timeout
 )
 
 # test_monitor_status_single_check_change verifies that a single check transitioning
@@ -428,5 +466,109 @@ test_usage_lists_monitor() {
   else
     fail=$((fail + 1))
     echo "FAIL: usage should list monitor command"
+  fi
+}
+
+# test_monitor_status_timeout_exits_two verifies that --timeout 2s with --interval 1
+# exits code 2 when no state change occurs within 2 seconds.
+test_monitor_status_timeout_exits_two() {
+  setup_mocks_monitor_no_change
+  local exit_code=0
+  run_script_with_real_sleep monitor status --pr 42 --interval 1 --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout should exit 2 (got $exit_code)"
+  fi
+}
+
+# test_monitor_status_timeout_stderr_message verifies that the timeout stderr message
+# includes the duration string (e.g. "monitor timed out after 2s").
+test_monitor_status_timeout_stderr_message() {
+  setup_mocks_monitor_no_change
+  local stderr_output
+  stderr_output=$(run_script_with_real_sleep monitor status --pr 42 --interval 1 --timeout 2s 2>&1 >/dev/null) || true
+  if echo "$stderr_output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout stderr should contain 'monitor timed out after 2s' (got: $stderr_output)"
+  fi
+}
+
+# test_monitor_status_timeout_minutes verifies that --timeout 5m is accepted and
+# the duration is parsed correctly by proving the monitor starts successfully.
+test_monitor_status_timeout_minutes() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local exit_code=0
+  run_script monitor status --pr 42 --interval 1 --timeout 5m >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --timeout 5m should be accepted (got exit $exit_code)"
+  fi
+}
+
+# test_monitor_status_timeout_hours verifies that --timeout 1h is accepted and
+# the duration is parsed correctly by proving the monitor starts successfully.
+test_monitor_status_timeout_hours() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local exit_code=0
+  run_script monitor status --pr 42 --interval 1 --timeout 1h >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --timeout 1h should be accepted (got exit $exit_code)"
+  fi
+}
+
+# test_monitor_status_no_timeout_preserves_behavior verifies that omitting --timeout
+# preserves existing behavior (monitor runs until change is detected, exits 0).
+test_monitor_status_no_timeout_preserves_behavior() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_explicit_pr "$initial" "$changed"
+  local exit_code=0
+  run_script monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no timeout should detect change and exit 0 (got exit $exit_code)"
+  fi
+}
+
+# test_monitor_status_missing_timeout_value_exits_nonzero verifies that --timeout
+# without a value exits 1 with a clear error message.
+test_monitor_status_missing_timeout_value_exits_nonzero() {
+  assert_exit 1 "monitor status --timeout without value exits 1" bash "$script" monitor status --timeout
+}
+
+# test_monitor_status_invalid_timeout_exits_nonzero verifies that --timeout with
+# an invalid value exits 1.
+test_monitor_status_invalid_timeout_exits_nonzero() {
+  assert_exit 1 "monitor status --timeout abc exits 1" bash "$script" monitor status --timeout abc
+}
+
+# test_monitor_status_help_shows_timeout verifies that monitor status --help
+# includes the --timeout option in the usage output.
+test_monitor_status_help_shows_timeout() {
+  local output
+  output=$(bash "$script" monitor status --help 2>&1)
+  if echo "$output" | grep -qF -- "--timeout"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --help should list --timeout (output: $output)"
   fi
 }

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -157,8 +157,10 @@ setup_mocks_monitor_api_failure() {
 }
 
 # setup_mocks_monitor_no_change configures git/gh mocks where data never changes,
-# suitable for timeout tests. Does NOT mock sleep so SECONDS advances in real time.
+# suitable for timeout tests. Defines a sleep() wrapper that calls the real system
+# sleep so SECONDS advances correctly and no leaked mock from other tests interferes.
 setup_mocks_monitor_no_change() {
+  sleep() { command sleep "$@"; }
   git() {
     case "$*" in
       "rev-parse --git-dir") echo ".git" ;;
@@ -181,7 +183,7 @@ setup_mocks_monitor_no_change() {
 # run_script_with_real_sleep runs the script with mocked git/gh but real sleep,
 # so SECONDS-based timeout tests work correctly.
 run_script_with_real_sleep() {
-  export -f git gh _mock_counter_next
+  export -f git gh sleep _mock_counter_next
   export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
   timeout 15 bash "$script" "$@" </dev/null
 }


### PR DESCRIPTION
## Summary

- Add `--timeout <duration>` flag to `monitor status` that caps how long the monitor polls before giving up
- Uses the existing `parse_duration()` function (from #42) to accept `30s`, `5m`, `1h` duration strings
- Polling loop checks elapsed time against the timeout at the end of each cycle; exits code **2** with stderr message (e.g. `monitor timed out after 5m`) when timeout expires without change
- Without `--timeout`, monitor runs indefinitely until change or kill (existing behavior preserved)

## Acceptance criteria (#44)

- [x] `monitor status --pr 42 --timeout 2s --interval 1` exits 2 with stderr message when no change occurs within 2 seconds
- [x] Timeout stderr message includes the duration (e.g. `monitor timed out after 2s`)
- [x] `monitor status --pr 42 --timeout 5m` works with minutes
- [x] `monitor status --pr 42 --timeout 1h` works with hours
- [x] Without `--timeout`, monitor runs until change or kill (existing behavior preserved)
- [x] Invalid `--timeout` value → exit 1 with clear stderr
- [x] Missing `--timeout` value → exit 1 with "missing value for --timeout"
- [x] Tests for timeout exit 2, timeout stderr message, invalid format rejection
- [x] Existing tests still pass

## Test plan

8 new tests in `test/test_monitor_status.sh`:
- `test_monitor_status_timeout_exits_two` — real-sleep integration test verifies exit code 2
- `test_monitor_status_timeout_stderr_message` — verifies stderr message format
- `test_monitor_status_timeout_minutes` — `--timeout 5m` accepted
- `test_monitor_status_timeout_hours` — `--timeout 1h` accepted
- `test_monitor_status_no_timeout_preserves_behavior` — regression test
- `test_monitor_status_missing_timeout_value_exits_nonzero` — missing value error
- `test_monitor_status_invalid_timeout_exits_nonzero` — invalid format error
- `test_monitor_status_help_shows_timeout` — help text includes --timeout

All 41 tests pass (11 duration + 30 monitor status).

Closes #44