### PR TITLE
feat: add per-call timeout parity to monitor comments

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -810,8 +810,20 @@ cmd_monitor_comments() {
   local owner_repo
   owner_repo=$(resolve_owner_repo)
 
-  local initial_snapshot
-  initial_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+  local initial_snapshot call_timeout api_rc=0
+  if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+    exit 2
+  fi
+  if initial_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number" "$call_timeout" 2>/dev/null); then
+    :
+  else
+    api_rc=$?
+    if [ "$api_rc" -eq 124 ]; then
+      echo "monitor timed out after $timeout_input" >&2
+      exit 2
+    fi
+    die "failed to fetch comments for PR #$pr_number"
+  fi
 
   local _monitor_interrupted=0
   trap '_monitor_interrupted=1' INT TERM
@@ -839,8 +851,21 @@ cmd_monitor_comments() {
       exit 2
     fi
 
-    local cur_snapshot
-    cur_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number")
+    local cur_snapshot call_timeout api_rc=0
+    if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
+      exit 2
+    fi
+    if cur_snapshot=$(capture_comment_id_snapshot "$owner_repo" "$pr_number" "$call_timeout" 2>/dev/null); then
+      :
+    else
+      api_rc=$?
+      if [ "$api_rc" -eq 124 ]; then
+        monitor_api_timeout_warning
+        if [ "$_monitor_interrupted" -eq 1 ]; then exit 130; fi
+        continue
+      fi
+      die "failed to fetch comments during poll"
+    fi
 
     local new_ids
     new_ids=$(comm -23 <(echo "$cur_snapshot") <(echo "$initial_snapshot"))

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -810,6 +810,11 @@ cmd_monitor_comments() {
   local owner_repo
   owner_repo=$(resolve_owner_repo)
 
+  local _monitor_interrupted=0
+  trap '_monitor_interrupted=1' INT TERM
+
+  SECONDS=0
+
   local initial_snapshot call_timeout api_rc=0
   if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then
     exit 2
@@ -825,10 +830,6 @@ cmd_monitor_comments() {
     die "failed to fetch comments for PR #$pr_number"
   fi
 
-  local _monitor_interrupted=0
-  trap '_monitor_interrupted=1' INT TERM
-
-  SECONDS=0
   while true; do
     if [ -n "$timeout_secs" ] && [ "$SECONDS" -ge "$timeout_secs" ]; then
       echo "monitor timed out after $timeout_input" >&2

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -10,6 +10,16 @@ _mock_counter_next() {
   echo "$val"
 }
 
+_mock_call_should_timeout() {
+  local call_num=$1 timeout_call
+  for timeout_call in $_MOCK_TIMEOUT_CALLS; do
+    if [ "$call_num" = "$timeout_call" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 setup_mocks() {
   git() {
     case "$*" in
@@ -175,17 +185,95 @@ setup_mocks_monitor_comments_api_failure() {
   }
 }
 
+setup_mocks_monitor_comments_api_timeout() {
+  _MOCK_INITIAL_REVIEWS="$1"
+  _MOCK_INITIAL_ISSUES="$2"
+  _MOCK_CHANGED_REVIEWS="$3"
+  _MOCK_CHANGED_ISSUES="$4"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  setup_mocks
+  _MOCK_TIMEOUT_CALLS="$5"
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/comments/"*"/replies"*)
+        echo "ERROR: replies endpoint should not be called" >&2
+        exit 1
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 2 ]; then
+          echo "$_MOCK_INITIAL_REVIEWS"
+        else
+          echo "$_MOCK_CHANGED_REVIEWS"
+        fi
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        if [ "$call_num" -le 3 ]; then
+          echo "$_MOCK_INITIAL_ISSUES"
+        else
+          echo "$_MOCK_CHANGED_ISSUES"
+        fi
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+setup_mocks_monitor_comments_api_timeout_no_change() {
+  _MOCK_INITIAL_REVIEWS="$1"
+  _MOCK_INITIAL_ISSUES="$2"
+  _MOCK_TIMEOUT_CALLS="$3"
+  _MOCK_COUNTER_FILE=$(mktemp)
+  echo 0 > "$_MOCK_COUNTER_FILE"
+  sleep() { command sleep "$@"; }
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    local call_num
+    call_num=$(_mock_counter_next)
+    if _mock_call_should_timeout "$call_num"; then
+      exit 124
+    fi
+    case "$*" in
+      *"pulls/42"*"--paginate"*"--jq"*)
+        echo "abc123def456abc123def456abc123def456abc1"
+        ;;
+      *"pulls/42/comments"*"--paginate"*)
+        echo "$_MOCK_INITIAL_REVIEWS"
+        ;;
+      *"issues/42/comments"*"--paginate"*)
+        echo "$_MOCK_INITIAL_ISSUES"
+        ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
 run_script() {
-  export -f git gh sleep _mock_counter_next
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
-  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE
+  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE _MOCK_TIMEOUT_CALLS
   timeout 15 bash "$script" "$@" </dev/null
 }
 
 run_script_with_real_sleep() {
-  export -f git gh sleep _mock_counter_next
+  export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
-  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE
+  export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE _MOCK_TIMEOUT_CALLS
   timeout 15 bash "$script" "$@" </dev/null
 }
 
@@ -216,6 +304,8 @@ test_names+=(
   test_monitor_comments_negative_interval_exits_nonzero
   test_monitor_comments_missing_timeout_value_exits_nonzero
   test_monitor_comments_invalid_timeout_exits_nonzero
+  test_monitor_comments_api_timeout_continues
+  test_monitor_comments_overall_timeout_after_api_timeout
 )
 
 test_monitor_comments_new_review_comment() {
@@ -512,4 +602,41 @@ test_monitor_comments_missing_timeout_value_exits_nonzero() {
 test_monitor_comments_invalid_timeout_exits_nonzero() {
   setup_mocks
   assert_exit 1 "monitor comments --timeout invalid exits 1" run_script monitor comments --timeout abc
+}
+
+test_monitor_comments_api_timeout_continues() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local changed_issues='[]'
+  setup_mocks_monitor_comments_api_timeout "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues" "4"
+  local output exit_code=0
+  output=$(run_script monitor comments --pr 42 --interval 1 --timeout 5m 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 0 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API timeout should warn, retry, and detect change (exit=$exit_code, output: $output)"
+  fi
+}
+
+test_monitor_comments_overall_timeout_after_api_timeout() {
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local initial_issues='[]'
+  setup_mocks_monitor_comments_api_timeout_no_change "$initial_reviews" "$initial_issues" "3"
+  local output exit_code=0
+  output=$(run_script_with_real_sleep monitor comments --pr 42 --interval 1 --timeout 2s 2>&1) || exit_code=$?
+  cleanup_mock_counter
+  if [ "$exit_code" -eq 2 ] \
+    && echo "$output" | grep -qF "gh api call timed out; retrying next poll" \
+    && echo "$output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: overall timeout should still fire after API timeout (exit=$exit_code, output: $output)"
+  fi
 }


### PR DESCRIPTION
## Summary

- Wire per-call timeout support into `cmd_monitor_comments` polling loop, matching the pattern already used by `cmd_monitor_status` and `cmd_monitor_all`
- When `--timeout` is specified, each API call in the comments polling loop is bounded by the remaining time budget
- A timed-out poll logs a stderr warning (`gh api call timed out; retrying next poll`) and retries on the next cycle instead of terminating
- The initial snapshot is also wrapped with the timeout, exiting 2 if it expires before the first fetch completes
- Add two new tests: `test_monitor_comments_api_timeout_continues` and `test_monitor_comments_overall_timeout_after_api_timeout`

## Acceptance criteria (#74)

- [x] `monitor comments --timeout <dur>` applies a per-call deadline to review comment API calls
- [x] `monitor comments --timeout <dur>` applies a per-call deadline to issue comment API calls
- [x] A per-call timeout logs a one-line stderr warning and continues to the next poll cycle
- [x] The overall `--timeout` wall-clock deadline is still respected
- [x] Existing monitor comments behavior and output format are unchanged
- [x] `bash test/run.sh` passes (279 passed, 0 failed)

## Test plan

- `test_monitor_comments_api_timeout_continues`: mock returns exit 124 on one poll, then succeeds with a new comment — verifies warning is logged and change is still detected
- `test_monitor_comments_overall_timeout_after_api_timeout`: mock always returns 124 with `--timeout 2s` + real sleep — verifies exit 2 and both timeout messages appear

Closes #74