### PR TITLE
fix: defer --since resolution until after git env setup

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -147,6 +147,32 @@ resolve_pr_head_sha() {
   gh api "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
 }
 
+validate_since_format() {
+  local input="${1:-}"
+  if [ -z "$input" ]; then return 0; fi
+  if [ "$input" = "last-commit" ]; then return 0; fi
+  if echo "$input" | grep -qE '^[0-9a-fA-F]{7,40}$'; then return 0; fi
+  if echo "$input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}$'; then
+    local ts="${input}T00:00:00Z"
+    local rt
+    rt=$(echo "$ts" | jq -R 'fromdateiso8601 | todateiso8601' 2>/dev/null) \
+      || die "invalid --since value: $input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    [ "$rt" = "\"$ts\"" ] \
+      || die "invalid --since value: $input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    return 0
+  fi
+  if echo "$input" | grep -qE '^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}$'; then
+    local ts="${input}Z"
+    local rt
+    rt=$(echo "$ts" | jq -R 'fromdateiso8601 | todateiso8601' 2>/dev/null) \
+      || die "invalid --since value: $input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    [ "$rt" = "\"$ts\"" ] \
+      || die "invalid --since value: $input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+    return 0
+  fi
+  die "invalid --since value: $input (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)"
+}
+
 resolve_since_timestamp() {
   local since_input="${1:-}"
   if [ -z "$since_input" ]; then
@@ -203,7 +229,7 @@ resolve_since_timestamp() {
 }
 
 cmd_comments() {
-  local pr_number="" since_ref="" force_all=false
+  local pr_number="" since_ref="" since_input="" force_all=false
 
   while [ $# -gt 0 ]; do
     case "$1" in
@@ -213,7 +239,8 @@ cmd_comments() {
         ;;
       --since)
         [ $# -ge 2 ] || die "missing value for --since"
-        since_ref=$(resolve_since_timestamp "$2"); shift 2
+        validate_since_format "$2"
+        since_input="$2"; shift 2
         ;;
       --all)  force_all=true; shift ;;
       -h|--help) usage; exit 0 ;;
@@ -222,10 +249,14 @@ cmd_comments() {
   done
 
   if [ "$force_all" = true ]; then
-    since_ref=""
+    since_input=""
   fi
 
   check_deps
+
+  if [ -n "$since_input" ]; then
+    since_ref=$(resolve_since_timestamp "$since_input")
+  fi
 
   if [ -z "$pr_number" ]; then
     pr_number=$(resolve_pr_number)

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -96,7 +96,7 @@ test_worktree_since_last_commit_after_setup() {
   tmpdir=$(mktemp -d)
   local gitdir_target="$tmpdir/gitdir_target"
   mkdir -p "$gitdir_target"
-  echo "gitdir: $gitdir_target" > "$tmpdir/.git"
+  echo "gitdir: gitdir_target" > "$tmpdir/.git"
 
   local exit_code=0 output
   output=$(

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -94,9 +94,9 @@ HEAD_EPOCH="1742040000"
 test_worktree_since_last_commit_after_setup() {
   local tmpdir
   tmpdir=$(mktemp -d)
-  local gitdir_base="$tmpdir/.git/worktrees/wt"
-  mkdir -p "$gitdir_base"
-  echo "gitdir: $gitdir_base" > "$tmpdir/.git"
+  local gitdir_target="$tmpdir/gitdir_target"
+  mkdir -p "$gitdir_target"
+  echo "gitdir: $gitdir_target" > "$tmpdir/.git"
 
   local exit_code=0 output
   output=$(

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -129,7 +129,7 @@ test_worktree_since_last_commit_after_setup() {
       esac
     }
     export -f git gh
-    timeout 15 bash "$script" comments --since last-commit 2>&1
+    timeout 15 bash "$script" comments --pr 42 --since last-commit 2>&1
   ) || exit_code=$?
 
   rm -rf "$tmpdir"

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -110,7 +110,13 @@ test_worktree_since_last_commit_after_setup() {
           ;;
         "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
         "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
-        "log -1 --format=%ct HEAD") echo "$HEAD_EPOCH" ;;
+        "log -1 --format=%ct HEAD")
+          if [ -n "${GIT_DIR:-}" ] && [ -n "${GIT_WORK_TREE:-}" ]; then
+            echo "$HEAD_EPOCH"
+          else
+            exit 1
+          fi
+          ;;
         *) exit 1 ;;
       esac
     }

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -4,6 +4,7 @@ test_names+=(
   test_worktree_noop_when_git_works
   test_worktree_windows_path_conversion
   test_worktree_broken_path_returns_nonzero
+  test_worktree_since_last_commit_after_setup
 )
 
 # test_worktree_noop_when_git_works verifies setup_git_env is a no-op
@@ -86,4 +87,51 @@ test_worktree_broken_path_returns_nonzero() {
   fi
 
   rm -rf "$tmpdir"
+}
+
+HEAD_EPOCH="1742040000"
+
+test_worktree_since_last_commit_after_setup() {
+  local tmpdir
+  tmpdir=$(mktemp -d)
+  local gitdir_base="$tmpdir/.git/worktrees/wt"
+  mkdir -p "$gitdir_base"
+  echo "gitdir: $gitdir_base" > "$tmpdir/.git"
+
+  local exit_code=0 output
+  output=$(
+    export -f die parse_duration resolve_since_timestamp resolve_owner_repo resolve_pr_number resolve_pr_head_sha check_deps setup_git_env
+    export HEAD_EPOCH
+    cd "$tmpdir"
+    git() {
+      case "$*" in
+        "rev-parse --git-dir")
+          if [ -n "${GIT_DIR:-}" ]; then echo "$GIT_DIR"; else exit 1; fi
+          ;;
+        "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+        "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+        "log -1 --format=%ct HEAD") echo "$HEAD_EPOCH" ;;
+        *) exit 1 ;;
+      esac
+    }
+    gh() {
+      case "$*" in
+        *"pulls?head="*) echo '[{"number":42}]' ;;
+        *"pulls/42/comments"*) echo '[]' ;;
+        *"issues/42/comments"*) echo '[{"user":{"login":"bot"},"created_at":"2099-01-01T00:00:00Z","body":"wt-future"}]' ;;
+        *) exit 1 ;;
+      esac
+    }
+    export -f git gh
+    timeout 15 bash "$script" comments --since last-commit 2>&1
+  ) || exit_code=$?
+
+  rm -rf "$tmpdir"
+
+  if [ "$exit_code" -eq 0 ] && echo "$output" | grep -qF "wt-future"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --since last-commit should work in worktree after env setup (exit: $exit_code, output: $output)"
+  fi
 }

