### PR TITLE
feat: bound monitor status API calls by timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Token-efficient PR context CLI for LLM coding assistants. Wraps `gh api` to fetc
 
 - [gh](https://cli.github.com/) (authenticated)
 - [jq](https://jqlang.github.io/jq/)
-- bash
+- bash 5.1+
 
 ## Install
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -8,6 +8,14 @@ die() {
   exit 1
 }
 
+require_bash_version() {
+  if [ "${BASH_VERSINFO[0]}" -lt 5 ] || { [ "${BASH_VERSINFO[0]}" -eq 5 ] && [ "${BASH_VERSINFO[1]}" -lt 1 ]; }; then
+    die "bash 5.1+ is required"
+  fi
+}
+
+require_bash_version
+
 # Parse a duration string (<number><s|m|h>) and output seconds.
 # Exits 1 on invalid input (empty, bare number, negative, non-numeric).
 parse_duration() {
@@ -445,10 +453,9 @@ _timed_gh_api() {
     return 124
   fi
 
-  local stdout_file stderr_file timed_out_file
+  local stdout_file stderr_file
   stdout_file=$(mktemp) || return 1
   stderr_file=$(mktemp) || { rm -f "$stdout_file"; return 1; }
-  timed_out_file=$(mktemp) || { rm -f "$stdout_file" "$stderr_file"; return 1; }
 
   gh api "$@" >"$stdout_file" 2>"$stderr_file" &
   local api_pid=$!
@@ -460,7 +467,6 @@ _timed_gh_api() {
   if [ "$completed_pid" = "$timer_pid" ]; then
     kill "$api_pid" 2>/dev/null || true
     wait "$api_pid" 2>/dev/null || true
-    echo 1 > "$timed_out_file"
     rc=124
   else
     kill "$timer_pid" 2>/dev/null || true
@@ -472,7 +478,7 @@ _timed_gh_api() {
     cat "$stderr_file" >&2
   fi
 
-  rm -f "$stdout_file" "$stderr_file" "$timed_out_file"
+  rm -f "$stdout_file" "$stderr_file"
   return "$rc"
 }
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -158,9 +158,10 @@ resolve_pr_number() {
 
 resolve_pr_head_sha() {
   local pr_number=$1
+  local timeout_secs="${2:-}"
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  gh api "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
+  _timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
 }
 
 validate_since_format() {
@@ -430,14 +431,81 @@ cmd_logs() {
   done <<< "$failed_pairs"
 }
 
+# _timed_gh_api runs gh api with an optional seconds deadline. It returns 124
+# when the deadline expires, matching the conventional timeout exit code.
+_timed_gh_api() {
+  local timeout_secs="${1:-}"
+  shift
+
+  if [ -z "$timeout_secs" ]; then
+    gh api "$@"
+    return
+  fi
+  if [ "$timeout_secs" -le 0 ]; then
+    return 124
+  fi
+
+  local stdout_file stderr_file timed_out_file
+  stdout_file=$(mktemp) || return 1
+  stderr_file=$(mktemp) || { rm -f "$stdout_file"; return 1; }
+  timed_out_file=$(mktemp) || { rm -f "$stdout_file" "$stderr_file"; return 1; }
+
+  gh api "$@" >"$stdout_file" 2>"$stderr_file" &
+  local api_pid=$!
+  command sleep "$timeout_secs" &
+  local timer_pid=$!
+
+  local rc=0 completed_pid=""
+  wait -n -p completed_pid "$api_pid" "$timer_pid" || rc=$?
+  if [ "$completed_pid" = "$timer_pid" ]; then
+    kill "$api_pid" 2>/dev/null || true
+    wait "$api_pid" 2>/dev/null || true
+    echo 1 > "$timed_out_file"
+    rc=124
+  else
+    kill "$timer_pid" 2>/dev/null || true
+    wait "$timer_pid" 2>/dev/null || true
+  fi
+
+  if [ "$rc" -ne 124 ]; then
+    cat "$stdout_file"
+    cat "$stderr_file" >&2
+  fi
+
+  rm -f "$stdout_file" "$stderr_file" "$timed_out_file"
+  return "$rc"
+}
+
+monitor_call_timeout() {
+  local timeout_secs="${1:-}" timeout_input="${2:-}"
+  if [ -z "$timeout_secs" ]; then
+    echo ""
+    return 0
+  fi
+
+  local remaining=$((timeout_secs - SECONDS))
+  if [ "$remaining" -le 0 ]; then
+    echo "monitor timed out after $timeout_input" >&2
+    return 2
+  fi
+  echo "$remaining"
+}
+
+monitor_api_timeout_warning() {
+  echo "gh api call timed out; retrying next poll" >&2
+}
+
 # capture_check_snapshot fetches check-runs for a given SHA via the GitHub API
 # and returns a normalized JSON array of {name, status, conclusion} objects
 # sorted by check name, suitable for diffing between poll cycles.
 capture_check_snapshot() {
-  local owner_repo=$1 sha=$2
+  local owner_repo=$1 sha=$2 timeout_secs="${3:-}"
   local checks_json
-  checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \
-    || die "failed to fetch check runs for SHA $sha"
+  if checks_json=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/commits/$sha/check-runs" --paginate); then
+    :
+  else
+    return $?
+  fi
   echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
 }
 
@@ -507,7 +575,8 @@ cmd_monitor_status() {
     || die "failed to resolve head SHA for PR #$pr_number"
 
   local prev_snapshot
-  prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha")
+  prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha") \
+    || die "failed to fetch check runs for SHA $prev_sha"
   if [ -n "$check_filter" ]; then
     prev_snapshot=$(echo "$prev_snapshot" | jq --arg name "$check_filter" 'map(select(.name == $name))')
   fi
@@ -539,7 +608,20 @@ cmd_monitor_status() {
     fi
 
     local cur_sha
-    if ! cur_sha=$(resolve_pr_head_sha "$pr_number" 2>&1); then
+    local call_timeout
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    local api_rc=0
+    if cur_sha=$(resolve_pr_head_sha "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
       die "failed to re-resolve head SHA for PR #$pr_number"
     fi
 
@@ -552,7 +634,18 @@ cmd_monitor_status() {
     fi
 
     local cur_snapshot
-    if ! cur_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" 2>&1); then
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
       die "failed to fetch check runs during poll"
     fi
     if [ -n "$check_filter" ]; then

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -14,10 +14,21 @@ _mock_counter_next() {
   echo "$val"
 }
 
+_mock_call_should_timeout() {
+  local call_num=$1 timeout_call
+  for timeout_call in $_MOCK_TIMEOUT_CALLS; do
+    if [ "$call_num" = "$timeout_call" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 # setup_mocks defines mocked `git` and `sleep` shell functions used by the test harness;
 # `git` responds with fixed repo URL and branch values for known invocations and exits
 # nonzero for others; `sleep` is a no-op so polling tests complete instantly.
 setup_mocks() {
+  _MOCK_TIMEOUT_CALLS=""
   git() {
     case "$*" in
       "rev-parse --git-dir") echo ".git" ;;
@@ -156,6 +167,64 @@ setup_mocks_monitor_api_failure() {
   }
 }
 
+setup_mocks_monitor_api_timeout() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  _MOCK_TIMEOUT_CALLS="$3"
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_api_timeout_no_change() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$1"
+  _MOCK_TIMEOUT_CALLS="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 # setup_mocks_monitor_no_change configures git/gh mocks where data never changes,
 # suitable for timeout tests. Defines a sleep() wrapper that calls the real system
 # sleep so SECONDS advances correctly and no leaked mock from other tests interferes.
@@ -183,14 +252,14 @@ setup_mocks_monitor_no_change() {
 # run_script_with_real_sleep runs the script with mocked git/gh but real sleep,
 # so SECONDS-based timeout tests work correctly.
 run_script_with_real_sleep() {
-  export -f git gh sleep _mock_counter_next
-  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
+  export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
   timeout 15 bash "$script" "$@" </dev/null
 }
 
 run_script() {
-  export -f git gh sleep _mock_counter_next
-  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
+  export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
   timeout 15 bash "$script" "$@" </dev/null
 }
 
@@ -210,6 +279,9 @@ test_names+=(
   test_monitor_status_no_pr_exits_nonzero
   test_monitor_status_no_pr_stderr_message
   test_monitor_status_api_failure_exits_nonzero
+  test_monitor_status_check_api_timeout_continues
+  test_monitor_status_sha_api_timeout_continues
+  test_monitor_status_overall_timeout_after_api_timeout
   test_monitor_no_subcommand_exits_nonzero
   test_monitor_help_exits_zero
   test_monitor_status_help_exits_zero
@@ -414,6 +486,58 @@ test_monitor_status_api_failure_exits_nonzero() {
   else
     fail=$((fail + 1))
     echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+test_monitor_status_check_api_timeout_continues() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_api_timeout "$initial" "$changed" "4"
+  local output exit_code=0
+  output=$(run_script monitor status --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: check-runs timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_sha_api_timeout_continues() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_api_timeout "$initial" "$changed" "3"
+  local output exit_code=0
+  output=$(run_script monitor status --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_overall_timeout_after_api_timeout() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_api_timeout_no_change "$initial" "4"
+  local output exit_code=0
+  output=$(run_script_with_real_sleep monitor status --pr 42 --interval 1 --timeout 2s 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 2 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: overall timeout should still fire after API timeout (exit=$exit_code, output: $output)"
   fi
 }
 


### PR DESCRIPTION
## Summary
- add a per-call deadline wrapper for `monitor status` GitHub API polling calls
- retry the next poll with a one-line stderr warning when a SHA or check-runs API call times out
- keep the overall `--timeout` deadline enforced after skipped timed-out polls

Closes #65.

## Testing
- `bash test/run.sh` (244 passed, 0 failed)