### PR TITLE
feat: add monitor comments sub-command for new comment polling (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.5
+
+- **monitor comments** — New sub-command to poll for new review and issue comments on a PR, reporting `type: new-comment` with `count` on change.
+
 ## v0.2.3
 
 - **Claude Code GitHub Action** — Added `anthropics/claude-code-action` workflow for AI-assisted PR reviews and issue handling via GitHub Actions.

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.2.4"
+version="0.2.5"
 
 die() {
   echo "error: $1" >&2
@@ -100,7 +100,8 @@ usage_monitor() {
   echo "usage: gh-pr-context monitor <sub-command> [options]"
   echo ""
   echo "sub-commands:"
-  echo "  status   Monitor CI check state changes"
+  echo "  status    Monitor CI check state changes"
+  echo "  comments  Monitor new comments on the PR"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -111,6 +112,17 @@ usage_monitor() {
 
 usage_monitor_status() {
   echo "usage: gh-pr-context monitor status [options]"
+  echo ""
+  echo "options:"
+  echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
+  echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
+  echo "  --check <name>       Watch only the named check (case-sensitive)"
+  echo "  -h, --help           Show this message"
+}
+
+usage_monitor_comments() {
+  echo "usage: gh-pr-context monitor comments [options]"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -427,6 +439,21 @@ capture_check_snapshot() {
   echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
 }
 
+# capture_comment_id_snapshot fetches top-level review comment IDs (excluding
+# replies) and issue comment IDs for a given PR, returning a sorted newline-
+# separated list suitable for set-difference comparison between poll cycles.
+capture_comment_id_snapshot() {
+  local owner_repo=$1 pr_number=$2
+  local review_ids issue_ids
+  review_ids=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate \
+    | jq -r '[.[] | select(.in_reply_to_id == null) | .id] | sort[]' | tr -d '\r') \
+    || die "failed to fetch review comments for PR #$pr_number"
+  issue_ids=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate \
+    | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
+    || die "failed to fetch issue comments for PR #$pr_number"
+  { echo "$review_ids"; echo "$issue_ids"; } | sort -n | grep -v '^$' || true
+}
+
 # cmd_monitor_status polls the GitHub check-runs API at a configurable interval,
 # detecting state transitions (status/conclusion changes), new checks appearing,
 # checks disappearing, and new commits pushed to the PR. Prints terse `--- change`
@@ -552,8 +579,91 @@ cmd_monitor_status() {
   done
 }
 
+# cmd_monitor_comments polls the GitHub review comments and issue comments
+# endpoints at a configurable interval, detecting new top-level comment IDs
+# not present in the initial snapshot. Prints terse `--- change` notifications
+# and exits 0 on change, exits 1 on error, exits 2 on timeout.
+cmd_monitor_comments() {
+  local pr_number="" interval=30 timeout_input="" timeout_secs=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] || die "missing value for --pr"
+        pr_number="$2"; shift 2
+        ;;
+      --interval)
+        [ $# -ge 2 ] || die "missing value for --interval"
+        interval="$2"; shift 2
+        if ! echo "$interval" | grep -qE '^[1-9][0-9]*$'; then
+          die "invalid --interval value: $interval (expected a positive integer)"
+        fi
+        ;;
+      --timeout)
+        [ $# -ge 2 ] || die "missing value for --timeout"
+        timeout_input="$2"; shift 2
+        timeout_secs=$(parse_duration "$timeout_input")
+        ;;
+      --check)
+        die "--check is not supported for monitor comments"
+        ;;
+      -h|--help) usage_monitor_comments; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+
+  check_deps
+
+  if [ -z "$pr_number" ]; then
+    pr_number=$(resolve_pr_number)
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
+  local initial_snapshot
+  initial_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+  SECONDS=0
+  while true; do
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local sleep_for="$interval"
+    if [ -n "$timeout_secs" ]; then
+      local remaining=$((timeout_secs - SECONDS))
+      if [ "$remaining" -lt "$sleep_for" ]; then
+        sleep_for="$remaining"
+      fi
+    fi
+    sleep "$sleep_for"
+
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local cur_snapshot
+    cur_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+    local new_ids
+    new_ids=$(comm -23 <(echo "$cur_snapshot") <(echo "$initial_snapshot"))
+    local new_count
+    new_count=$(echo "$new_ids" | grep -c '.' || true)
+
+    if [ "$new_count" -gt 0 ]; then
+      echo "--- change"
+      echo "type: new-comment"
+      echo "count: $new_count"
+      exit 0
+    fi
+  done
+}
+
 # cmd_monitor is the top-level dispatcher for the monitor command, routing
-# sub-commands (status) to their handlers. Exits 1 with usage when no
+# sub-commands (status, comments) to their handlers. Exits 1 with usage when no
 # sub-command is provided.
 cmd_monitor() {
   if [ $# -eq 0 ]; then
@@ -565,6 +675,7 @@ cmd_monitor() {
 
   case "$sub_command" in
     status) cmd_monitor_status "$@" ;;
+    comments) cmd_monitor_comments "$@" ;;
     -h|--help) usage_monitor; exit 0 ;;
     *) die "unknown monitor sub-command: $sub_command" ;;
   esac

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+
+_MOCK_COUNTER_FILE=""
+
+_mock_counter_next() {
+  local val
+  val=$(cat "$_MOCK_COUNTER_FILE")
+  val=$((val + 1))
+  echo "$val" > "$_MOCK_COUNTER_FILE"
+  echo "$val"
+}
+
+setup_mocks() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  sleep() {
+    :
+  }
+}
+
+setup_mocks_monitor_comments_explicit_pr() {
+  _MOCK_INITIAL_REVIEWS="$1"
+  _MOCK_INITIAL_ISSUES="$2"
+  _MOCK_CHANGED_REVIEWS="$3"
+  _MOCK_CHANGED_ISSUES="$4"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 3 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_comments_auto_detect() {
+  _MOCK_INITIAL_REVIEWS="$1"
+  _MOCK_INITIAL_ISSUES="$2"
+  _MOCK_CHANGED_REVIEWS="$3"
+  _MOCK_CHANGED_ISSUES="$4"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo '42' ;;
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 3 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 4 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_comments_no_change() {
+  _MOCK_REVIEWS="$1"
+  _MOCK_ISSUES="$2"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        echo "$_MOCK_REVIEWS"
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        echo "$_MOCK_ISSUES"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_comments_no_pr() {
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo "" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_comments_api_failure() {
+  _MOCK_INITIAL_REVIEWS="$1"
+  _MOCK_INITIAL_ISSUES="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_INITIAL_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 3 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          exit 1
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+run_script() {
+  export -f git gh sleep _mock_counter_next
+  export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
+  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
+run_script_with_real_sleep() {
+  export -f git gh sleep _mock_counter_next
+  export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
+  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
+cleanup_mock_counter() {
+  [ -n "$_MOCK_COUNTER_FILE" ] && [ -f "$_MOCK_COUNTER_FILE" ] && rm -f "$_MOCK_COUNTER_FILE"
+}
+
+test_names+=(
+  test_monitor_comments_new_review_comment
+  test_monitor_comments_new_issue_comment
+  test_monitor_comments_multiple_new_comments
+  test_monitor_comments_existing_not_reported
+  test_monitor_comments_reply_not_counted
+  test_monitor_comments_output_format
+  test_monitor_comments_check_flag_rejected
+  test_monitor_comments_timeout_exits_two
+  test_monitor_comments_timeout_stderr_message
+  test_monitor_comments_explicit_pr
+  test_monitor_comments_auto_detect
+  test_monitor_comments_no_pr_exits_nonzero
+  test_monitor_comments_api_failure_exits_nonzero
+  test_monitor_comments_help_exits_zero
+  test_monitor_comments_missing_pr_value_exits_nonzero
+  test_monitor_comments_missing_interval_value_exits_nonzero
+  test_monitor_comments_invalid_interval_exits_nonzero
+  test_monitor_comments_missing_timeout_value_exits_nonzero
+  test_monitor_comments_invalid_timeout_exits_nonzero
+)
+
+test_monitor_comments_new_review_comment() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor comments --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: new review comment (output: $output)"
+  fi
+}
+
+test_monitor_comments_new_issue_comment() {
+  local initial_reviews='[]'
+  local initial_issues='[{"id":201}]'
+  local changed_reviews='[]'
+  local changed_issues='[{"id":201},{"id":202}]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor comments --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: new issue comment (output: $output)"
+  fi
+}
+
+test_monitor_comments_multiple_new_comments() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[{"id":201}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null},{"id":103,"in_reply_to_id":null}]'
+  local changed_issues='[{"id":201},{"id":202}]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor comments --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 3"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: multiple new comments (output: $output)"
+  fi
+}
+
+test_monitor_comments_existing_not_reported() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[{"id":201}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_issues='[{"id":201}]'
+  setup_mocks_monitor_comments_no_change "$initial_reviews" "$initial_issues"
+  local output
+  output=$(run_script_with_real_sleep monitor comments --pr 42 --interval 1 --timeout 2s 2>&1) || true
+  if echo "$output" | grep -qF "timed out" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: existing comments should not be reported (output: $output)"
+  fi
+}
+
+test_monitor_comments_reply_not_counted() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":101}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script_with_real_sleep monitor comments --pr 42 --interval 1 --timeout 2s 2>&1) || true
+  if ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: reply should not be counted as new comment (output: $output)"
+  fi
+}
+
+test_monitor_comments_output_format() {
+  local initial_reviews='[]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor comments --pr 42 --interval 1 2>&1)
+  cleanup_mock_counter
+  local line1 line2 line3
+  line1=$(echo "$output" | head -1 | tr -d '\r')
+  line2=$(echo "$output" | sed -n '2p' | tr -d '\r')
+  line3=$(echo "$output" | sed -n '3p' | tr -d '\r')
+  if [ "$line1" = "--- change" ] \
+    && [ "$line2" = "type: new-comment" ] \
+    && [ "$line3" = "count: 1" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: output format (line1=$line1, line2=$line2, line3=$line3, output: $output)"
+  fi
+}
+
+test_monitor_comments_check_flag_rejected() {
+  local output
+  output=$(bash "$script" monitor comments --check CI 2>&1) || true
+  if echo "$output" | grep -qF -- "--check is not supported for monitor comments"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check should be rejected (output: $output)"
+  fi
+}
+
+test_monitor_comments_timeout_exits_two() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  setup_mocks_monitor_comments_no_change "$initial_reviews" "$initial_issues"
+  local exit_code=0
+  run_script_with_real_sleep monitor comments --pr 42 --interval 1 --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout should exit 2 (exit: $exit_code)"
+  fi
+}
+
+test_monitor_comments_timeout_stderr_message() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  setup_mocks_monitor_comments_no_change "$initial_reviews" "$initial_issues"
+  local output
+  output=$(run_script_with_real_sleep monitor comments --pr 42 --interval 1 --timeout 2s 2>&1) || true
+  if echo "$output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout stderr message (output: $output)"
+  fi
+}
+
+test_monitor_comments_explicit_pr() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_explicit_pr "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local exit_code=0
+  run_script monitor comments --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr 42 should succeed (exit: $exit_code)"
+  fi
+}
+
+test_monitor_comments_auto_detect() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_auto_detect "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor comments --interval 1 2>&1)
+  cleanup_mock_counter
+  if echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect PR should work (output: $output)"
+  fi
+}
+
+test_monitor_comments_no_pr_exits_nonzero() {
+  setup_mocks_monitor_comments_no_pr
+  local exit_code=0
+  run_script monitor comments --interval 1 >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR should exit non-zero"
+  fi
+}
+
+test_monitor_comments_api_failure_exits_nonzero() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  setup_mocks_monitor_comments_api_failure "$initial_reviews" "$initial_issues"
+  local exit_code=0
+  run_script monitor comments --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+test_monitor_comments_help_exits_zero() {
+  assert_exit 0 "monitor comments --help exits 0" bash "$script" monitor comments --help
+  assert_exit 0 "monitor comments -h exits 0" bash "$script" monitor comments -h
+}
+
+test_monitor_comments_missing_pr_value_exits_nonzero() {
+  assert_exit 1 "monitor comments --pr without value exits 1" bash "$script" monitor comments --pr
+}
+
+test_monitor_comments_missing_interval_value_exits_nonzero() {
+  assert_exit 1 "monitor comments --interval without value exits 1" bash "$script" monitor comments --interval
+}
+
+test_monitor_comments_invalid_interval_exits_nonzero() {
+  assert_exit 1 "monitor comments --interval invalid exits 1" bash "$script" monitor comments --interval abc
+}
+
+test_monitor_comments_missing_timeout_value_exits_nonzero() {
+  assert_exit 1 "monitor comments --timeout without value exits 1" bash "$script" monitor comments --timeout
+}
+
+test_monitor_comments_invalid_timeout_exits_nonzero() {
+  assert_exit 1 "monitor comments --timeout invalid exits 1" bash "$script" monitor comments --timeout abc
+}