--- a/test/test_worktree.sh
+++ b/test/test_worktree.sh
@@ -100,6 +100,7 @@ test_worktree_since_last_commit_after_setup() {
 
   local exit_code=0 output
   output=$(
+    unset GIT_DIR GIT_WORK_TREE
     export -f die parse_duration resolve_since_timestamp resolve_owner_repo resolve_pr_number resolve_pr_head_sha check_deps setup_git_env
     export HEAD_EPOCH
     cd "$tmpdir"


### PR DESCRIPTION
## Summary

- `--since last-commit` and `--since <SHA>` failed in git worktrees because `resolve_since_timestamp()` was called during argument parsing (before `check_deps()`/`setup_git_env()` configured `GIT_DIR`/`GIT_WORK_TREE`).
- Split `--since` handling into two phases:
  - `validate_since_format()` — early format validation during parsing (no git/gh needed, uses only jq for date checks)
  - `resolve_since_timestamp()` — deferred resolution after `check_deps()` sets up the git environment
- Added regression test `test_worktree_since_last_commit_after_setup` that verifies `--since last-commit` works in a simulated worktree scenario.

## Testing

- All existing tests pass (same pre-existing `test_comments.sh` failure unrelated to this change).
- New test `test_worktree_since_last_commit_after_setup` passes.

Closes #51