### PR TITLE
docs: add delivery instructions with /to-issues skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,3 +61,7 @@ Five-label vocabulary: `needs-triage`, `needs-info`, `ready-for-agent`, `ready-f
 ### Domain docs
 
 Single-context: `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.
+
+### Delivery
+
+When delivering a task, if there are follow-up items that can't be implemented now or are outside the scope of the current PR, use the `/to-issues` skill to create new issues for them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,3 +13,7 @@ When creating a new release:
 5. Push: `git push && git push --tags`
 
 The CI version/tag consistency check will fail if the script version doesn't match the latest tag.
+
+## Delivery
+
+When delivering a task, if there are follow-up items that can't be implemented now or are outside the scope of the current PR, use the `/to-issues` skill to create new issues for them.


### PR DESCRIPTION
## Summary
- Add `### Delivery` section to `AGENTS.md` instructing agents to use the `/to-issues` skill for follow-up items outside the current PR scope
- Add matching `## Delivery` section to `CLAUDE.md`

## Test plan
- [ ] Verify both files contain the new delivery section
- [ ] Confirm the wording matches the user request