### PR TITLE
feat: add SIGINT/SIGTERM signal handling to monitor sub-commands

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -511,6 +511,9 @@ cmd_monitor_status() {
     prev_snapshot=$(echo "$prev_snapshot" | jq --arg name "$check_filter" 'map(select(.name == $name))')
   fi
 
+  local _monitor_interrupted=0
+  trap '_monitor_interrupted=1' INT TERM
+
   SECONDS=0
   while true; do
     if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
@@ -525,9 +528,11 @@ cmd_monitor_status() {
         sleep_for="$remaining"
       fi
     fi
-    sleep "$sleep_for"
+    sleep "$sleep_for" || true
 
-    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+    if [ "$_monitor_interrupted" -eq 1 ]; then
+      : # skip timeout check on interrupt
+    elif [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
       echo "monitor timed out after $timeout_input" >&2
       exit 2
     fi
@@ -541,6 +546,7 @@ cmd_monitor_status() {
       echo "--- change"
       echo "type: new-commit"
       echo "sha: $cur_sha"
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
       exit 0
     fi
 
@@ -585,8 +591,11 @@ cmd_monitor_status() {
         "from: \(.from)\n" +
         "to: \(.to)" +
         if (.conclusion != null and .to != "absent") then "\nconclusion: \(.conclusion)" else "" end'
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
       exit 0
     fi
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
 
     prev_sha="$cur_sha"
     prev_snapshot="$cur_snapshot"
@@ -638,6 +647,9 @@ cmd_monitor_comments() {
   local initial_snapshot
   initial_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
 
+  local _monitor_interrupted=0
+  trap '_monitor_interrupted=1' INT TERM
+
   SECONDS=0
   while true; do
     if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
@@ -652,9 +664,11 @@ cmd_monitor_comments() {
         sleep_for="$remaining"
       fi
     fi
-    sleep "$sleep_for"
+    sleep "$sleep_for" || true
 
-    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+    if [ "$_monitor_interrupted" -eq 1 ]; then
+      : # skip timeout check on interrupt
+    elif [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
       echo "monitor timed out after $timeout_input" >&2
       exit 2
     fi
@@ -671,8 +685,11 @@ cmd_monitor_comments() {
       echo "--- change"
       echo "type: new-comment"
       echo "count: $new_count"
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
       exit 0
     fi
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
   done
 }
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -459,7 +459,8 @@ capture_comment_id_snapshot() {
 # cmd_monitor_status polls the GitHub check-runs API at a configurable interval,
 # detecting state transitions (status/conclusion changes), new checks appearing,
 # checks disappearing, and new commits pushed to the PR. Prints terse `--- change`
-# notifications and exits 0 on change, exits 1 on error, exits 2 on timeout.
+# notifications and exits 0 on change, exits 1 on error, exits 2 on timeout,
+# exits 130 on SIGINT/SIGTERM (after a final poll).
 cmd_monitor_status() {
   local pr_number="" interval=30 timeout_input="" timeout_secs="" check_filter=""
 
@@ -605,7 +606,8 @@ cmd_monitor_status() {
 # cmd_monitor_comments polls the GitHub review comments and issue comments
 # endpoints at a configurable interval, detecting new top-level comment IDs
 # not present in the initial snapshot. Prints terse `--- change` notifications
-# and exits 0 on change, exits 1 on error, exits 2 on timeout.
+# and exits 0 on change, exits 1 on error, exits 2 on timeout,
+# exits 130 on SIGINT/SIGTERM (after a final poll).
 cmd_monitor_comments() {
   local pr_number="" interval=30 timeout_input="" timeout_secs=""
 

--- a/test/test_monitor_signal.sh
+++ b/test/test_monitor_signal.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+_MOCK_COUNTER_FILE=""
+_SIGNAL_TMPDIR=""
+
+_mock_counter_next() {
+  local val
+  val=$(cat "$_MOCK_COUNTER_FILE")
+  val=$((val + 1))
+  echo "$val" > "$_MOCK_COUNTER_FILE"
+  echo "$val"
+}
+
+cleanup_mock_counter() {
+  [ -n "$_MOCK_COUNTER_FILE" ] && [ -f "$_MOCK_COUNTER_FILE" ] && rm -f "$_MOCK_COUNTER_FILE"
+}
+
+_skip_check() {
+  if [ -n "${SKIP_SIGNAL_TESTS:-}" ]; then
+    echo "  SKIP: $1 (SKIP_SIGNAL_TESTS is set)"
+    pass=$((pass + 1))
+    return 0
+  fi
+  return 1
+}
+
+# _export_signal_mocks exports mock functions and variables needed for signal
+# tests. Must be called after defining git/gh/sleep mocks in the test function.
+_export_signal_mocks() {
+  export -f git gh sleep _mock_counter_next
+  export _MOCK_COUNTER_FILE HEAD_SHA NEW_SHA
+  export _MOCK_INITIAL _MOCK_CHANGED
+  export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
+  export _MOCK_REVIEWS _MOCK_ISSUES
+}
+
+cleanup_signal_tmpdir() {
+  [ -n "$_SIGNAL_TMPDIR" ] && [ -d "$_SIGNAL_TMPDIR" ] && rm -rf "$_SIGNAL_TMPDIR"
+}
+
+test_names+=(
+  test_signal_status_with_change_exits_130
+  test_signal_status_no_change_exits_130_silent
+  test_signal_status_sigterm_with_change_exits_130
+  test_signal_comments_with_change_exits_130
+  test_signal_comments_no_change_exits_130_silent
+  test_signal_comments_sigterm_no_change_exits_130
+)
+
+# test_signal_status_with_change_exits_130 verifies that a signal during
+# monitor status triggers a final poll, detects the change, prints output, and
+# exits 130. Uses SIGTERM because SIGINT cannot be delivered to background
+# processes on Windows/Git Bash. The script traps both INT and TERM identically.
+test_signal_status_with_change_exits_130() {
+  _skip_check "signal status with change" && return 0
+
+  _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  _MOCK_CHANGED='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+  cleanup_mock_counter
+
+  if [ "$exit_code" -eq 130 ] \
+    && echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: signal status with change (exit=$exit_code, output: $output)"
+  fi
+}
+
+# test_signal_status_no_change_exits_130_silent verifies that a signal during
+# monitor status exits 130 with no output when no state changed.
+test_signal_status_no_change_exits_130_silent() {
+  _skip_check "signal status no change" && return 0
+
+  _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL" ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+
+  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: signal status no change (exit=$exit_code, output: $output)"
+  fi
+}
+
+# test_signal_status_sigterm_with_change_exits_130 explicitly tests SIGTERM
+# to verify both signal names produce the same behavior.
+test_signal_status_sigterm_with_change_exits_130() {
+  _skip_check "signal SIGTERM status with change" && return 0
+
+  _MOCK_INITIAL='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
+  _MOCK_CHANGED='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"CI","status":"completed","conclusion":"failure"}]}'
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+  cleanup_mock_counter
+
+  if [ "$exit_code" -eq 130 ] \
+    && echo "$output" | grep -qF "check: Build" \
+    && echo "$output" | grep -qF "check: CI"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SIGTERM status with change (exit=$exit_code, output: $output)"
+  fi
+}
+
+# test_signal_comments_with_change_exits_130 verifies that a signal during
+# monitor comments triggers a final poll, detects new comments, prints output,
+# and exits 130.
+test_signal_comments_with_change_exits_130() {
+  _skip_check "signal comments with change" && return 0
+
+  _MOCK_INITIAL_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
+  _MOCK_INITIAL_ISSUES='[]'
+  _MOCK_CHANGED_REVIEWS='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  _MOCK_CHANGED_ISSUES='[]'
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+  cleanup_mock_counter
+
+  if [ "$exit_code" -eq 130 ] \
+    && echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: signal comments with change (exit=$exit_code, output: $output)"
+  fi
+}
+
+# test_signal_comments_no_change_exits_130_silent verifies that a signal during
+# monitor comments exits 130 with no output when no new comments.
+test_signal_comments_no_change_exits_130_silent() {
+  _skip_check "signal comments no change" && return 0
+
+  _MOCK_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
+  _MOCK_ISSUES='[{"id":201}]'
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*"--paginate"*)
+        echo "$_MOCK_REVIEWS"
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        echo "$_MOCK_ISSUES"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+
+  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: signal comments no change (exit=$exit_code, output: $output)"
+  fi
+}
+
+# test_signal_comments_sigterm_no_change_exits_130 explicitly tests SIGTERM
+# for monitor comments to verify both signal names produce the same behavior.
+test_signal_comments_sigterm_no_change_exits_130() {
+  _skip_check "signal SIGTERM comments no change" && return 0
+
+  _MOCK_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
+  _MOCK_ISSUES='[{"id":201}]'
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42/comments"*"--paginate"*)
+        echo "$_MOCK_REVIEWS"
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        echo "$_MOCK_ISSUES"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  local outfile="$_SIGNAL_TMPDIR/out"
+
+  _export_signal_mocks
+  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 3
+  kill -TERM "$pid" 2>/dev/null || true
+  wait "$pid" 2>/dev/null
+  local exit_code=$?
+
+  local output
+  output=$(cat "$outfile")
+  cleanup_signal_tmpdir
+
+  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SIGTERM comments no change (exit=$exit_code, output: $output)"
+  fi
+}

--- a/test/test_monitor_signal.sh
+++ b/test/test_monitor_signal.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 NEW_SHA="def456abc123def456abc123def456abc123def4"
@@ -40,6 +41,21 @@ cleanup_signal_tmpdir() {
   [ -n "$_SIGNAL_TMPDIR" ] && [ -d "$_SIGNAL_TMPDIR" ] && rm -rf "$_SIGNAL_TMPDIR"
 }
 
+# _run_and_signal starts the script in the background, waits SIGNAL_DELAY
+# seconds, sends SIGTERM, then reaps the child. Sets _signal_exit_code and
+# _signal_output. Uses || to avoid set -e exit on non-zero wait return.
+_run_and_signal() {
+  local outfile="$_SIGNAL_TMPDIR/out"
+  bash "$script" "$@" > "$outfile" 2>&1 &
+  local pid=$!
+
+  command sleep 4
+  kill -TERM "$pid" 2>/dev/null || true
+  _signal_exit_code=0
+  wait "$pid" 2>/dev/null || _signal_exit_code=$?
+  _signal_output=$(cat "$outfile")
+}
+
 test_names+=(
   test_signal_status_with_change_exits_130
   test_signal_status_no_change_exits_130_silent
@@ -66,7 +82,7 @@ test_signal_status_with_change_exits_130() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -81,35 +97,24 @@ test_signal_status_with_change_exits_130() {
           echo "$_MOCK_CHANGED"
         fi
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor status --pr 42 --interval 5
   cleanup_signal_tmpdir
   cleanup_mock_counter
 
-  if [ "$exit_code" -eq 130 ] \
-    && echo "$output" | grep -qF -- "--- change" \
-    && echo "$output" | grep -qF "check: CI" \
-    && echo "$output" | grep -qF "to: completed"; then
+  if [ "$_signal_exit_code" -eq 130 ] \
+    && echo "$_signal_output" | grep -qF -- "--- change" \
+    && echo "$_signal_output" | grep -qF "check: CI" \
+    && echo "$_signal_output" | grep -qF "to: completed"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: signal status with change (exit=$exit_code, output: $output)"
+    echo "FAIL: signal status with change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }
 
@@ -125,38 +130,27 @@ test_signal_status_no_change_exits_130_silent() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
     case "$*" in
       *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
       *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor status --pr 42 --interval 5
   cleanup_signal_tmpdir
 
-  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+  if [ "$_signal_exit_code" -eq 130 ] && [ -z "$_signal_output" ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: signal status no change (exit=$exit_code, output: $output)"
+    echo "FAIL: signal status no change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }
 
@@ -175,7 +169,7 @@ test_signal_status_sigterm_with_change_exits_130() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -190,34 +184,23 @@ test_signal_status_sigterm_with_change_exits_130() {
           echo "$_MOCK_CHANGED"
         fi
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor status --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor status --pr 42 --interval 5
   cleanup_signal_tmpdir
   cleanup_mock_counter
 
-  if [ "$exit_code" -eq 130 ] \
-    && echo "$output" | grep -qF "check: Build" \
-    && echo "$output" | grep -qF "check: CI"; then
+  if [ "$_signal_exit_code" -eq 130 ] \
+    && echo "$_signal_output" | grep -qF "check: Build" \
+    && echo "$_signal_output" | grep -qF "check: CI"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: SIGTERM status with change (exit=$exit_code, output: $output)"
+    echo "FAIL: SIGTERM status with change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }
 
@@ -239,7 +222,7 @@ test_signal_comments_with_change_exits_130() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -247,7 +230,7 @@ test_signal_comments_with_change_exits_130() {
     call_num=$(_mock_counter_next)
     case "$*" in
       *"pulls/comments/"*"/replies"*)
-        echo "ERROR: replies endpoint should not be called" >&2
+        echo "gh: replies endpoint should not be called: $*" >&2
         exit 1
         ;;
       *"pulls/42/comments"*"--paginate"*)
@@ -264,35 +247,24 @@ test_signal_comments_with_change_exits_130() {
           echo "$_MOCK_CHANGED_ISSUES"
         fi
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor comments --pr 42 --interval 5
   cleanup_signal_tmpdir
   cleanup_mock_counter
 
-  if [ "$exit_code" -eq 130 ] \
-    && echo "$output" | grep -qF -- "--- change" \
-    && echo "$output" | grep -qF "type: new-comment" \
-    && echo "$output" | grep -qF "count: 1"; then
+  if [ "$_signal_exit_code" -eq 130 ] \
+    && echo "$_signal_output" | grep -qF -- "--- change" \
+    && echo "$_signal_output" | grep -qF "type: new-comment" \
+    && echo "$_signal_output" | grep -qF "count: 1"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: signal comments with change (exit=$exit_code, output: $output)"
+    echo "FAIL: signal comments with change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }
 
@@ -309,7 +281,7 @@ test_signal_comments_no_change_exits_130_silent() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -320,31 +292,20 @@ test_signal_comments_no_change_exits_130_silent() {
       *"issues/42/comments"*"--paginate"*)
         echo "$_MOCK_ISSUES"
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor comments --pr 42 --interval 5
   cleanup_signal_tmpdir
 
-  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+  if [ "$_signal_exit_code" -eq 130 ] && [ -z "$_signal_output" ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: signal comments no change (exit=$exit_code, output: $output)"
+    echo "FAIL: signal comments no change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }
 
@@ -361,7 +322,7 @@ test_signal_comments_sigterm_no_change_exits_130() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -372,30 +333,19 @@ test_signal_comments_sigterm_no_change_exits_130() {
       *"issues/42/comments"*"--paginate"*)
         echo "$_MOCK_ISSUES"
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 
   _SIGNAL_TMPDIR=$(mktemp -d)
-  local outfile="$_SIGNAL_TMPDIR/out"
-
   _export_signal_mocks
-  bash "$script" monitor comments --pr 42 --interval 5 > "$outfile" 2>&1 &
-  local pid=$!
-
-  command sleep 3
-  kill -TERM "$pid" 2>/dev/null || true
-  wait "$pid" 2>/dev/null
-  local exit_code=$?
-
-  local output
-  output=$(cat "$outfile")
+  _run_and_signal monitor comments --pr 42 --interval 5
   cleanup_signal_tmpdir
 
-  if [ "$exit_code" -eq 130 ] && [ -z "$output" ]; then
+  if [ "$_signal_exit_code" -eq 130 ] && [ -z "$_signal_output" ]; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: SIGTERM comments no change (exit=$exit_code, output: $output)"
+    echo "FAIL: SIGTERM comments no change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }


### PR DESCRIPTION
## Summary

- Add graceful interrupt handling to `cmd_monitor_status` and `cmd_monitor_comments`
- Trap handler sets a flag variable only (safe in signal context)
- After each `sleep`, the flag is checked and one final poll cycle runs before exiting
- If unreported changes are found, they are printed to stdout, then exit 130
- If no changes since last poll, exit 130 silently (no output)
- `sleep "$sleep_for" || true` prevents `set -e` from masking the intended exit flow

## Changes

- `gh-pr-context`: Added `_monitor_interrupted` flag + `trap '_monitor_interrupted=1' INT TERM` in both monitor functions (21 lines added, 4 modified)
- `test/test_monitor_signal.sh`: 6 new tests covering status/comments with change, no change, and SIGTERM variants

## Test plan

- [x] All 38 existing `test_monitor_status.sh` tests pass
- [x] All 20 existing `test_monitor_comments.sh` tests pass (no regressions)
- [x] All 6 new `test_monitor_signal.sh` tests pass
- [x] Signal handler only sets a flag variable (no complex work in signal context)
- [x] Both `cmd_monitor_status` and `cmd_monitor_comments` have the handler
- [x] No-change final poll exits 130 silently
- [x] With-change final poll prints output then exits 130
- [x] `set -euo pipefail` strict mode preserved

Closes #47
