### PR TITLE
test: harden monitor validation coverage

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -754,7 +754,7 @@ cmd_monitor_comments() {
         timeout_secs=$(parse_duration "$timeout_input")
         ;;
       --check)
-        die "--check is not supported for monitor comments"
+        die "unknown option: --check (only valid with monitor status)"
         ;;
       -h|--help) usage_monitor_comments; exit 0 ;;
       *) die "unknown option: $1" ;;

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -248,6 +248,10 @@ test_names+=(
   test_monitor_all_mixed_changes_status_first
   test_monitor_all_new_commit
   test_monitor_all_check_flag_rejected
+  test_monitor_all_missing_interval_value_exits_nonzero
+  test_monitor_all_invalid_interval_exits_nonzero
+  test_monitor_all_zero_interval_exits_nonzero
+  test_monitor_all_negative_interval_exits_nonzero
   test_monitor_all_timeout_exits_two
   test_monitor_all_explicit_pr
   test_monitor_all_auto_detect
@@ -348,12 +352,56 @@ test_monitor_all_new_commit() {
 
 test_monitor_all_check_flag_rejected() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --check CI 2>&1) || exit_code=$?
+  output=$(bash "$script" monitor --all --check ci.yml 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all --check should be rejected (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_missing_interval_value_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_invalid_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_zero_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -207,6 +207,8 @@ test_names+=(
   test_monitor_comments_missing_pr_value_exits_nonzero
   test_monitor_comments_missing_interval_value_exits_nonzero
   test_monitor_comments_invalid_interval_exits_nonzero
+  test_monitor_comments_zero_interval_exits_nonzero
+  test_monitor_comments_negative_interval_exits_nonzero
   test_monitor_comments_missing_timeout_value_exits_nonzero
   test_monitor_comments_invalid_timeout_exits_nonzero
 )
@@ -325,13 +327,13 @@ test_monitor_comments_output_format() {
 }
 
 test_monitor_comments_check_flag_rejected() {
-  local output
-  output=$(bash "$script" monitor comments --check CI 2>&1) || true
-  if echo "$output" | grep -qF -- "--check is not supported for monitor comments"; then
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --check ci.yml 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF -- "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: --check should be rejected (output: $output)"
+    echo "FAIL: --check should be rejected for monitor comments (exit=$exit_code, output: $output)"
   fi
 }
 
@@ -434,11 +436,47 @@ test_monitor_comments_missing_pr_value_exits_nonzero() {
 }
 
 test_monitor_comments_missing_interval_value_exits_nonzero() {
-  assert_exit 1 "monitor comments --interval without value exits 1" bash "$script" monitor comments --interval
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
 }
 
 test_monitor_comments_invalid_interval_exits_nonzero() {
-  assert_exit 1 "monitor comments --interval invalid exits 1" bash "$script" monitor comments --interval abc
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_comments_zero_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_comments_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 test_monitor_comments_missing_timeout_value_exits_nonzero() {

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -290,6 +290,7 @@ test_names+=(
   test_monitor_status_missing_interval_value_exits_nonzero
   test_monitor_status_invalid_interval_exits_nonzero
   test_monitor_status_zero_interval_exits_nonzero
+  test_monitor_status_negative_interval_exits_nonzero
   test_usage_lists_monitor
   test_monitor_status_timeout_exits_two
   test_monitor_status_timeout_stderr_message
@@ -574,19 +575,51 @@ test_monitor_status_missing_pr_value_exits_nonzero() {
 # test_monitor_status_missing_interval_value_exits_nonzero verifies that --interval
 # without a value exits 1 with a clear error message.
 test_monitor_status_missing_interval_value_exits_nonzero() {
-  assert_exit 1 "monitor status --interval without value exits 1" bash "$script" monitor status --interval
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_invalid_interval_exits_nonzero verifies that --interval with
 # a non-numeric value exits 1.
 test_monitor_status_invalid_interval_exits_nonzero() {
-  assert_exit 1 "monitor status --interval abc exits 1" bash "$script" monitor status --interval abc
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_zero_interval_exits_nonzero verifies that --interval 0 is
 # rejected (zero is not a positive integer).
 test_monitor_status_zero_interval_exits_nonzero() {
-  assert_exit 1 "monitor status --interval 0 exits 1" bash "$script" monitor status --interval 0
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_usage_lists_monitor verifies that the main --help output includes the monitor


### PR DESCRIPTION
## Summary
- Align monitor comments --check with the status-only error wording
- Add stderr-checked validation coverage for invalid/missing --interval values across monitor status/comments/all
- Cover monitor --all --check ci.yml with the canonical status-only error contract

Closes #49

## Tests
- ash test/run.sh (265 passed, 0 failed)