### PR TITLE
fix: reorder deliver skill workflow steps into execution order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@
 *.swo
 *~
 .DS_Store
+.agents/
+.claude/skills/
+.trae/
+.windsurf/
+skills-lock.json

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -27,7 +27,7 @@ Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.
 
 ## When to invoke
 
-Invoke BEFORE creating a PR. Steps 1-5 are pre-PR. Step 6 creates the PR. Step 7 is post-PR monitoring. Do NOT invoke after pushing as a post-hoc review.
+Invoke BEFORE creating a PR to run the pre-PR checks (steps 1-3), then create the PR (step 4), and proceed with post-PR review (steps 5-7). Do NOT invoke after pushing as a post-hoc review.
 
 ## Workflow
 
@@ -51,7 +51,13 @@ Invoke BEFORE creating a PR. Steps 1-5 are pre-PR. Step 6 creates the PR. Step 7
 - Exercise changed functionality manually or via integration tests where applicable.
 - Check container logs, server output, or browser console for errors if relevant.
 
-### 4. Gather PR Context
+### 4. Create a Pull Request (skip if PR already exists)
+
+- Do **not** push to `main`. Create a feature branch and open a PR.
+- Write a clear summary: what changed, why, and how it was tested.
+- Link the original issue.
+
+### 5. Gather PR Context
 
 Run these commands in the project directory (branch must have an open PR, or pass `--pr <number>`):
 
@@ -78,15 +84,9 @@ Read the output carefully. For each comment or failed check, determine if action
 - `--- check` — CI check. Fields: `name`, `status`, optional `conclusion`.
 - `--- log` — Failed check log. Fields: `name`, log body. Truncated at 500 lines with `[truncated: N lines omitted]`.
 
-### 5. Fix All Findings
+### 6. Fix All Findings
 
-Address every legitimate issue from steps 1–4. Dismiss only clearly false positives — explain dismissals in the commit message or PR description.
-
-### 6. Create a Pull Request (skip if PR already exists)
-
-- Do **not** push to `main`. Create a feature branch and open a PR.
-- Write a clear summary: what changed, why, and how it was tested.
-- Link the original issue.
+Address every legitimate issue from steps 1, 2, 3, and 5. Dismiss only clearly false positives — explain dismissals in the commit message or PR description.
 
 ### 7. Monitor & Iterate
 


### PR DESCRIPTION
## Summary

Restructure the `deliver` skill workflow steps to follow actual execution order, fixing the pre-PR/post-PR inconsistency flagged in PR #67.

## Problem

The previous workflow listed steps in a confusing order:
- Steps 1-3 were pre-PR (correct)
- Step 4 gathered PR context (requires an open PR — not pre-PR)
- Step 5 fixed findings
- Step 6 created the PR (too late in the sequence)
- Step 7 monitored

This meant an agent following steps in order would hit step 4 (which needs a PR) before step 6 (which creates the PR).

## Changes

| Before | After | Phase |
|---|---|---|
| 1. Self-Review | 1. Self-Review | Pre-PR |
| 2. Integration Check | 2. Integration Check | Pre-PR |
| 3. Runtime Verification | 3. Runtime Verification | Pre-PR |
| 4. Gather PR Context | 4. **Create PR** | Creates PR |
| 5. Fix Findings | 5. **Gather PR Context** | Post-PR |
| 6. Create PR | 6. **Fix Findings** | Post-PR |
| 7. Monitor | 7. Monitor | Post-PR |

Also updated the `## When to invoke` section and step 6 cross-references.

Follow-up to #67.