### PR TITLE
feat: add monitor --all

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -105,11 +105,12 @@ usage() {
 }
 
 usage_monitor() {
-  echo "usage: gh-pr-context monitor <sub-command> [options]"
+  echo "usage: gh-pr-context monitor <sub-command|--all> [options]"
   echo ""
   echo "sub-commands:"
   echo "  status    Monitor CI check state changes"
   echo "  comments  Monitor new comments on the PR"
+  echo "  --all     Monitor CI check and comment changes"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -133,6 +134,16 @@ usage_monitor_status() {
 
 usage_monitor_comments() {
   echo "usage: gh-pr-context monitor comments [options]"
+  echo ""
+  echo "options:"
+  echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
+  echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
+  echo "  -h, --help           Show this message"
+}
+
+usage_monitor_all() {
+  echo "usage: gh-pr-context monitor --all [options]"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -794,9 +805,184 @@ cmd_monitor_comments() {
   done
 }
 
+cmd_monitor_all() {
+  local pr_number="" interval=30 timeout_input="" timeout_secs=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] || die "missing value for --pr"
+        pr_number="$2"; shift 2
+        ;;
+      --interval)
+        [ $# -ge 2 ] || die "missing value for --interval"
+        interval="$2"; shift 2
+        if ! echo "$interval" | grep -qE '^[1-9][0-9]*$'; then
+          die "invalid --interval value: $interval (expected a positive integer)"
+        fi
+        ;;
+      --timeout)
+        [ $# -ge 2 ] || die "missing value for --timeout"
+        timeout_input="$2"; shift 2
+        timeout_secs=$(parse_duration "$timeout_input")
+        ;;
+      --check)
+        die "unknown option: --check (only valid with monitor status)"
+        ;;
+      -h|--help) usage_monitor_all; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+
+  check_deps
+
+  if [ -z "$pr_number" ]; then
+    pr_number=$(resolve_pr_number)
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
+  local prev_sha
+  prev_sha=$(resolve_pr_head_sha "$pr_number") \
+    || die "failed to resolve head SHA for PR #$pr_number"
+
+  local prev_status_snapshot
+  prev_status_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha") \
+    || die "failed to fetch check runs for SHA $prev_sha"
+
+  local initial_comment_snapshot
+  initial_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+  local _monitor_interrupted=0
+  trap '_monitor_interrupted=1' INT TERM
+
+  SECONDS=0
+  while true; do
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local sleep_for="$interval"
+    if [ -n "$timeout_secs" ]; then
+      local remaining=$((timeout_secs - SECONDS))
+      if [ "$remaining" -lt "$sleep_for" ]; then
+        sleep_for="$remaining"
+      fi
+    fi
+    sleep "$sleep_for" || true
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then
+      :
+    elif [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local cur_sha call_timeout api_rc=0
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_sha=$(resolve_pr_head_sha "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to re-resolve head SHA for PR #$pr_number"
+    fi
+
+    if [ "$cur_sha" != "$prev_sha" ]; then
+      echo "--- change"
+      echo "type: new-commit"
+      echo "sha: $cur_sha"
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+      exit 0
+    fi
+
+    local cur_status_snapshot
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_status_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to fetch check runs during poll"
+    fi
+
+    local cur_comment_snapshot
+    cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+    local status_changes
+    status_changes=$(printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '
+      . as $snapshots |
+      ($snapshots[0]) as $old |
+      ($snapshots[1]) as $new |
+      (($old | map(.name)) + ($new | map(.name))) | unique | sort |
+      map(
+        . as $name |
+        ($old | map(select(.name == $name)) | first) as $o |
+        ($new | map(select(.name == $name)) | first) as $n |
+        if $o == null then
+          {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
+        elif $n == null then
+          {check: $name, from: $o.status, to: "absent", conclusion: null}
+        elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
+          {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
+        else
+          empty
+        end
+      )
+    ')
+
+    local status_change_count
+    status_change_count=$(echo "$status_changes" | jq 'length' | tr -d '\r')
+
+    local new_comment_ids new_comment_count
+    new_comment_ids=$(comm -23 <(echo "$cur_comment_snapshot") <(echo "$initial_comment_snapshot"))
+    new_comment_count=$(echo "$new_comment_ids" | grep -c '.' || true)
+
+    if [ "$status_change_count" -gt 0 ]; then
+      echo "$status_changes" | jq -r '.[] |
+        "--- change\n" +
+        "type: status\n" +
+        "check: \(.check)\n" +
+        "from: \(.from)\n" +
+        "to: \(.to)" +
+        if (.conclusion != null and .to != "absent") then "\nconclusion: \(.conclusion)" else "" end'
+    fi
+
+    if [ "$new_comment_count" -gt 0 ]; then
+      echo "--- change"
+      echo "type: new-comment"
+      echo "count: $new_comment_count"
+    fi
+
+    if [ "$status_change_count" -gt 0 ] || [ "$new_comment_count" -gt 0 ]; then
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+      exit 0
+    fi
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+
+    prev_sha="$cur_sha"
+    prev_status_snapshot="$cur_status_snapshot"
+  done
+}
+
 # cmd_monitor is the top-level dispatcher for the monitor command, routing
-# sub-commands (status, comments) to their handlers. Exits 1 with usage when no
-# sub-command is provided.
+# sub-commands (status, comments, --all) to their handlers. Exits 1 with usage
+# when no sub-command is provided.
 cmd_monitor() {
   if [ $# -eq 0 ]; then
     die "missing monitor sub-command (see 'gh-pr-context monitor --help')"
@@ -808,6 +994,7 @@ cmd_monitor() {
   case "$sub_command" in
     status) cmd_monitor_status "$@" ;;
     comments) cmd_monitor_comments "$@" ;;
+    --all) cmd_monitor_all "$@" ;;
     -h|--help) usage_monitor; exit 0 ;;
     *) die "unknown monitor sub-command: $sub_command" ;;
   esac

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -530,13 +530,27 @@ capture_check_snapshot() {
 # replies) and issue comment IDs for a given PR, returning a sorted newline-
 # separated list suitable for set-difference comparison between poll cycles.
 capture_comment_id_snapshot() {
-  local owner_repo=$1 pr_number=$2
+  local owner_repo=$1 pr_number=$2 timeout_secs="${3:-}"
+  local review_raw issue_raw review_rc issue_rc
+  if review_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number/comments" --paginate); then
+    :
+  else
+    review_rc=$?
+    if [ "$review_rc" -eq 124 ]; then return 124; fi
+    die "failed to fetch review comments for PR #$pr_number"
+  fi
+  if issue_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/issues/$pr_number/comments" --paginate); then
+    :
+  else
+    issue_rc=$?
+    if [ "$issue_rc" -eq 124 ]; then return 124; fi
+    die "failed to fetch issue comments for PR #$pr_number"
+  fi
+
   local review_ids issue_ids
-  review_ids=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate \
-    | jq -r '[.[] | select(.in_reply_to_id == null) | .id] | sort[]' | tr -d '\r') \
+  review_ids=$(echo "$review_raw" | jq -r '[.[] | select(.in_reply_to_id == null) | .id] | sort[]' | tr -d '\r') \
     || die "failed to fetch review comments for PR #$pr_number"
-  issue_ids=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate \
-    | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
+  issue_ids=$(echo "$issue_raw" | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
     || die "failed to fetch issue comments for PR #$pr_number"
   { echo "$review_ids"; echo "$issue_ids"; } | sort -n | grep -v '^$' || true
 }
@@ -921,7 +935,20 @@ cmd_monitor_all() {
     fi
 
     local cur_comment_snapshot
-    cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to fetch comments during poll"
+    fi
 
     local status_changes
     status_changes=$(printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 NEW_SHA="def456abc123def456abc123def456abc123def4"
@@ -176,6 +177,52 @@ setup_mocks_monitor_all_api_failure() {
   }
 }
 
+setup_mocks_monitor_all_comment_api_timeout() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$5"
+  _MOCK_CHANGED_ISSUES="$6"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+        if [ "$call_num" -eq 2 ]; then
+          exit 124
+        elif [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 run_script() {
   export -f git gh sleep _mock_counter_next
   export HEAD_SHA NEW_SHA
@@ -206,6 +253,7 @@ test_names+=(
   test_monitor_all_auto_detect
   test_monitor_all_accepts_timeout
   test_monitor_all_api_failure_exits_nonzero
+  test_monitor_all_comment_api_timeout_continues
   test_monitor_all_help_exits_zero
   test_monitor_help_lists_all
 )
@@ -381,6 +429,25 @@ test_monitor_all_api_failure_exits_nonzero() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all API failure should exit non-zero"
+  fi
+}
+
+test_monitor_all_comment_api_timeout_continues() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_all_comment_api_timeout "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all comment API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+_MOCK_SHA_COUNTER_FILE=""
+_MOCK_CHECK_COUNTER_FILE=""
+_MOCK_REVIEW_COUNTER_FILE=""
+_MOCK_ISSUE_COUNTER_FILE=""
+
+_mock_counter_next() {
+  local file=$1 val
+  val=$(cat "$file")
+  val=$((val + 1))
+  echo "$val" > "$file"
+  echo "$val"
+}
+
+setup_counter_files() {
+  _MOCK_SHA_COUNTER_FILE=$(mktemp)
+  _MOCK_CHECK_COUNTER_FILE=$(mktemp)
+  _MOCK_REVIEW_COUNTER_FILE=$(mktemp)
+  _MOCK_ISSUE_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_SHA_COUNTER_FILE"
+  echo 0 > "$_MOCK_CHECK_COUNTER_FILE"
+  echo 0 > "$_MOCK_REVIEW_COUNTER_FILE"
+  echo 0 > "$_MOCK_ISSUE_COUNTER_FILE"
+}
+
+setup_mocks() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  sleep() {
+    :
+  }
+}
+
+setup_mocks_monitor_all() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$5"
+  _MOCK_CHANGED_ISSUES="$6"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo "42" ;;
+      *"pulls/42"*"--paginate"*"--jq"*)
+        _mock_counter_next "$_MOCK_SHA_COUNTER_FILE" >/dev/null
+        echo "$HEAD_SHA"
+        ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_new_commit() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$HEAD_SHA"
+        else
+          echo "$NEW_SHA"
+        fi
+        ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_no_change() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_api_failure() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          exit 1
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+run_script() {
+  export -f git gh sleep _mock_counter_next
+  export HEAD_SHA NEW_SHA
+  export _MOCK_INITIAL_CHECKS _MOCK_CHANGED_CHECKS
+  export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
+  export _MOCK_SHA_COUNTER_FILE _MOCK_CHECK_COUNTER_FILE _MOCK_REVIEW_COUNTER_FILE _MOCK_ISSUE_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
+run_script_with_real_sleep() {
+  run_script "$@"
+}
+
+cleanup_mock_counters() {
+  for file in "$_MOCK_SHA_COUNTER_FILE" "$_MOCK_CHECK_COUNTER_FILE" "$_MOCK_REVIEW_COUNTER_FILE" "$_MOCK_ISSUE_COUNTER_FILE"; do
+    [ -n "$file" ] && [ -f "$file" ] && rm -f "$file"
+  done
+}
+
+test_names+=(
+  test_monitor_all_status_only
+  test_monitor_all_comments_only
+  test_monitor_all_mixed_changes_status_first
+  test_monitor_all_new_commit
+  test_monitor_all_check_flag_rejected
+  test_monitor_all_timeout_exits_two
+  test_monitor_all_explicit_pr
+  test_monitor_all_auto_detect
+  test_monitor_all_accepts_timeout
+  test_monitor_all_api_failure_exits_nonzero
+  test_monitor_all_help_exits_zero
+  test_monitor_help_lists_all
+)
+
+test_monitor_all_status_only() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  local initial_reviews='[]'
+  local initial_issues='[{"id":201}]'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "$initial_reviews" "$initial_issues" "$initial_reviews" "$initial_issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all status-only change (output: $output)"
+  fi
+}
+
+test_monitor_all_comments_only() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_all "$checks" "$checks" "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1" \
+    && ! echo "$output" | grep -qF "type: status"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all comment-only change (output: $output)"
+  fi
+}
+
+test_monitor_all_mixed_changes_status_first() {
+  local initial_checks='{"total_count":2,"check_runs":[{"name":"Test","status":"queued","conclusion":null},{"name":"Build","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":2,"check_runs":[{"name":"Test","status":"completed","conclusion":"failure"},{"name":"Build","status":"completed","conclusion":"success"}]}'
+  local initial_reviews='[]'
+  local initial_issues='[{"id":201}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_issues='[{"id":201},{"id":202}]'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output first_type last_type first_check second_check comment_count
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  first_type=$(echo "$output" | grep "^type:" | head -1 | tr -d '\r')
+  last_type=$(echo "$output" | grep "^type:" | tail -1 | tr -d '\r')
+  first_check=$(echo "$output" | grep "^check:" | head -1 | sed 's/check: //' | tr -d '\r')
+  second_check=$(echo "$output" | grep "^check:" | tail -1 | sed 's/check: //' | tr -d '\r')
+  comment_count=$(echo "$output" | grep "type: new-comment" | wc -l | tr -d '[:space:]')
+  if [ "$first_type" = "type: status" ] \
+    && [ "$last_type" = "type: new-comment" ] \
+    && [ "$first_check" = "Build" ] \
+    && [ "$second_check" = "Test" ] \
+    && [ "$comment_count" = "1" ] \
+    && echo "$output" | grep -qF "count: 2"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all mixed output ordering (output: $output)"
+  fi
+}
+
+test_monitor_all_new_commit() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[]'
+  local issues='[]'
+  setup_mocks_monitor_all_new_commit "$checks" "$reviews" "$issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-commit" \
+    && echo "$output" | grep -qF "sha: $NEW_SHA" \
+    && ! echo "$output" | grep -qF "type: status" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all new commit (output: $output)"
+  fi
+}
+
+test_monitor_all_check_flag_rejected() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --check CI 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --check (only valid with monitor status)"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --check should be rejected (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_timeout_exits_two() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[{"id":101,"in_reply_to_id":null}]'
+  local issues='[]'
+  setup_mocks_monitor_all_no_change "$checks" "$reviews" "$issues"
+  local exit_code=0
+  run_script_with_real_sleep monitor --all --pr 42 --interval 1 --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all timeout should exit 2 (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_explicit_pr() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"queued","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all explicit --pr should succeed (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_auto_detect() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  setup_mocks_monitor_all "$checks" "$checks" "[]" "[]" "$changed_reviews" "[]"
+  local output
+  output=$(run_script monitor --all --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all auto-detect should work (output: $output)"
+  fi
+}
+
+test_monitor_all_accepts_timeout() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"queued","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 --timeout 5m >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all should accept --timeout 5m (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_api_failure_exits_nonzero() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all_api_failure "$checks" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all API failure should exit non-zero"
+  fi
+}
+
+test_monitor_all_help_exits_zero() {
+  assert_exit 0 "monitor --all --help exits 0" bash "$script" monitor --all --help
+  assert_exit 0 "monitor --all -h exits 0" bash "$script" monitor --all -h
+}
+
+test_monitor_help_lists_all() {
+  local output
+  output=$(bash "$script" monitor --help 2>&1)
+  if echo "$output" | grep -qF -- "--all"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --help should list --all (output: $output)"
+  fi
+}


### PR DESCRIPTION
## Summary
- Add gh-pr-context monitor --all for combined status/comment polling
- Report status changes first in deterministic check-name order, then a new-comment count block
- Reject --check for monitor --all and cover explicit PR, auto-detect, timeout, mixed, status-only, comment-only, new-commit, and failure paths

Closes #48

## Tests
- ash test/run.sh (257 passed, 0 failed)