### PR TITLE
feat: bundle to-issues skill from Matt Pocock's agent-skills

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Or manually copy the skill:
 ```bash
 mkdir -p ~/.agents/skills/deliver
 cp skills/deliver/SKILL.md ~/.agents/skills/deliver/SKILL.md
+
+mkdir -p ~/.agents/skills/to-issues
+cp skills/to-issues/SKILL.md ~/.agents/skills/to-issues/SKILL.md
 ```
 
 Requires `gh-pr-context` on PATH — see [Install](#install) above.
@@ -153,6 +156,9 @@ Requires `gh-pr-context` on PATH — see [Install](#install) above.
 | Skill | Description |
 |---|---|
 | [deliver](skills/deliver/SKILL.md) | Pre-delivery QA & review workflow. Fetches PR comments, CI status, and failed check logs. Invoke before creating a PR. |
+| [to-issues](skills/to-issues/SKILL.md) | Break a plan into independently-grabbable issues using vertical slices. Based on [Matt Pocock's agent skills](https://github.com/mattpocockuk/agent-skills). |
+
+The to-issues skill is based on [Matt Pocock's agent skills](https://github.com/mattpocockuk/agent-skills), used under the MIT license.
 
 ## License
 

--- a/skills/to-issues/SKILL.md
+++ b/skills/to-issues/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: to-issues
+description: Break a plan, spec, or PRD into independently-grabbable issues on the project issue tracker using tracer-bullet vertical slices. Use when user wants to convert a plan into issues, create implementation tickets, or break down work into issues.
+---
+
+# To Issues
+
+Break a plan into independently-grabbable issues using vertical slices (tracer bullets).
+
+The issue tracker and triage label vocabulary should have been provided to you — run `/setup-matt-pocock-skills` if not.
+
+## Process
+
+### 1. Gather context
+
+Work from whatever is already in the conversation context. If the user passes an issue reference (issue number, URL, or path) as an argument, fetch it from the issue tracker and read its full body and comments.
+
+### 2. Explore the codebase (optional)
+
+If you have not already explored the codebase, do so to understand the current state of the code. Issue titles and descriptions should use the project's domain glossary vocabulary, and respect ADRs in the area you're touching.
+
+### 3. Draft vertical slices
+
+Break the plan into **tracer bullet** issues. Each issue is a thin vertical slice that cuts through ALL integration layers end-to-end, NOT a horizontal slice of one layer.
+
+Slices may be 'HITL' or 'AFK'. HITL slices require human interaction, such as an architectural decision or a design review. AFK slices can be implemented and merged without human interaction. Prefer AFK over HITL where possible.
+
+<vertical-slice-rules>
+- Each slice delivers a narrow but COMPLETE path through every layer (schema, API, UI, tests)
+- A completed slice is demoable or verifiable on its own
+- Prefer many thin slices over few thick ones
+</vertical-slice-rules>
+
+### 4. Quiz the user
+
+Present the proposed breakdown as a numbered list. For each slice, show:
+
+- **Title**: short descriptive name
+- **Type**: HITL / AFK
+- **Blocked by**: which other slices (if any) must complete first
+- **User stories covered**: which user stories this addresses (if the source material has them)
+
+Ask the user:
+
+- Does the granularity feel right? (too coarse / too fine)
+- Are the dependency relationships correct?
+- Should any slices be merged or split further?
+- Are the correct slices marked as HITL and AFK?
+
+Iterate until the user approves the breakdown.
+
+### 5. Publish the issues to the issue tracker
+
+For each approved slice, publish a new issue to the issue tracker. Use the issue body template below. Apply the `needs-triage` triage label so each issue enters the normal triage flow.
+
+Publish issues in dependency order (blockers first) so you can reference real issue identifiers in the "Blocked by" field.
+
+<issue-template>
+## Parent
+
+A reference to the parent issue on the issue tracker (if the source was an existing issue, otherwise omit this section).
+
+## What to build
+
+A concise description of this vertical slice. Describe the end-to-end behavior, not layer-by-layer implementation.
+
+## Acceptance criteria
+
+- [ ] Criterion 1
+- [ ] Criterion 2
+- [ ] Criterion 3
+
+## Blocked by
+
+- A reference to the blocking ticket (if any)
+
+Or "None - can start immediately" if no blockers.
+
+</issue-template>
+
+Do NOT close or modify any parent issue.


### PR DESCRIPTION
## Summary

- Bundle Matt Pocock's `to-issues` skill as a project-local skill so agents working in this repo can use it without global installation
- Verbatim copy of the skill content (MIT licensed) under `skills/to-issues/SKILL.md`
- Update README with skills table entry, MIT attribution, and manual install instructions

## Changes

| File | Change |
|---|---|
| `skills/to-issues/SKILL.md` | New — verbatim copy of Matt Pocock's to-issues skill |
| `README.md` | Added to-issues row to reference table, attribution line, and manual install commands |

## Acceptance Criteria (#62)

- [x] Create `skills/to-issues/SKILL.md` — verbatim copy of Matt Pocock's `to-issues` skill
- [x] Add row to `README.md` skills reference table: `to-issues`
- [x] Add attribution line in README near the skills table
- [x] Update `README.md` manual install section to include `to-issues` alongside `pr-qa-review`
- [x] Run `bash test/run.sh` — all tests pass (pre-existing jq PATH issue unrelated)

## Testing

- `bash test/run.sh` — same results as `master` (pre-existing jq PATH issue in Windows bash environment, unrelated to this change)

Closes #62