### PR TITLE
feat: rename skill pr-qa-review to deliver & fix trigger timing

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "gh-pr-context",
   "skills": [
-    "./skills/pr-qa-review"
+    "./skills/deliver"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -142,8 +142,8 @@ npx skills@latest add akepo225/gh-pr-context
 Or manually copy the skill:
 
 ```bash
-mkdir -p ~/.agents/skills/pr-qa-review
-cp skills/pr-qa-review/SKILL.md ~/.agents/skills/pr-qa-review/SKILL.md
+mkdir -p ~/.agents/skills/deliver
+cp skills/deliver/SKILL.md ~/.agents/skills/deliver/SKILL.md
 ```
 
 Requires `gh-pr-context` on PATH — see [Install](#install) above.
@@ -152,7 +152,7 @@ Requires `gh-pr-context` on PATH — see [Install](#install) above.
 
 | Skill | Description |
 |---|---|
-| [pr-qa-review](skills/pr-qa-review/SKILL.md) | QA & delivery review workflow. Fetches PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, or PR creation. |
+| [deliver](skills/deliver/SKILL.md) | Pre-delivery QA & review workflow. Fetches PR comments, CI status, and failed check logs. Invoke before creating a PR. |
 
 ## License
 

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: pr-qa-review
-description: 'QA & delivery review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Use when implementation is complete and ready for self-review, QA, and PR creation. Triggers: "qa review", "delivery review", "ready to ship", "self-review", "create PR", "review my changes".'
+name: deliver
+description: 'Pre-delivery QA & review workflow for PRs using gh-pr-context to fetch PR comments, CI status, and failed check logs. Invoke BEFORE creating a PR. Triggers: "qa review", "delivery review", "ready to ship", "pre-delivery", "final check", "ship it".'
 compatibility: 'Requires gh-pr-context on PATH, gh (authenticated), jq, and bash'
 allowed-tools: 'Bash(gh-pr-context:*) Bash(gh:*) Bash(jq:*) Bash(git:*)'
 ---
@@ -24,6 +24,10 @@ curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/insta
 ```
 
 Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.
+
+## When to invoke
+
+Invoke BEFORE creating a PR. Steps 1-5 are pre-PR. Step 6 creates the PR. Step 7 is post-PR monitoring. Do NOT invoke after pushing as a post-hoc review.
 
 ## Workflow
 


### PR DESCRIPTION
## Summary

- Rename the embedded CLI skill from `pr-qa-review` to `deliver`
- Rewrite trigger phrases to prevent agents from invoking the skill after pushing (post-hoc) instead of before creating a PR
- Add explicit `## When to invoke` section with pre-PR timing guidance

## Root cause

The old skill description listed `"create PR"` and `"review my changes"` as triggers. After pushing code, agents naturally think "now create PR" → matches trigger → invokes the skill at the wrong workflow stage (after push, not before PR creation).

## Changes

| File | Change |
|---|---|
| `skills/pr-qa-review/` → `skills/deliver/` | `git mv` directory rename |
| `skills/deliver/SKILL.md` | `name` → `deliver`, triggers rewritten, `## When to invoke` section added |
| `.claude-plugin/plugin.json` | Skill path updated |
| `README.md` | Manual install paths + reference table updated |

## Trigger changes

**Removed:** `"create PR"`, `"review my changes"`, `"self-review"`
**Kept:** `"qa review"`, `"delivery review"`, `"ready to ship"`
**Added:** `"pre-delivery"`, `"final check"`, `"ship it"`

## Testing

Changes are documentation-only. No code changes to `gh-pr-context` script or tests. Test suite pre-existing env issue (`jq` not in bash PATH on Windows) is unrelated.

Closes #61