### PR TITLE
Sprint 3: monitor completion and delivery workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Token-efficient PR context CLI for LLM coding assistants. Wraps `gh api` to fetc
 
 - [gh](https://cli.github.com/) (authenticated)
 - [jq](https://jqlang.github.io/jq/)
-- bash
+- bash 5.1+
 
 ## Install
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -129,7 +129,6 @@ usage_monitor_status() {
   echo "  --interval <sec>     Poll interval in seconds (default: 30)"
   echo "  --check <name>       Watch only the named check (case-sensitive)"
   echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
-  echo "  --check <name>       Watch only the named check (case-sensitive)"
   echo "  -h, --help           Show this message"
 }
 
@@ -161,15 +160,24 @@ resolve_owner_repo() {
   echo "$owner_repo"
 }
 
+# resolve_pr_number prints the open PR number for the current branch. The
+# optional timeout argument is passed through to _timed_gh_api.
 resolve_pr_number() {
+  local timeout_secs="${1:-}"
   local branch
   branch=$(git rev-parse --abbrev-ref HEAD) || die "failed to determine current branch"
   local owner_repo
   owner_repo=$(resolve_owner_repo)
   local owner=${owner_repo%%/*}
   local repo=${owner_repo#*/}
-  local pr_data
-  pr_data=$(gh api "repos/$owner/$repo/pulls?head=$owner:$branch" --paginate --jq '.[0].number' | tr -d '\r') || die "failed to look up PR for branch '$branch'"
+  local pr_data rc
+  if pr_data=$(_timed_gh_api "$timeout_secs" "repos/$owner/$repo/pulls?head=$owner:$branch" --paginate --jq '.[0].number' | tr -d '\r'); then
+    :
+  else
+    rc=$?
+    if [ "$rc" -eq 124 ]; then return 124; fi
+    die "failed to look up PR for branch '$branch'"
+  fi
   if [ -z "$pr_data" ] || [ "$pr_data" = "null" ]; then
     die "no open PR found for branch '$branch'"
   fi
@@ -603,7 +611,7 @@ capture_comment_id_snapshot() {
     || die "failed to fetch review comments for PR #$pr_number"
   issue_ids=$(echo "$issue_raw" | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
     || die "failed to fetch issue comments for PR #$pr_number"
-  { echo "$review_ids"; echo "$issue_ids"; } | sort -n | grep -v '^$' || true
+  { echo "$review_ids"; echo "$issue_ids"; } | sort | grep -v '^$' || true
 }
 
 # cmd_monitor_status polls the GitHub check-runs API at a configurable interval,
@@ -885,19 +893,31 @@ cmd_monitor_all() {
 
   check_deps
 
-  if [ -z "$pr_number" ]; then
-    pr_number=$(resolve_pr_number)
-  fi
-
-  local owner_repo
-  owner_repo=$(resolve_owner_repo)
-
   local _monitor_interrupted=0
   trap '_monitor_interrupted=1' INT TERM
 
   SECONDS=0
 
   local call_timeout api_rc=0
+  if [ -z "$pr_number" ]; then
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if pr_number=$(resolve_pr_number "$call_timeout"); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        echo "monitor timed out after $timeout_input" >&2
+        exit 2
+      fi
+      exit "$api_rc"
+    fi
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
   local prev_sha
   if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
     exit 2

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -513,6 +513,22 @@ monitor_call_timeout() {
   echo "$remaining"
 }
 
+# remaining_timeout_since returns the unspent seconds from a timeout that
+# started at start_seconds, or an empty value when no timeout is active.
+remaining_timeout_since() {
+  local timeout_secs="${1:-}" start_seconds=$2
+  if [ -z "$timeout_secs" ]; then
+    echo ""
+    return 0
+  fi
+
+  local remaining=$((timeout_secs - (SECONDS - start_seconds)))
+  if [ "$remaining" -lt 0 ]; then
+    remaining=0
+  fi
+  echo "$remaining"
+}
+
 # monitor_api_timeout_warning emits the retry notice for per-call gh api timeouts.
 monitor_api_timeout_warning() {
   echo "gh api call timed out; retrying next poll" >&2
@@ -564,14 +580,17 @@ compute_status_diff() {
 capture_comment_id_snapshot() {
   local owner_repo=$1 pr_number=$2 timeout_secs="${3:-}"
   local review_raw issue_raw review_rc issue_rc
-  if review_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number/comments" --paginate); then
+  local started_at=$SECONDS call_timeout
+  call_timeout=$(remaining_timeout_since "$timeout_secs" "$started_at")
+  if review_raw=$(_timed_gh_api "$call_timeout" "repos/$owner_repo/pulls/$pr_number/comments" --paginate); then
     :
   else
     review_rc=$?
     if [ "$review_rc" -eq 124 ]; then return 124; fi
     die "failed to fetch review comments for PR #$pr_number"
   fi
-  if issue_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/issues/$pr_number/comments" --paginate); then
+  call_timeout=$(remaining_timeout_since "$timeout_secs" "$started_at")
+  if issue_raw=$(_timed_gh_api "$call_timeout" "repos/$owner_repo/issues/$pr_number/comments" --paginate); then
     :
   else
     issue_rc=$?
@@ -873,21 +892,56 @@ cmd_monitor_all() {
   local owner_repo
   owner_repo=$(resolve_owner_repo)
 
-  local prev_sha
-  prev_sha=$(resolve_pr_head_sha "$pr_number") \
-    || die "failed to resolve head SHA for PR #$pr_number"
-
-  local prev_status_snapshot
-  prev_status_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha") \
-    || die "failed to fetch check runs for SHA $prev_sha"
-
-  local initial_comment_snapshot
-  initial_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
-
   local _monitor_interrupted=0
   trap '_monitor_interrupted=1' INT TERM
 
   SECONDS=0
+
+  local call_timeout api_rc=0
+  local prev_sha
+  if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+    exit 2
+  fi
+  if prev_sha=$(resolve_pr_head_sha "$pr_number" "$call_timeout" 2>/dev/null); then
+    :
+  else
+    api_rc=$?
+    if [ "$api_rc" -eq 124 ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+    die "failed to resolve head SHA for PR #$pr_number"
+  fi
+
+  local prev_status_snapshot
+  if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+    exit 2
+  fi
+  if prev_status_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha" "$call_timeout" 2>/dev/null); then
+    :
+  else
+    api_rc=$?
+    if [ "$api_rc" -eq 124 ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+    die "failed to fetch check runs for SHA $prev_sha"
+  fi
+
+  local initial_comment_snapshot
+  if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+    exit 2
+  fi
+  if initial_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number" "$call_timeout" 2>/dev/null); then
+    :
+  else
+    api_rc=$?
+    if [ "$api_rc" -eq 124 ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+    die "failed to fetch comments for PR #$pr_number"
+  fi
   while true; do
     if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
       echo "monitor timed out after $timeout_input" >&2

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -105,11 +105,12 @@ usage() {
 }
 
 usage_monitor() {
-  echo "usage: gh-pr-context monitor <sub-command> [options]"
+  echo "usage: gh-pr-context monitor <sub-command|--all> [options]"
   echo ""
   echo "sub-commands:"
   echo "  status    Monitor CI check state changes"
   echo "  comments  Monitor new comments on the PR"
+  echo "  --all     Monitor CI check and comment changes"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -133,6 +134,16 @@ usage_monitor_status() {
 
 usage_monitor_comments() {
   echo "usage: gh-pr-context monitor comments [options]"
+  echo ""
+  echo "options:"
+  echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
+  echo "  --interval <sec>     Poll interval in seconds (default: 30)"
+  echo "  --timeout <dur>      Maximum time to poll (e.g. 30s, 5m, 1h)"
+  echo "  -h, --help           Show this message"
+}
+
+usage_monitor_all() {
+  echo "usage: gh-pr-context monitor --all [options]"
   echo ""
   echo "options:"
   echo "  --pr <number>        PR number (auto-detected from branch if omitted)"
@@ -794,9 +805,184 @@ cmd_monitor_comments() {
   done
 }
 
+cmd_monitor_all() {
+  local pr_number="" interval=30 timeout_input="" timeout_secs=""
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --pr)
+        [ $# -ge 2 ] || die "missing value for --pr"
+        pr_number="$2"; shift 2
+        ;;
+      --interval)
+        [ $# -ge 2 ] || die "missing value for --interval"
+        interval="$2"; shift 2
+        if ! echo "$interval" | grep -qE '^[1-9][0-9]*$'; then
+          die "invalid --interval value: $interval (expected a positive integer)"
+        fi
+        ;;
+      --timeout)
+        [ $# -ge 2 ] || die "missing value for --timeout"
+        timeout_input="$2"; shift 2
+        timeout_secs=$(parse_duration "$timeout_input")
+        ;;
+      --check)
+        die "unknown option: --check (only valid with monitor status)"
+        ;;
+      -h|--help) usage_monitor_all; exit 0 ;;
+      *) die "unknown option: $1" ;;
+    esac
+  done
+
+  check_deps
+
+  if [ -z "$pr_number" ]; then
+    pr_number=$(resolve_pr_number)
+  fi
+
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+
+  local prev_sha
+  prev_sha=$(resolve_pr_head_sha "$pr_number") \
+    || die "failed to resolve head SHA for PR #$pr_number"
+
+  local prev_status_snapshot
+  prev_status_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha") \
+    || die "failed to fetch check runs for SHA $prev_sha"
+
+  local initial_comment_snapshot
+  initial_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+  local _monitor_interrupted=0
+  trap '_monitor_interrupted=1' INT TERM
+
+  SECONDS=0
+  while true; do
+    if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local sleep_for="$interval"
+    if [ -n "$timeout_secs" ]; then
+      local remaining=$((timeout_secs - SECONDS))
+      if [ "$remaining" -lt "$sleep_for" ]; then
+        sleep_for="$remaining"
+      fi
+    fi
+    sleep "$sleep_for" || true
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then
+      :
+    elif [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+
+    local cur_sha call_timeout api_rc=0
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_sha=$(resolve_pr_head_sha "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to re-resolve head SHA for PR #$pr_number"
+    fi
+
+    if [ "$cur_sha" != "$prev_sha" ]; then
+      echo "--- change"
+      echo "type: new-commit"
+      echo "sha: $cur_sha"
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+      exit 0
+    fi
+
+    local cur_status_snapshot
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_status_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to fetch check runs during poll"
+    fi
+
+    local cur_comment_snapshot
+    cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+
+    local status_changes
+    status_changes=$(printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '
+      . as $snapshots |
+      ($snapshots[0]) as $old |
+      ($snapshots[1]) as $new |
+      (($old | map(.name)) + ($new | map(.name))) | unique | sort |
+      map(
+        . as $name |
+        ($old | map(select(.name == $name)) | first) as $o |
+        ($new | map(select(.name == $name)) | first) as $n |
+        if $o == null then
+          {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
+        elif $n == null then
+          {check: $name, from: $o.status, to: "absent", conclusion: null}
+        elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
+          {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
+        else
+          empty
+        end
+      )
+    ')
+
+    local status_change_count
+    status_change_count=$(echo "$status_changes" | jq 'length' | tr -d '\r')
+
+    local new_comment_ids new_comment_count
+    new_comment_ids=$(comm -23 <(echo "$cur_comment_snapshot") <(echo "$initial_comment_snapshot"))
+    new_comment_count=$(echo "$new_comment_ids" | grep -c '.' || true)
+
+    if [ "$status_change_count" -gt 0 ]; then
+      echo "$status_changes" | jq -r '.[] |
+        "--- change\n" +
+        "type: status\n" +
+        "check: \(.check)\n" +
+        "from: \(.from)\n" +
+        "to: \(.to)" +
+        if (.conclusion != null and .to != "absent") then "\nconclusion: \(.conclusion)" else "" end'
+    fi
+
+    if [ "$new_comment_count" -gt 0 ]; then
+      echo "--- change"
+      echo "type: new-comment"
+      echo "count: $new_comment_count"
+    fi
+
+    if [ "$status_change_count" -gt 0 ] || [ "$new_comment_count" -gt 0 ]; then
+      if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+      exit 0
+    fi
+
+    if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+
+    prev_sha="$cur_sha"
+    prev_status_snapshot="$cur_status_snapshot"
+  done
+}
+
 # cmd_monitor is the top-level dispatcher for the monitor command, routing
-# sub-commands (status, comments) to their handlers. Exits 1 with usage when no
-# sub-command is provided.
+# sub-commands (status, comments, --all) to their handlers. Exits 1 with usage
+# when no sub-command is provided.
 cmd_monitor() {
   if [ $# -eq 0 ]; then
     die "missing monitor sub-command (see 'gh-pr-context monitor --help')"
@@ -808,6 +994,7 @@ cmd_monitor() {
   case "$sub_command" in
     status) cmd_monitor_status "$@" ;;
     comments) cmd_monitor_comments "$@" ;;
+    --all) cmd_monitor_all "$@" ;;
     -h|--help) usage_monitor; exit 0 ;;
     *) die "unknown monitor sub-command: $sub_command" ;;
   esac

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -530,13 +530,27 @@ capture_check_snapshot() {
 # replies) and issue comment IDs for a given PR, returning a sorted newline-
 # separated list suitable for set-difference comparison between poll cycles.
 capture_comment_id_snapshot() {
-  local owner_repo=$1 pr_number=$2
+  local owner_repo=$1 pr_number=$2 timeout_secs="${3:-}"
+  local review_raw issue_raw review_rc issue_rc
+  if review_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number/comments" --paginate); then
+    :
+  else
+    review_rc=$?
+    if [ "$review_rc" -eq 124 ]; then return 124; fi
+    die "failed to fetch review comments for PR #$pr_number"
+  fi
+  if issue_raw=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/issues/$pr_number/comments" --paginate); then
+    :
+  else
+    issue_rc=$?
+    if [ "$issue_rc" -eq 124 ]; then return 124; fi
+    die "failed to fetch issue comments for PR #$pr_number"
+  fi
+
   local review_ids issue_ids
-  review_ids=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate \
-    | jq -r '[.[] | select(.in_reply_to_id == null) | .id] | sort[]' | tr -d '\r') \
+  review_ids=$(echo "$review_raw" | jq -r '[.[] | select(.in_reply_to_id == null) | .id] | sort[]' | tr -d '\r') \
     || die "failed to fetch review comments for PR #$pr_number"
-  issue_ids=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate \
-    | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
+  issue_ids=$(echo "$issue_raw" | jq -r '[.[] | .id] | sort[]' | tr -d '\r') \
     || die "failed to fetch issue comments for PR #$pr_number"
   { echo "$review_ids"; echo "$issue_ids"; } | sort -n | grep -v '^$' || true
 }
@@ -921,7 +935,20 @@ cmd_monitor_all() {
     fi
 
     local cur_comment_snapshot
-    cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_comment_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to fetch comments during poll"
+    fi
 
     local status_changes
     status_changes=$(printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -8,6 +8,14 @@ die() {
   exit 1
 }
 
+require_bash_version() {
+  if [ "${BASH_VERSINFO[0]}" -lt 5 ] || { [ "${BASH_VERSINFO[0]}" -eq 5 ] && [ "${BASH_VERSINFO[1]}" -lt 1 ]; }; then
+    die "bash 5.1+ is required"
+  fi
+}
+
+require_bash_version
+
 # Parse a duration string (<number><s|m|h>) and output seconds.
 # Exits 1 on invalid input (empty, bare number, negative, non-numeric).
 parse_duration() {
@@ -445,10 +453,9 @@ _timed_gh_api() {
     return 124
   fi
 
-  local stdout_file stderr_file timed_out_file
+  local stdout_file stderr_file
   stdout_file=$(mktemp) || return 1
   stderr_file=$(mktemp) || { rm -f "$stdout_file"; return 1; }
-  timed_out_file=$(mktemp) || { rm -f "$stdout_file" "$stderr_file"; return 1; }
 
   gh api "$@" >"$stdout_file" 2>"$stderr_file" &
   local api_pid=$!
@@ -460,7 +467,6 @@ _timed_gh_api() {
   if [ "$completed_pid" = "$timer_pid" ]; then
     kill "$api_pid" 2>/dev/null || true
     wait "$api_pid" 2>/dev/null || true
-    echo 1 > "$timed_out_file"
     rc=124
   else
     kill "$timer_pid" 2>/dev/null || true
@@ -472,7 +478,7 @@ _timed_gh_api() {
     cat "$stderr_file" >&2
   fi
 
-  rm -f "$stdout_file" "$stderr_file" "$timed_out_file"
+  rm -f "$stdout_file" "$stderr_file"
   return "$rc"
 }
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -8,6 +8,7 @@ die() {
   exit 1
 }
 
+# require_bash_version enforces Bash 5.1+, exiting via die on older shells.
 require_bash_version() {
   if [ "${BASH_VERSINFO[0]}" -lt 5 ] || { [ "${BASH_VERSINFO[0]}" -eq 5 ] && [ "${BASH_VERSINFO[1]}" -lt 1 ]; }; then
     die "bash 5.1+ is required"
@@ -175,6 +176,8 @@ resolve_pr_number() {
   echo "$pr_data"
 }
 
+# resolve_pr_head_sha prints the remote PR head SHA. The optional timeout
+# argument is passed through to _timed_gh_api, so callers can observe exit 124.
 resolve_pr_head_sha() {
   local pr_number=$1
   local timeout_secs="${2:-}"
@@ -493,6 +496,8 @@ _timed_gh_api() {
   return "$rc"
 }
 
+# monitor_call_timeout converts the remaining overall monitor budget into a
+# per-call deadline, returning 2 after printing the timeout message if exhausted.
 monitor_call_timeout() {
   local timeout_secs="${1:-}" timeout_input="${2:-}"
   if [ -z "$timeout_secs" ]; then
@@ -508,6 +513,7 @@ monitor_call_timeout() {
   echo "$remaining"
 }
 
+# monitor_api_timeout_warning emits the retry notice for per-call gh api timeouts.
 monitor_api_timeout_warning() {
   echo "gh api call timed out; retrying next poll" >&2
 }
@@ -526,6 +532,8 @@ capture_check_snapshot() {
   echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
 }
 
+# compute_status_diff returns a JSON array of check status/conclusion changes
+# between two normalized check snapshots, including absent/new checks.
 compute_status_diff() {
   local prev_status_snapshot=$1 cur_status_snapshot=$2
   printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '
@@ -824,6 +832,9 @@ cmd_monitor_comments() {
   done
 }
 
+# cmd_monitor_all polls check status and comments in the same loop. It prints
+# all detected status changes before a new-comment summary and uses the same
+# exit codes as other monitor commands: 0 change, 1 error, 2 timeout, 130 signal.
 cmd_monitor_all() {
   local pr_number="" interval=30 timeout_input="" timeout_secs=""
 

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -158,9 +158,10 @@ resolve_pr_number() {
 
 resolve_pr_head_sha() {
   local pr_number=$1
+  local timeout_secs="${2:-}"
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  gh api "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
+  _timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
 }
 
 validate_since_format() {
@@ -430,14 +431,81 @@ cmd_logs() {
   done <<< "$failed_pairs"
 }
 
+# _timed_gh_api runs gh api with an optional seconds deadline. It returns 124
+# when the deadline expires, matching the conventional timeout exit code.
+_timed_gh_api() {
+  local timeout_secs="${1:-}"
+  shift
+
+  if [ -z "$timeout_secs" ]; then
+    gh api "$@"
+    return
+  fi
+  if [ "$timeout_secs" -le 0 ]; then
+    return 124
+  fi
+
+  local stdout_file stderr_file timed_out_file
+  stdout_file=$(mktemp) || return 1
+  stderr_file=$(mktemp) || { rm -f "$stdout_file"; return 1; }
+  timed_out_file=$(mktemp) || { rm -f "$stdout_file" "$stderr_file"; return 1; }
+
+  gh api "$@" >"$stdout_file" 2>"$stderr_file" &
+  local api_pid=$!
+  command sleep "$timeout_secs" &
+  local timer_pid=$!
+
+  local rc=0 completed_pid=""
+  wait -n -p completed_pid "$api_pid" "$timer_pid" || rc=$?
+  if [ "$completed_pid" = "$timer_pid" ]; then
+    kill "$api_pid" 2>/dev/null || true
+    wait "$api_pid" 2>/dev/null || true
+    echo 1 > "$timed_out_file"
+    rc=124
+  else
+    kill "$timer_pid" 2>/dev/null || true
+    wait "$timer_pid" 2>/dev/null || true
+  fi
+
+  if [ "$rc" -ne 124 ]; then
+    cat "$stdout_file"
+    cat "$stderr_file" >&2
+  fi
+
+  rm -f "$stdout_file" "$stderr_file" "$timed_out_file"
+  return "$rc"
+}
+
+monitor_call_timeout() {
+  local timeout_secs="${1:-}" timeout_input="${2:-}"
+  if [ -z "$timeout_secs" ]; then
+    echo ""
+    return 0
+  fi
+
+  local remaining=$((timeout_secs - SECONDS))
+  if [ "$remaining" -le 0 ]; then
+    echo "monitor timed out after $timeout_input" >&2
+    return 2
+  fi
+  echo "$remaining"
+}
+
+monitor_api_timeout_warning() {
+  echo "gh api call timed out; retrying next poll" >&2
+}
+
 # capture_check_snapshot fetches check-runs for a given SHA via the GitHub API
 # and returns a normalized JSON array of {name, status, conclusion} objects
 # sorted by check name, suitable for diffing between poll cycles.
 capture_check_snapshot() {
-  local owner_repo=$1 sha=$2
+  local owner_repo=$1 sha=$2 timeout_secs="${3:-}"
   local checks_json
-  checks_json=$(gh api "repos/$owner_repo/commits/$sha/check-runs" --paginate) \
-    || die "failed to fetch check runs for SHA $sha"
+  if checks_json=$(_timed_gh_api "$timeout_secs" "repos/$owner_repo/commits/$sha/check-runs" --paginate); then
+    :
+  else
+    return $?
+  fi
   echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
 }
 
@@ -507,7 +575,8 @@ cmd_monitor_status() {
     || die "failed to resolve head SHA for PR #$pr_number"
 
   local prev_snapshot
-  prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha")
+  prev_snapshot=$(capture_check_snapshot "$owner_repo" "$prev_sha") \
+    || die "failed to fetch check runs for SHA $prev_sha"
   if [ -n "$check_filter" ]; then
     prev_snapshot=$(echo "$prev_snapshot" | jq --arg name "$check_filter" 'map(select(.name == $name))')
   fi
@@ -539,7 +608,20 @@ cmd_monitor_status() {
     fi
 
     local cur_sha
-    if ! cur_sha=$(resolve_pr_head_sha "$pr_number" 2>&1); then
+    local call_timeout
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    local api_rc=0
+    if cur_sha=$(resolve_pr_head_sha "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
       die "failed to re-resolve head SHA for PR #$pr_number"
     fi
 
@@ -552,7 +634,18 @@ cmd_monitor_status() {
     fi
 
     local cur_snapshot
-    if ! cur_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" 2>&1); then
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_snapshot=$(capture_check_snapshot "$owner_repo" "$cur_sha" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
       die "failed to fetch check runs during poll"
     fi
     if [ -n "$check_filter" ]; then

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -526,6 +526,30 @@ capture_check_snapshot() {
   echo "$checks_json" | jq -s 'map(.check_runs) | add // [] | sort_by(.name) | map({name: .name, status: .status, conclusion: .conclusion})'
 }
 
+compute_status_diff() {
+  local prev_status_snapshot=$1 cur_status_snapshot=$2
+  printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '
+    . as $snapshots |
+    ($snapshots[0]) as $old |
+    ($snapshots[1]) as $new |
+    (($old | map(.name)) + ($new | map(.name))) | unique | sort |
+    map(
+      . as $name |
+      ($old | map(select(.name == $name)) | first) as $o |
+      ($new | map(select(.name == $name)) | first) as $n |
+      if $o == null then
+        {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
+      elif $n == null then
+        {check: $name, from: $o.status, to: "absent", conclusion: null}
+      elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
+        {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
+      else
+        empty
+      end
+    )
+  '
+}
+
 # capture_comment_id_snapshot fetches top-level review comment IDs (excluding
 # replies) and issue comment IDs for a given PR, returning a sorted newline-
 # separated list suitable for set-difference comparison between poll cycles.
@@ -684,26 +708,7 @@ cmd_monitor_status() {
     fi
 
     local changes
-    changes=$(printf '%s\n%s\n' "$prev_snapshot" "$cur_snapshot" | jq -s '
-      . as $snapshots |
-      ($snapshots[0]) as $old |
-      ($snapshots[1]) as $new |
-      (($old | map(.name)) + ($new | map(.name))) | unique | sort |
-      map(
-        . as $name |
-        ($old | map(select(.name == $name)) | first) as $o |
-        ($new | map(select(.name == $name)) | first) as $n |
-        if $o == null then
-          {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
-        elif $n == null then
-          {check: $name, from: $o.status, to: "absent", conclusion: null}
-        elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
-          {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
-        else
-          empty
-        end
-      )
-    ')
+    changes=$(compute_status_diff "$prev_snapshot" "$cur_snapshot")
 
     local change_count
     change_count=$(echo "$changes" | jq 'length' | tr -d '\r')
@@ -951,26 +956,7 @@ cmd_monitor_all() {
     fi
 
     local status_changes
-    status_changes=$(printf '%s\n%s\n' "$prev_status_snapshot" "$cur_status_snapshot" | jq -s '
-      . as $snapshots |
-      ($snapshots[0]) as $old |
-      ($snapshots[1]) as $new |
-      (($old | map(.name)) + ($new | map(.name))) | unique | sort |
-      map(
-        . as $name |
-        ($old | map(select(.name == $name)) | first) as $o |
-        ($new | map(select(.name == $name)) | first) as $n |
-        if $o == null then
-          {check: $name, from: "absent", to: $n.status, conclusion: $n.conclusion}
-        elif $n == null then
-          {check: $name, from: $o.status, to: "absent", conclusion: null}
-        elif ($o.status != $n.status) or (($o.conclusion // "") != ($n.conclusion // "")) then
-          {check: $name, from: $o.status, to: $n.status, conclusion: $n.conclusion}
-        else
-          empty
-        end
-      )
-    ')
+    status_changes=$(compute_status_diff "$prev_status_snapshot" "$cur_status_snapshot")
 
     local status_change_count
     status_change_count=$(echo "$status_changes" | jq 'length' | tr -d '\r')

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -754,7 +754,7 @@ cmd_monitor_comments() {
         timeout_secs=$(parse_duration "$timeout_input")
         ;;
       --check)
-        die "--check is not supported for monitor comments"
+        die "unknown option: --check (only valid with monitor status)"
         ;;
       -h|--help) usage_monitor_comments; exit 0 ;;
       *) die "unknown option: $1" ;;

--- a/skills/deliver/SKILL.md
+++ b/skills/deliver/SKILL.md
@@ -27,7 +27,7 @@ Verify: `gh-pr-context --help`. Requires `gh` (authenticated), `jq`, and `bash`.
 
 ## When to invoke
 
-Invoke BEFORE creating a PR to run the pre-PR checks (steps 1-3), then create the PR (step 4), and proceed with post-PR review (steps 5-7). Do NOT invoke after pushing as a post-hoc review.
+Invoke BEFORE creating a PR to run the pre-PR checks (steps 1-3), then create the PR (step 4), and proceed with post-PR review (steps 5-8). Do NOT invoke after pushing as a post-hoc review.
 
 ## Workflow
 
@@ -88,7 +88,11 @@ Read the output carefully. For each comment or failed check, determine if action
 
 Address every legitimate issue from steps 1, 2, 3, and 5. Dismiss only clearly false positives — explain dismissals in the commit message or PR description.
 
-### 7. Monitor & Iterate
+### 7. ☑ Follow-up items
+
+If the review uncovered improvements, refactors, or feature requests that are valid but out of scope for this PR: (1) If `/to-issues` is available, use it to create new GitHub issues for each follow-up, tagged `needs-triage`. (2) Otherwise, list the follow-ups in the PR description under a `## Follow-up` heading. Do NOT implement them in this PR.
+
+### 8. Monitor & Iterate
 
 - Re-run `gh-pr-context comments --since last-commit` after each push to catch new feedback.
 - Re-run `gh-pr-context status` and `gh-pr-context logs` to verify CI.

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -248,6 +248,10 @@ test_names+=(
   test_monitor_all_mixed_changes_status_first
   test_monitor_all_new_commit
   test_monitor_all_check_flag_rejected
+  test_monitor_all_missing_interval_value_exits_nonzero
+  test_monitor_all_invalid_interval_exits_nonzero
+  test_monitor_all_zero_interval_exits_nonzero
+  test_monitor_all_negative_interval_exits_nonzero
   test_monitor_all_timeout_exits_two
   test_monitor_all_explicit_pr
   test_monitor_all_auto_detect
@@ -348,12 +352,56 @@ test_monitor_all_new_commit() {
 
 test_monitor_all_check_flag_rejected() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --check CI 2>&1) || exit_code=$?
+  output=$(bash "$script" monitor --all --check ci.yml 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all --check should be rejected (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_missing_interval_value_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_invalid_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_zero_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 NEW_SHA="def456abc123def456abc123def456abc123def4"
@@ -176,6 +177,52 @@ setup_mocks_monitor_all_api_failure() {
   }
 }
 
+setup_mocks_monitor_all_comment_api_timeout() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$5"
+  _MOCK_CHANGED_ISSUES="$6"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+        if [ "$call_num" -eq 2 ]; then
+          exit 124
+        elif [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 run_script() {
   export -f git gh sleep _mock_counter_next
   export HEAD_SHA NEW_SHA
@@ -206,6 +253,7 @@ test_names+=(
   test_monitor_all_auto_detect
   test_monitor_all_accepts_timeout
   test_monitor_all_api_failure_exits_nonzero
+  test_monitor_all_comment_api_timeout_continues
   test_monitor_all_help_exits_zero
   test_monitor_help_lists_all
 )
@@ -381,6 +429,25 @@ test_monitor_all_api_failure_exits_nonzero() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all API failure should exit non-zero"
+  fi
+}
+
+test_monitor_all_comment_api_timeout_continues() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_all_comment_api_timeout "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all comment API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -1,0 +1,401 @@
+#!/usr/bin/env bash
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+_MOCK_SHA_COUNTER_FILE=""
+_MOCK_CHECK_COUNTER_FILE=""
+_MOCK_REVIEW_COUNTER_FILE=""
+_MOCK_ISSUE_COUNTER_FILE=""
+
+_mock_counter_next() {
+  local file=$1 val
+  val=$(cat "$file")
+  val=$((val + 1))
+  echo "$val" > "$file"
+  echo "$val"
+}
+
+setup_counter_files() {
+  _MOCK_SHA_COUNTER_FILE=$(mktemp)
+  _MOCK_CHECK_COUNTER_FILE=$(mktemp)
+  _MOCK_REVIEW_COUNTER_FILE=$(mktemp)
+  _MOCK_ISSUE_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_SHA_COUNTER_FILE"
+  echo 0 > "$_MOCK_CHECK_COUNTER_FILE"
+  echo 0 > "$_MOCK_REVIEW_COUNTER_FILE"
+  echo 0 > "$_MOCK_ISSUE_COUNTER_FILE"
+}
+
+setup_mocks() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  sleep() {
+    :
+  }
+}
+
+setup_mocks_monitor_all() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$5"
+  _MOCK_CHANGED_ISSUES="$6"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls?head=acme:feature-branch"*"--paginate"*) echo "42" ;;
+      *"pulls/42"*"--paginate"*"--jq"*)
+        _mock_counter_next "$_MOCK_SHA_COUNTER_FILE" >/dev/null
+        echo "$HEAD_SHA"
+        ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_new_commit() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$HEAD_SHA"
+        else
+          echo "$NEW_SHA"
+        fi
+        ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_no_change() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_api_failure() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          exit 1
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+run_script() {
+  export -f git gh sleep _mock_counter_next
+  export HEAD_SHA NEW_SHA
+  export _MOCK_INITIAL_CHECKS _MOCK_CHANGED_CHECKS
+  export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
+  export _MOCK_SHA_COUNTER_FILE _MOCK_CHECK_COUNTER_FILE _MOCK_REVIEW_COUNTER_FILE _MOCK_ISSUE_COUNTER_FILE
+  timeout 15 bash "$script" "$@" </dev/null
+}
+
+run_script_with_real_sleep() {
+  run_script "$@"
+}
+
+cleanup_mock_counters() {
+  for file in "$_MOCK_SHA_COUNTER_FILE" "$_MOCK_CHECK_COUNTER_FILE" "$_MOCK_REVIEW_COUNTER_FILE" "$_MOCK_ISSUE_COUNTER_FILE"; do
+    [ -n "$file" ] && [ -f "$file" ] && rm -f "$file"
+  done
+}
+
+test_names+=(
+  test_monitor_all_status_only
+  test_monitor_all_comments_only
+  test_monitor_all_mixed_changes_status_first
+  test_monitor_all_new_commit
+  test_monitor_all_check_flag_rejected
+  test_monitor_all_timeout_exits_two
+  test_monitor_all_explicit_pr
+  test_monitor_all_auto_detect
+  test_monitor_all_accepts_timeout
+  test_monitor_all_api_failure_exits_nonzero
+  test_monitor_all_help_exits_zero
+  test_monitor_help_lists_all
+)
+
+test_monitor_all_status_only() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  local initial_reviews='[]'
+  local initial_issues='[{"id":201}]'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "$initial_reviews" "$initial_issues" "$initial_reviews" "$initial_issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all status-only change (output: $output)"
+  fi
+}
+
+test_monitor_all_comments_only() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_all "$checks" "$checks" "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1" \
+    && ! echo "$output" | grep -qF "type: status"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all comment-only change (output: $output)"
+  fi
+}
+
+test_monitor_all_mixed_changes_status_first() {
+  local initial_checks='{"total_count":2,"check_runs":[{"name":"Test","status":"queued","conclusion":null},{"name":"Build","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":2,"check_runs":[{"name":"Test","status":"completed","conclusion":"failure"},{"name":"Build","status":"completed","conclusion":"success"}]}'
+  local initial_reviews='[]'
+  local initial_issues='[{"id":201}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_issues='[{"id":201},{"id":202}]'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output first_type last_type first_check second_check comment_count
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  first_type=$(echo "$output" | grep "^type:" | head -1 | tr -d '\r')
+  last_type=$(echo "$output" | grep "^type:" | tail -1 | tr -d '\r')
+  first_check=$(echo "$output" | grep "^check:" | head -1 | sed 's/check: //' | tr -d '\r')
+  second_check=$(echo "$output" | grep "^check:" | tail -1 | sed 's/check: //' | tr -d '\r')
+  comment_count=$(echo "$output" | grep "type: new-comment" | wc -l | tr -d '[:space:]')
+  if [ "$first_type" = "type: status" ] \
+    && [ "$last_type" = "type: new-comment" ] \
+    && [ "$first_check" = "Build" ] \
+    && [ "$second_check" = "Test" ] \
+    && [ "$comment_count" = "1" ] \
+    && echo "$output" | grep -qF "count: 2"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all mixed output ordering (output: $output)"
+  fi
+}
+
+test_monitor_all_new_commit() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[]'
+  local issues='[]'
+  setup_mocks_monitor_all_new_commit "$checks" "$reviews" "$issues"
+  local output
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-commit" \
+    && echo "$output" | grep -qF "sha: $NEW_SHA" \
+    && ! echo "$output" | grep -qF "type: status" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all new commit (output: $output)"
+  fi
+}
+
+test_monitor_all_check_flag_rejected() {
+  local output exit_code=0
+  output=$(bash "$script" monitor --all --check CI 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --check (only valid with monitor status)"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --check should be rejected (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_timeout_exits_two() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[{"id":101,"in_reply_to_id":null}]'
+  local issues='[]'
+  setup_mocks_monitor_all_no_change "$checks" "$reviews" "$issues"
+  local exit_code=0
+  run_script_with_real_sleep monitor --all --pr 42 --interval 1 --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all timeout should exit 2 (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_explicit_pr() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"queued","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all explicit --pr should succeed (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_auto_detect() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null}]'
+  setup_mocks_monitor_all "$checks" "$checks" "[]" "[]" "$changed_reviews" "[]"
+  local output
+  output=$(run_script monitor --all --interval 1 2>&1)
+  cleanup_mock_counters
+  if echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all auto-detect should work (output: $output)"
+  fi
+}
+
+test_monitor_all_accepts_timeout() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"queued","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all "$initial_checks" "$changed_checks" "[]" "[]" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 --timeout 5m >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all should accept --timeout 5m (exit: $exit_code)"
+  fi
+}
+
+test_monitor_all_api_failure_exits_nonzero() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all_api_failure "$checks" "[]" "[]"
+  local exit_code=0
+  run_script monitor --all --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all API failure should exit non-zero"
+  fi
+}
+
+test_monitor_all_help_exits_zero() {
+  assert_exit 0 "monitor --all --help exits 0" bash "$script" monitor --all --help
+  assert_exit 0 "monitor --all -h exits 0" bash "$script" monitor --all -h
+}
+
+test_monitor_help_lists_all() {
+  local output
+  output=$(bash "$script" monitor --help 2>&1)
+  if echo "$output" | grep -qF -- "--all"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --help should list --all (output: $output)"
+  fi
+}

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -7,6 +7,51 @@ _MOCK_SHA_COUNTER_FILE=""
 _MOCK_CHECK_COUNTER_FILE=""
 _MOCK_REVIEW_COUNTER_FILE=""
 _MOCK_ISSUE_COUNTER_FILE=""
+_MONITOR_ALL_TEST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$_MONITOR_ALL_TEST_DIR/../gh-pr-context"
+
+# shellcheck source=/dev/null
+source "$script"
+
+contains_arg() {
+  local needle=$1 arg
+  shift
+  for arg in "$@"; do
+    if [[ "$arg" == *"$needle"* ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+is_pr_lookup_call() {
+  contains_arg "pulls?head=acme:feature-branch" "$@" && contains_arg "--paginate" "$@"
+}
+
+is_pr_sha_call() {
+  contains_arg "pulls/42" "$@" && contains_arg "--paginate" "$@" && contains_arg "--jq" "$@"
+}
+
+is_replies_call() {
+  contains_arg "pulls/comments/" "$@" && contains_arg "/replies" "$@"
+}
+
+is_check_runs_call() {
+  contains_arg "check-runs" "$@" && contains_arg "--paginate" "$@"
+}
+
+is_review_comments_call() {
+  contains_arg "pulls/42/comments" "$@" && contains_arg "--paginate" "$@"
+}
+
+is_issue_comments_call() {
+  contains_arg "issues/42/comments" "$@" && contains_arg "--paginate" "$@"
+}
+
+unexpected_gh_call() {
+  echo "gh: unexpected call: $*" >&2
+  exit 1
+}
 
 _mock_counter_next() {
   local file=$1 val
@@ -55,45 +100,41 @@ setup_mocks_monitor_all() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls?head=acme:feature-branch"*"--paginate"*) echo "42" ;;
-      *"pulls/42"*"--paginate"*"--jq"*)
-        _mock_counter_next "$_MOCK_SHA_COUNTER_FILE" >/dev/null
-        echo "$HEAD_SHA"
-        ;;
-      *"pulls/comments/"*"/replies"*)
-        echo "ERROR: replies endpoint should not be called" >&2
-        exit 1
-        ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_CHECKS"
-        else
-          echo "$_MOCK_CHANGED_CHECKS"
-        fi
-        ;;
-      *"pulls/42/comments"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_REVIEWS"
-        else
-          echo "$_MOCK_CHANGED_REVIEWS"
-        fi
-        ;;
-      *"issues/42/comments"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_ISSUES"
-        else
-          echo "$_MOCK_CHANGED_ISSUES"
-        fi
-        ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_lookup_call "$@"; then
+      echo "42"
+    elif is_pr_sha_call "$@"; then
+      _mock_counter_next "$_MOCK_SHA_COUNTER_FILE" >/dev/null
+      echo "$HEAD_SHA"
+    elif is_replies_call "$@"; then
+      echo "ERROR: replies endpoint should not be called" >&2
+      exit 1
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_CHECKS"
+      else
+        echo "$_MOCK_CHANGED_CHECKS"
+      fi
+    elif is_review_comments_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_REVIEWS"
+      else
+        echo "$_MOCK_CHANGED_REVIEWS"
+      fi
+    elif is_issue_comments_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_ISSUES"
+      else
+        echo "$_MOCK_CHANGED_ISSUES"
+      fi
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -107,21 +148,23 @@ setup_mocks_monitor_all_new_commit() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$HEAD_SHA"
-        else
-          echo "$NEW_SHA"
-        fi
-        ;;
-      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$HEAD_SHA"
+      else
+        echo "$NEW_SHA"
+      fi
+    elif is_check_runs_call "$@"; then
+      echo "$_MOCK_INITIAL_CHECKS"
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -143,13 +186,17 @@ setup_mocks_monitor_all_no_change() {
     esac
   }
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      echo "$_MOCK_INITIAL_CHECKS"
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -163,21 +210,23 @@ setup_mocks_monitor_all_api_failure() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_CHECKS"
-        else
-          exit 1
-        fi
-        ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_CHECKS"
+      else
+        exit 1
+      fi
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -191,39 +240,37 @@ setup_mocks_monitor_all_comment_api_timeout() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_CHECKS"
-        else
-          echo "$_MOCK_CHANGED_CHECKS"
-        fi
-        ;;
-      *"pulls/42/comments"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
-        if [ "$call_num" -eq 2 ]; then
-          exit 124
-        elif [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_REVIEWS"
-        else
-          echo "$_MOCK_CHANGED_REVIEWS"
-        fi
-        ;;
-      *"issues/42/comments"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_ISSUES"
-        else
-          echo "$_MOCK_CHANGED_ISSUES"
-        fi
-        ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_CHECKS"
+      else
+        echo "$_MOCK_CHANGED_CHECKS"
+      fi
+    elif is_review_comments_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_REVIEW_COUNTER_FILE")
+      if [ "$call_num" -eq 2 ]; then
+        exit 124
+      elif [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_REVIEWS"
+      else
+        echo "$_MOCK_CHANGED_REVIEWS"
+      fi
+    elif is_issue_comments_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_ISSUE_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_ISSUES"
+      else
+        echo "$_MOCK_CHANGED_ISSUES"
+      fi
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -237,28 +284,28 @@ setup_mocks_monitor_all_sha_api_timeout() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
-        if [ "$call_num" -eq 2 ]; then
-          exit 124
-        fi
-        echo "$HEAD_SHA"
-        ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_CHECKS"
-        else
-          echo "$_MOCK_CHANGED_CHECKS"
-        fi
-        ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
+      if [ "$call_num" -eq 2 ]; then
+        exit 124
+      fi
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_CHECKS"
+      else
+        echo "$_MOCK_CHANGED_CHECKS"
+      fi
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -272,23 +319,25 @@ setup_mocks_monitor_all_check_api_timeout() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -eq 2 ]; then
-          exit 124
-        elif [ "$call_num" -le 1 ]; then
-          echo "$_MOCK_INITIAL_CHECKS"
-        else
-          echo "$_MOCK_CHANGED_CHECKS"
-        fi
-        ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -eq 2 ]; then
+        exit 124
+      elif [ "$call_num" -le 1 ]; then
+        echo "$_MOCK_INITIAL_CHECKS"
+      else
+        echo "$_MOCK_CHANGED_CHECKS"
+      fi
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -310,20 +359,22 @@ setup_mocks_monitor_all_api_timeout_no_change() {
     esac
   }
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*)
-        local call_num
-        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
-        if [ "$call_num" -eq 2 ]; then
-          exit 124
-        fi
-        echo "$_MOCK_INITIAL_CHECKS"
-        ;;
-      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
-      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      local call_num
+      call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+      if [ "$call_num" -eq 2 ]; then
+        exit 124
+      fi
+      echo "$_MOCK_INITIAL_CHECKS"
+    elif is_review_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_REVIEWS"
+    elif is_issue_comments_call "$@"; then
+      echo "$_MOCK_INITIAL_ISSUES"
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
@@ -332,18 +383,35 @@ setup_mocks_monitor_all_bootstrap_comment_api_timeout() {
   setup_counter_files
   setup_mocks
   gh() {
-    case "$*" in
-      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
-      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
-      *"pulls/42/comments"*"--paginate"*) exit 124 ;;
-      *"issues/42/comments"*"--paginate"*) echo "[]" ;;
-      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
-    esac
+    if is_pr_sha_call "$@"; then
+      echo "$HEAD_SHA"
+    elif is_check_runs_call "$@"; then
+      echo "$_MOCK_INITIAL_CHECKS"
+    elif is_review_comments_call "$@"; then
+      exit 124
+    elif is_issue_comments_call "$@"; then
+      echo "[]"
+    else
+      unexpected_gh_call "$@"
+    fi
+  }
+}
+
+setup_mocks_monitor_all_autodetect_timeout() {
+  setup_counter_files
+  setup_mocks
+  gh() {
+    if is_pr_lookup_call "$@"; then
+      exit 124
+    else
+      unexpected_gh_call "$@"
+    fi
   }
 }
 
 run_script() {
-  export -f git gh sleep _mock_counter_next
+  export -f git gh sleep _mock_counter_next contains_arg is_pr_lookup_call is_pr_sha_call is_replies_call
+  export -f is_check_runs_call is_review_comments_call is_issue_comments_call unexpected_gh_call
   export HEAD_SHA NEW_SHA
   export _MOCK_INITIAL_CHECKS _MOCK_CHANGED_CHECKS
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
@@ -365,6 +433,7 @@ test_names+=(
   test_monitor_all_status_only
   test_monitor_all_comments_only
   test_monitor_all_mixed_changes_status_first
+  test_monitor_all_comment_id_sorting_for_comm
   test_monitor_all_new_commit
   test_monitor_all_check_flag_rejected
   test_monitor_all_missing_pr_value_exits_nonzero
@@ -378,6 +447,7 @@ test_names+=(
   test_monitor_all_timeout_exits_two
   test_monitor_all_explicit_pr
   test_monitor_all_auto_detect
+  test_monitor_all_auto_detect_timeout_exits_two
   test_monitor_all_accepts_timeout
   test_monitor_all_api_failure_exits_nonzero
   test_monitor_all_sha_api_timeout_continues
@@ -455,6 +525,27 @@ test_monitor_all_mixed_changes_status_first() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all mixed output ordering (output: $output)"
+  fi
+}
+
+test_monitor_all_comment_id_sorting_for_comm() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local initial_reviews='[]'
+  local initial_issues='[{"id":2}]'
+  local changed_reviews='[]'
+  local changed_issues='[{"id":2},{"id":10}]'
+  setup_mocks_monitor_all "$checks" "$checks" "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1" \
+    && ! echo "$output" | grep -qF "not in sorted order"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all comment IDs should be sorted for comm (exit=$exit_code, output: $output)"
   fi
 }
 
@@ -628,6 +719,19 @@ test_monitor_all_auto_detect() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all auto-detect should work (output: $output)"
+  fi
+}
+
+test_monitor_all_auto_detect_timeout_exits_two() {
+  setup_mocks_monitor_all_autodetect_timeout
+  local output exit_code=0
+  output=$(run_script monitor --all --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 2 ] && echo "$output" | grep -qF "monitor timed out after 5m"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all auto-detect timeout should exit 2 (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -33,10 +33,11 @@ setup_mocks() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
+    echo "gh: unexpected call: $*" >&2
     exit 1
   }
   sleep() {
@@ -91,7 +92,7 @@ setup_mocks_monitor_all() {
           echo "$_MOCK_CHANGED_ISSUES"
         fi
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -119,7 +120,7 @@ setup_mocks_monitor_all_new_commit() {
       *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -138,7 +139,7 @@ setup_mocks_monitor_all_no_change() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -147,7 +148,7 @@ setup_mocks_monitor_all_no_change() {
       *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -175,7 +176,7 @@ setup_mocks_monitor_all_api_failure() {
         ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -221,7 +222,7 @@ setup_mocks_monitor_all_comment_api_timeout() {
           echo "$_MOCK_CHANGED_ISSUES"
         fi
         ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -256,7 +257,7 @@ setup_mocks_monitor_all_sha_api_timeout() {
         ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -286,7 +287,7 @@ setup_mocks_monitor_all_check_api_timeout() {
         ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -305,7 +306,7 @@ setup_mocks_monitor_all_api_timeout_no_change() {
       "rev-parse --git-dir") echo ".git" ;;
       "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
-      *) exit 1 ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
   gh() {
@@ -321,7 +322,22 @@ setup_mocks_monitor_all_api_timeout_no_change() {
         ;;
       *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
       *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
-      *) exit 1 ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_bootstrap_comment_api_timeout() {
+  _MOCK_INITIAL_CHECKS="$1"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL_CHECKS" ;;
+      *"pulls/42/comments"*"--paginate"*) exit 124 ;;
+      *"issues/42/comments"*"--paginate"*) echo "[]" ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
     esac
   }
 }
@@ -368,6 +384,7 @@ test_names+=(
   test_monitor_all_check_api_timeout_continues
   test_monitor_all_comment_api_timeout_continues
   test_monitor_all_overall_timeout_after_api_timeout
+  test_monitor_all_bootstrap_timeout_exits_two
   test_monitor_all_help_exits_zero
   test_monitor_help_lists_all
 )
@@ -713,6 +730,20 @@ test_monitor_all_overall_timeout_after_api_timeout() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all overall timeout should still fire after API timeout (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_bootstrap_timeout_exits_two() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all_bootstrap_comment_api_timeout "$checks"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 2 ] && echo "$output" | grep -qF "monitor timed out after 5m"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all bootstrap timeout should exit 2 (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -36,6 +36,9 @@ setup_mocks() {
       *) exit 1 ;;
     esac
   }
+  gh() {
+    exit 1
+  }
   sleep() {
     :
   }
@@ -223,6 +226,106 @@ setup_mocks_monitor_all_comment_api_timeout() {
   }
 }
 
+setup_mocks_monitor_all_sha_api_timeout() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$3"
+  _MOCK_CHANGED_ISSUES="$4"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_SHA_COUNTER_FILE")
+        if [ "$call_num" -eq 2 ]; then
+          exit 124
+        fi
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_check_api_timeout() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$2"
+  _MOCK_INITIAL_REVIEWS="$3"
+  _MOCK_INITIAL_ISSUES="$4"
+  _MOCK_CHANGED_REVIEWS="$3"
+  _MOCK_CHANGED_ISSUES="$4"
+  setup_counter_files
+  setup_mocks
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -eq 2 ]; then
+          exit 124
+        elif [ "$call_num" -le 1 ]; then
+          echo "$_MOCK_INITIAL_CHECKS"
+        else
+          echo "$_MOCK_CHANGED_CHECKS"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_all_api_timeout_no_change() {
+  _MOCK_INITIAL_CHECKS="$1"
+  _MOCK_CHANGED_CHECKS="$1"
+  _MOCK_INITIAL_REVIEWS="$2"
+  _MOCK_INITIAL_ISSUES="$3"
+  _MOCK_CHANGED_REVIEWS="$2"
+  _MOCK_CHANGED_ISSUES="$3"
+  setup_counter_files
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*)
+        local call_num
+        call_num=$(_mock_counter_next "$_MOCK_CHECK_COUNTER_FILE")
+        if [ "$call_num" -eq 2 ]; then
+          exit 124
+        fi
+        echo "$_MOCK_INITIAL_CHECKS"
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 run_script() {
   export -f git gh sleep _mock_counter_next
   export HEAD_SHA NEW_SHA
@@ -248,16 +351,23 @@ test_names+=(
   test_monitor_all_mixed_changes_status_first
   test_monitor_all_new_commit
   test_monitor_all_check_flag_rejected
+  test_monitor_all_missing_pr_value_exits_nonzero
+  test_monitor_all_unknown_option_exits_nonzero
   test_monitor_all_missing_interval_value_exits_nonzero
   test_monitor_all_invalid_interval_exits_nonzero
   test_monitor_all_zero_interval_exits_nonzero
   test_monitor_all_negative_interval_exits_nonzero
+  test_monitor_all_missing_timeout_value_exits_nonzero
+  test_monitor_all_invalid_timeout_exits_nonzero
   test_monitor_all_timeout_exits_two
   test_monitor_all_explicit_pr
   test_monitor_all_auto_detect
   test_monitor_all_accepts_timeout
   test_monitor_all_api_failure_exits_nonzero
+  test_monitor_all_sha_api_timeout_continues
+  test_monitor_all_check_api_timeout_continues
   test_monitor_all_comment_api_timeout_continues
+  test_monitor_all_overall_timeout_after_api_timeout
   test_monitor_all_help_exits_zero
   test_monitor_help_lists_all
 )
@@ -352,7 +462,8 @@ test_monitor_all_new_commit() {
 
 test_monitor_all_check_flag_rejected() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --check ci.yml 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor --all --check ci.yml 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
@@ -361,9 +472,34 @@ test_monitor_all_check_flag_rejected() {
   fi
 }
 
+test_monitor_all_missing_pr_value_exits_nonzero() {
+  local output exit_code=0
+  setup_mocks
+  output=$(run_script monitor --all --pr 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --pr"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --pr should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_unknown_option_exits_nonzero() {
+  local output exit_code=0
+  setup_mocks
+  output=$(run_script monitor --all --bogus 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "unknown option: --bogus"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --bogus should exit 1 with unknown option message (exit=$exit_code, output: $output)"
+  fi
+}
+
 test_monitor_all_missing_interval_value_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --interval 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor --all --interval 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
     pass=$((pass + 1))
   else
@@ -374,7 +510,8 @@ test_monitor_all_missing_interval_value_exits_nonzero() {
 
 test_monitor_all_invalid_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --interval abc 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor --all --interval abc 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
     pass=$((pass + 1))
   else
@@ -385,7 +522,8 @@ test_monitor_all_invalid_interval_exits_nonzero() {
 
 test_monitor_all_zero_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --interval 0 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor --all --interval 0 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
     pass=$((pass + 1))
   else
@@ -396,12 +534,37 @@ test_monitor_all_zero_interval_exits_nonzero() {
 
 test_monitor_all_negative_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor --all --interval -1 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor --all --interval -1 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_missing_timeout_value_exits_nonzero() {
+  local output exit_code=0
+  setup_mocks
+  output=$(run_script monitor --all --timeout 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --timeout"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --timeout should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_invalid_timeout_exits_nonzero() {
+  local output exit_code=0
+  setup_mocks
+  output=$(run_script monitor --all --timeout abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid duration"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --timeout abc should exit 1 with invalid duration message (exit=$exit_code, output: $output)"
   fi
 }
 
@@ -480,6 +643,44 @@ test_monitor_all_api_failure_exits_nonzero() {
   fi
 }
 
+test_monitor_all_sha_api_timeout_continues() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_all_sha_api_timeout "$initial_checks" "$changed_checks" "[]" "[]"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all SHA API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_check_api_timeout_continues() {
+  local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_all_check_api_timeout "$initial_checks" "$changed_checks" "[]" "[]"
+  local output exit_code=0
+  output=$(run_script monitor --all --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all check-runs API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
 test_monitor_all_comment_api_timeout_continues() {
   local initial_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
   local changed_checks='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
@@ -496,6 +697,22 @@ test_monitor_all_comment_api_timeout_continues() {
   else
     fail=$((fail + 1))
     echo "FAIL: monitor --all comment API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_all_overall_timeout_after_api_timeout() {
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_all_api_timeout_no_change "$checks" "[]" "[]"
+  local output exit_code=0
+  output=$(run_script_with_real_sleep monitor --all --pr 42 --interval 1 --timeout 2s 2>&1) || exit_code=$?
+  cleanup_mock_counters
+  if [ "$exit_code" -eq 2 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all overall timeout should still fire after API timeout (exit=$exit_code, output: $output)"
   fi
 }
 

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -20,6 +20,7 @@ setup_mocks() {
     esac
   }
   gh() {
+    echo "gh: unexpected call: $*" >&2
     exit 1
   }
   sleep() {

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -207,6 +207,8 @@ test_names+=(
   test_monitor_comments_missing_pr_value_exits_nonzero
   test_monitor_comments_missing_interval_value_exits_nonzero
   test_monitor_comments_invalid_interval_exits_nonzero
+  test_monitor_comments_zero_interval_exits_nonzero
+  test_monitor_comments_negative_interval_exits_nonzero
   test_monitor_comments_missing_timeout_value_exits_nonzero
   test_monitor_comments_invalid_timeout_exits_nonzero
 )
@@ -325,13 +327,13 @@ test_monitor_comments_output_format() {
 }
 
 test_monitor_comments_check_flag_rejected() {
-  local output
-  output=$(bash "$script" monitor comments --check CI 2>&1) || true
-  if echo "$output" | grep -qF -- "--check is not supported for monitor comments"; then
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --check ci.yml 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF -- "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
     fail=$((fail + 1))
-    echo "FAIL: --check should be rejected (output: $output)"
+    echo "FAIL: --check should be rejected for monitor comments (exit=$exit_code, output: $output)"
   fi
 }
 
@@ -434,11 +436,47 @@ test_monitor_comments_missing_pr_value_exits_nonzero() {
 }
 
 test_monitor_comments_missing_interval_value_exits_nonzero() {
-  assert_exit 1 "monitor comments --interval without value exits 1" bash "$script" monitor comments --interval
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
 }
 
 test_monitor_comments_invalid_interval_exits_nonzero() {
-  assert_exit 1 "monitor comments --interval invalid exits 1" bash "$script" monitor comments --interval abc
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_comments_zero_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_comments_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor comments --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor comments --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 test_monitor_comments_missing_timeout_value_exits_nonzero() {

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -19,6 +19,9 @@ setup_mocks() {
       *) exit 1 ;;
     esac
   }
+  gh() {
+    exit 1
+  }
   sleep() {
     :
   }
@@ -329,7 +332,8 @@ test_monitor_comments_output_format() {
 
 test_monitor_comments_check_flag_rejected() {
   local output exit_code=0
-  output=$(bash "$script" monitor comments --check ci.yml 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor comments --check ci.yml 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF -- "unknown option: --check (only valid with monitor status)"; then
     pass=$((pass + 1))
   else
@@ -440,17 +444,21 @@ test_monitor_comments_api_failure_exits_nonzero() {
 }
 
 test_monitor_comments_help_exits_zero() {
-  assert_exit 0 "monitor comments --help exits 0" bash "$script" monitor comments --help
-  assert_exit 0 "monitor comments -h exits 0" bash "$script" monitor comments -h
+  setup_mocks
+  assert_exit 0 "monitor comments --help exits 0" run_script monitor comments --help
+  setup_mocks
+  assert_exit 0 "monitor comments -h exits 0" run_script monitor comments -h
 }
 
 test_monitor_comments_missing_pr_value_exits_nonzero() {
-  assert_exit 1 "monitor comments --pr without value exits 1" bash "$script" monitor comments --pr
+  setup_mocks
+  assert_exit 1 "monitor comments --pr without value exits 1" run_script monitor comments --pr
 }
 
 test_monitor_comments_missing_interval_value_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor comments --interval 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor comments --interval 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
     pass=$((pass + 1))
   else
@@ -461,7 +469,8 @@ test_monitor_comments_missing_interval_value_exits_nonzero() {
 
 test_monitor_comments_invalid_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor comments --interval abc 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor comments --interval abc 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
     pass=$((pass + 1))
   else
@@ -472,7 +481,8 @@ test_monitor_comments_invalid_interval_exits_nonzero() {
 
 test_monitor_comments_zero_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor comments --interval 0 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor comments --interval 0 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
     pass=$((pass + 1))
   else
@@ -483,7 +493,8 @@ test_monitor_comments_zero_interval_exits_nonzero() {
 
 test_monitor_comments_negative_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor comments --interval -1 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor comments --interval -1 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
     pass=$((pass + 1))
   else
@@ -493,9 +504,11 @@ test_monitor_comments_negative_interval_exits_nonzero() {
 }
 
 test_monitor_comments_missing_timeout_value_exits_nonzero() {
-  assert_exit 1 "monitor comments --timeout without value exits 1" bash "$script" monitor comments --timeout
+  setup_mocks
+  assert_exit 1 "monitor comments --timeout without value exits 1" run_script monitor comments --timeout
 }
 
 test_monitor_comments_invalid_timeout_exits_nonzero() {
-  assert_exit 1 "monitor comments --timeout invalid exits 1" bash "$script" monitor comments --timeout abc
+  setup_mocks
+  assert_exit 1 "monitor comments --timeout invalid exits 1" run_script monitor comments --timeout abc
 }

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -202,6 +202,7 @@ test_names+=(
   test_monitor_comments_explicit_pr
   test_monitor_comments_auto_detect
   test_monitor_comments_no_pr_exits_nonzero
+  test_monitor_comments_no_pr_stderr_message
   test_monitor_comments_api_failure_exits_nonzero
   test_monitor_comments_help_exits_zero
   test_monitor_comments_missing_pr_value_exits_nonzero
@@ -408,6 +409,18 @@ test_monitor_comments_no_pr_exits_nonzero() {
   else
     fail=$((fail + 1))
     echo "FAIL: no PR should exit non-zero"
+  fi
+}
+
+test_monitor_comments_no_pr_stderr_message() {
+  setup_mocks_monitor_comments_no_pr
+  local output
+  output=$(run_script monitor comments --interval 1 2>&1) || true
+  if echo "$output" | grep -qF "no open PR found for branch 'feature-branch'"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR stderr should contain no-open-PR message (output: $output)"
   fi
 }
 

--- a/test/test_monitor_signal.sh
+++ b/test/test_monitor_signal.sh
@@ -63,6 +63,7 @@ test_names+=(
   test_signal_comments_with_change_exits_130
   test_signal_comments_no_change_exits_130_silent
   test_signal_comments_sigterm_no_change_exits_130
+  test_signal_all_with_change_exits_130
 )
 
 # test_signal_status_with_change_exits_130 verifies that a signal during
@@ -347,5 +348,68 @@ test_signal_comments_sigterm_no_change_exits_130() {
   else
     fail=$((fail + 1))
     echo "FAIL: SIGTERM comments no change (exit=$_signal_exit_code, output: $_signal_output)"
+  fi
+}
+
+# test_signal_all_with_change_exits_130 verifies that a signal during
+# monitor --all triggers a final combined poll, emits detected status changes,
+# and exits 130. Uses SIGTERM because the script traps TERM and INT identically.
+test_signal_all_with_change_exits_130() {
+  _skip_check "signal all with change" && return 0
+
+  _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  _MOCK_CHANGED='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  _MOCK_INITIAL_REVIEWS='[]'
+  _MOCK_INITIAL_ISSUES='[]'
+  _MOCK_CHANGED_REVIEWS='[]'
+  _MOCK_CHANGED_ISSUES='[]'
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) echo "git: unexpected call: $*" >&2; exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "gh: replies endpoint should not be called: $*" >&2
+        exit 1
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *"pulls/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_REVIEWS" ;;
+      *"issues/42/comments"*"--paginate"*) echo "$_MOCK_INITIAL_ISSUES" ;;
+      *) echo "gh: unexpected call: $*" >&2; exit 1 ;;
+    esac
+  }
+
+  _SIGNAL_TMPDIR=$(mktemp -d)
+  _export_signal_mocks
+  _run_and_signal monitor --all --pr 42 --interval 5
+  cleanup_signal_tmpdir
+  cleanup_mock_counter
+
+  if [ "$_signal_exit_code" -eq 130 ] \
+    && echo "$_signal_output" | grep -qF -- "--- change" \
+    && echo "$_signal_output" | grep -qF "type: status" \
+    && echo "$_signal_output" | grep -qF "check: CI" \
+    && echo "$_signal_output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: signal all with change (exit=$_signal_exit_code, output: $_signal_output)"
   fi
 }

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -290,6 +290,7 @@ test_names+=(
   test_monitor_status_missing_interval_value_exits_nonzero
   test_monitor_status_invalid_interval_exits_nonzero
   test_monitor_status_zero_interval_exits_nonzero
+  test_monitor_status_negative_interval_exits_nonzero
   test_usage_lists_monitor
   test_monitor_status_timeout_exits_two
   test_monitor_status_timeout_stderr_message
@@ -574,19 +575,51 @@ test_monitor_status_missing_pr_value_exits_nonzero() {
 # test_monitor_status_missing_interval_value_exits_nonzero verifies that --interval
 # without a value exits 1 with a clear error message.
 test_monitor_status_missing_interval_value_exits_nonzero() {
-  assert_exit 1 "monitor status --interval without value exits 1" bash "$script" monitor status --interval
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval should exit 1 with missing value message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_invalid_interval_exits_nonzero verifies that --interval with
 # a non-numeric value exits 1.
 test_monitor_status_invalid_interval_exits_nonzero() {
-  assert_exit 1 "monitor status --interval abc exits 1" bash "$script" monitor status --interval abc
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval abc 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval abc should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_monitor_status_zero_interval_exits_nonzero verifies that --interval 0 is
 # rejected (zero is not a positive integer).
 test_monitor_status_zero_interval_exits_nonzero() {
-  assert_exit 1 "monitor status --interval 0 exits 1" bash "$script" monitor status --interval 0
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval 0 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval 0 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_negative_interval_exits_nonzero() {
+  local output exit_code=0
+  output=$(bash "$script" monitor status --interval -1 2>&1) || exit_code=$?
+  if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --interval -1 should exit 1 with invalid interval message (exit=$exit_code, output: $output)"
+  fi
 }
 
 # test_usage_lists_monitor verifies that the main --help output includes the monitor

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -24,9 +24,9 @@ _mock_call_should_timeout() {
   return 1
 }
 
-# setup_mocks defines mocked `git` and `sleep` shell functions used by the test harness;
+# setup_mocks defines mocked `git`, `gh`, and `sleep` shell functions used by the test harness;
 # `git` responds with fixed repo URL and branch values for known invocations and exits
-# nonzero for others; `sleep` is a no-op so polling tests complete instantly.
+# nonzero for others; `gh` defaults to fail closed; `sleep` is a no-op so polling tests complete instantly.
 setup_mocks() {
   _MOCK_TIMEOUT_CALLS=""
   git() {
@@ -36,6 +36,9 @@ setup_mocks() {
       "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
       *) exit 1 ;;
     esac
+  }
+  gh() {
+    exit 1
   }
   sleep() {
     :
@@ -576,7 +579,8 @@ test_monitor_status_missing_pr_value_exits_nonzero() {
 # without a value exits 1 with a clear error message.
 test_monitor_status_missing_interval_value_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor status --interval 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor status --interval 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "missing value for --interval"; then
     pass=$((pass + 1))
   else
@@ -589,7 +593,8 @@ test_monitor_status_missing_interval_value_exits_nonzero() {
 # a non-numeric value exits 1.
 test_monitor_status_invalid_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor status --interval abc 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor status --interval abc 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: abc"; then
     pass=$((pass + 1))
   else
@@ -602,7 +607,8 @@ test_monitor_status_invalid_interval_exits_nonzero() {
 # rejected (zero is not a positive integer).
 test_monitor_status_zero_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor status --interval 0 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor status --interval 0 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: 0"; then
     pass=$((pass + 1))
   else
@@ -613,7 +619,8 @@ test_monitor_status_zero_interval_exits_nonzero() {
 
 test_monitor_status_negative_interval_exits_nonzero() {
   local output exit_code=0
-  output=$(bash "$script" monitor status --interval -1 2>&1) || exit_code=$?
+  setup_mocks
+  output=$(run_script monitor status --interval -1 2>&1) || exit_code=$?
   if [ "$exit_code" -eq 1 ] && echo "$output" | grep -qF "invalid --interval value: -1"; then
     pass=$((pass + 1))
   else

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -14,10 +14,21 @@ _mock_counter_next() {
   echo "$val"
 }
 
+_mock_call_should_timeout() {
+  local call_num=$1 timeout_call
+  for timeout_call in $_MOCK_TIMEOUT_CALLS; do
+    if [ "$call_num" = "$timeout_call" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 # setup_mocks defines mocked `git` and `sleep` shell functions used by the test harness;
 # `git` responds with fixed repo URL and branch values for known invocations and exits
 # nonzero for others; `sleep` is a no-op so polling tests complete instantly.
 setup_mocks() {
+  _MOCK_TIMEOUT_CALLS=""
   git() {
     case "$*" in
       "rev-parse --git-dir") echo ".git" ;;
@@ -156,6 +167,64 @@ setup_mocks_monitor_api_failure() {
   }
 }
 
+setup_mocks_monitor_api_timeout() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  _MOCK_TIMEOUT_CALLS="$3"
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "$HEAD_SHA"
+        ;;
+      *"check-runs"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL"
+        else
+          echo "$_MOCK_CHANGED"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_api_timeout_no_change() {
+  _MOCK_INITIAL="$1"
+  _MOCK_CHANGED="$1"
+  _MOCK_TIMEOUT_CALLS="$2"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*) echo "$HEAD_SHA" ;;
+      *"check-runs"*"--paginate"*) echo "$_MOCK_INITIAL" ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 # setup_mocks_monitor_no_change configures git/gh mocks where data never changes,
 # suitable for timeout tests. Defines a sleep() wrapper that calls the real system
 # sleep so SECONDS advances correctly and no leaked mock from other tests interferes.
@@ -183,14 +252,14 @@ setup_mocks_monitor_no_change() {
 # run_script_with_real_sleep runs the script with mocked git/gh but real sleep,
 # so SECONDS-based timeout tests work correctly.
 run_script_with_real_sleep() {
-  export -f git gh sleep _mock_counter_next
-  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
+  export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
   timeout 15 bash "$script" "$@" </dev/null
 }
 
 run_script() {
-  export -f git gh sleep _mock_counter_next
-  export _MOCK_INITIAL _MOCK_CHANGED HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
+  export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
   timeout 15 bash "$script" "$@" </dev/null
 }
 
@@ -210,6 +279,9 @@ test_names+=(
   test_monitor_status_no_pr_exits_nonzero
   test_monitor_status_no_pr_stderr_message
   test_monitor_status_api_failure_exits_nonzero
+  test_monitor_status_check_api_timeout_continues
+  test_monitor_status_sha_api_timeout_continues
+  test_monitor_status_overall_timeout_after_api_timeout
   test_monitor_no_subcommand_exits_nonzero
   test_monitor_help_exits_zero
   test_monitor_status_help_exits_zero
@@ -414,6 +486,58 @@ test_monitor_status_api_failure_exits_nonzero() {
   else
     fail=$((fail + 1))
     echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+test_monitor_status_check_api_timeout_continues() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_api_timeout "$initial" "$changed" "4"
+  local output exit_code=0
+  output=$(run_script monitor status --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: check-runs timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_sha_api_timeout_continues() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  setup_mocks_monitor_api_timeout "$initial" "$changed" "3"
+  local output exit_code=0
+  output=$(run_script monitor status --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_status_overall_timeout_after_api_timeout() {
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  setup_mocks_monitor_api_timeout_no_change "$initial" "4"
+  local output exit_code=0
+  output=$(run_script_with_real_sleep monitor status --pr 42 --interval 1 --timeout 2s 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 2 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: overall timeout should still fire after API timeout (exit=$exit_code, output: $output)"
   fi
 }
 


### PR DESCRIPTION
## Summary
- Add delivery skill follow-up item guidance
- Add per-call timeout handling for monitor status API polling
- Add `monitor --all` combined status/comment polling
- Harden monitor input validation and edge-case test coverage

## Sprint 3 issues
- Refs #63
- Refs #65
- Refs #48
- Refs #49

## Follow-ups
- #74 tracks comments-monitor per-call timeout parity

## Review request
@claude @coderabbitai @codex please review and provide a written report, even if no findings are found.

## Tests
- `bash test/run.sh` (265 passed, 0 failed)