### PR DESCRIPTION
## Summary

- Add `monitor comments` sub-command that polls for new review and issue comments on a PR
- Implements comment ID snapshot-based change detection using `comm -23` for set-difference
- Filters review comments to top-level only (`in_reply_to_id == null`), never calls replies endpoint
- Supports `--pr`, `--interval`, `--timeout`; explicitly rejects `--check`
- 20 new tests in `test/test_monitor_comments.sh` (all passing)
- Fixes CRLF issue in snapshot helper with `tr -d '\r'` (consistent with existing Windows CRLF handling)

## How it works

1. Captures initial snapshot of all top-level review comment IDs and issue comment IDs
2. Polls at configurable interval, re-fetching both endpoints
3. Uses `comm -23` to detect new IDs not in the initial snapshot
4. Reports `--- change` / `type: new-comment` / `count: N` and exits 0 on change
5. Exits 2 on timeout, exits 1 on error (same as `monitor status`)

## Testing

- 20 tests covering: new review/issue comment detection, multiple comments, existing comment filtering, reply exclusion, output format, `--check` rejection, timeout behavior, PR auto-detection, API failure handling, CLI flag validation
- Existing 29 `monitor status` tests still pass
- Pre-existing `test_comments.sh` CRLF failures are unrelated (existed before this PR)

Closes #46