### PR TITLE
Add Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Invoke-WebRequest https://raw.githubusercontent.com/akepo225/gh-pr-context/maste
 
 The Windows installer requires `gh`, `git`, and Python 3.11+ available as `py`, `python`, or `python3`. It installs the Python entry point and a `gh-pr-context.cmd` shim to `$env:USERPROFILE\.local\bin` by default, or to `$env:INSTALL_DIR` when set. Pin a version with `$env:GH_PR_CONTEXT_VERSION = "v0.2.5"` before running the installer.
 
+Note: native Windows support currently verifies the install path with `gh-pr-context --version`; only `--version` and `--help` are available until full `comments`, `status`, `logs`, and `monitor` command support lands in later Windows slices.
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ For example, to install `v0.2.2`:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.2 bash
 ```
 
+Windows PowerShell install:
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.ps1 -OutFile install.ps1
+.\install.ps1
+```
+
+The Windows installer requires `gh`, `git`, and Python 3.11+ available as `py`, `python`, or `python3`. It installs the Python entry point and a `gh-pr-context.cmd` shim to `$env:USERPROFILE\.local\bin` by default, or to `$env:INSTALL_DIR` when set. Pin a version with `$env:GH_PR_CONTEXT_VERSION = "v0.2.5"` before running the installer.
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -10,20 +10,13 @@ def die(message):
 
 
 def usage():
-    print("usage: gh-pr-context <command> [options]")
-    print("")
-    print("commands:")
-    print("  comments   Fetch PR comments")
-    print("  status     Fetch CI check status")
-    print("  logs       Fetch logs for failed CI checks")
-    print("  monitor    Poll for changes to CI status or comments")
+    print("usage: gh-pr-context [--version|--help]")
     print("")
     print("options:")
-    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
-    print("  --since <ref>   Filter comments by time")
-    print("  --all           Return all comments (default)")
     print("  --version       Show version")
     print("  -h, --help      Show this message")
+    print("")
+    print("note: Windows Python runtime currently supports --version and --help only")
 
 
 def main(argv):
@@ -42,7 +35,7 @@ def main(argv):
         usage()
         return 0
 
-    return die("Windows Python runtime currently supports --version only")
+    return die("Windows Python runtime currently supports --version and --help only")
 
 
 if __name__ == "__main__":

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import sys
+
+VERSION = "0.2.5"
+
+
+def die(message):
+    print(f"error: {message}", file=sys.stderr)
+    return 1
+
+
+def usage():
+    print("usage: gh-pr-context <command> [options]")
+    print("")
+    print("commands:")
+    print("  comments   Fetch PR comments")
+    print("  status     Fetch CI check status")
+    print("  logs       Fetch logs for failed CI checks")
+    print("  monitor    Poll for changes to CI status or comments")
+    print("")
+    print("options:")
+    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
+    print("  --since <ref>   Filter comments by time")
+    print("  --all           Return all comments (default)")
+    print("  --version       Show version")
+    print("  -h, --help      Show this message")
+
+
+def main(argv):
+    if sys.version_info < (3, 11):
+        return die("python 3.11+ is required")
+
+    if not argv:
+        usage()
+        return 1
+
+    command = argv[0]
+    if command == "--version":
+        print(f"gh-pr-context {VERSION}")
+        return 0
+    if command in ("-h", "--help"):
+        usage()
+        return 0
+
+    return die("Windows Python runtime currently supports --version only")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/install.ps1
+++ b/install.ps1
@@ -175,9 +175,14 @@ if (-not $installDirOnPath) {
     $env:Path = "$InstallDir;$env:Path"
 }
 
-$versionOutput = & $ScriptName --version 2>$null
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+$versionOutput = & $WrapperPath --version 2>$null
+if (
+    $LASTEXITCODE -ne 0 -or
+    [string]::IsNullOrWhiteSpace($versionOutput) -or
+    $versionOutput -notmatch "^$ScriptName\s+\S+"
+) {
     Die "failed to run $ScriptName --version"
 }
 
 Write-Output "verified $versionOutput"
+Write-Output "note: Windows Python runtime currently supports --version and --help only"

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,183 @@
+[CmdletBinding()]
+param(
+    [string]$InstallDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repo = "akepo225/gh-pr-context"
+$ScriptName = "gh-pr-context"
+$PythonArtifact = "gh-pr-context.py"
+$WrapperName = "gh-pr-context.cmd"
+$VersionRef = if ([string]::IsNullOrWhiteSpace($env:GH_PR_CONTEXT_VERSION)) { "master" } else { $env:GH_PR_CONTEXT_VERSION }
+
+function Die {
+    param([string]$Message)
+    [Console]::Error.WriteLine("error: $Message")
+    exit 1
+}
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Die "$Name is required but not found on PATH"
+    }
+}
+
+function Quote-CmdArgument {
+    param([string]$Value)
+    '"' + ($Value -replace '"', '\"') + '"'
+}
+
+function Quote-PowerShellSingleQuotedString {
+    param([string]$Value)
+    "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Test-PathContainsDirectory {
+    param(
+        [string]$PathValue,
+        [string]$Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    $target = [System.IO.Path]::GetFullPath($Directory).TrimEnd('\', '/')
+    foreach ($entry in ($PathValue -split ';')) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+        try {
+            $candidate = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($entry)).TrimEnd('\', '/')
+        } catch {
+            continue
+        }
+        if ([StringComparer]::OrdinalIgnoreCase.Equals($candidate, $target)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-PythonCandidate {
+    param(
+        [string]$Command,
+        [string[]]$Arguments
+    )
+
+    $resolved = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $resolved -or $resolved.CommandType -ne "Application") {
+        return $null
+    }
+
+    $probe = "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"
+    & $Command @Arguments -c $probe *> $null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $commandPath = if ($resolved.Source) { $resolved.Source } else { $Command }
+    [pscustomobject]@{
+        Command = $commandPath
+        Arguments = $Arguments
+    }
+}
+
+function Resolve-Python {
+    $candidates = @(
+        @{ Command = "py"; Arguments = @("-3") },
+        @{ Command = "python"; Arguments = @() },
+        @{ Command = "python3"; Arguments = @() }
+    )
+
+    foreach ($candidate in $candidates) {
+        $python = Test-PythonCandidate -Command $candidate.Command -Arguments $candidate.Arguments
+        if ($python) {
+            return $python
+        }
+    }
+
+    Die "python 3.11+ is required but was not found as py, python, or python3"
+}
+
+if ($VersionRef -notmatch '^[a-zA-Z0-9._/-]+$') {
+    Die "invalid GH_PR_CONTEXT_VERSION: $VersionRef"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+    Die "USERPROFILE is not set"
+}
+
+Require-Command "gh"
+Require-Command "git"
+$Python = Resolve-Python
+
+if (-not [string]::IsNullOrWhiteSpace($env:INSTALL_DIR)) {
+    $InstallDir = $env:INSTALL_DIR
+} elseif ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+} catch {
+    Die "failed to create directory: $InstallDir"
+}
+
+$RawBase = "https://raw.githubusercontent.com/$Repo/$VersionRef"
+$DownloadUrl = "$RawBase/$PythonArtifact"
+$PythonPath = Join-Path $InstallDir $PythonArtifact
+$WrapperPath = Join-Path $InstallDir $WrapperName
+$TempPath = [System.IO.Path]::GetTempFileName()
+
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempPath -UseBasicParsing | Out-Null
+} catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Die "failed to download $PythonArtifact"
+}
+
+try {
+    Move-Item -LiteralPath $TempPath -Destination $PythonPath -Force
+} catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Die "failed to write to $PythonPath"
+}
+
+$pythonCommand = @($Python.Command) + @($Python.Arguments)
+$pythonInvocation = ($pythonCommand | ForEach-Object { Quote-CmdArgument $_ }) -join " "
+$wrapper = @(
+    "@echo off",
+    "setlocal",
+    'set "SCRIPT_DIR=%~dp0"',
+    'set "SCRIPT=%SCRIPT_DIR%gh-pr-context.py"',
+    "$pythonInvocation ""%SCRIPT%"" %*",
+    "exit /b %ERRORLEVEL%"
+) -join "`r`n"
+
+try {
+    Set-Content -LiteralPath $WrapperPath -Value $wrapper -Encoding ASCII
+} catch {
+    Die "failed to write to $WrapperPath"
+}
+
+Write-Output "installed $ScriptName to $WrapperPath"
+
+$installDirOnPath = Test-PathContainsDirectory -PathValue $env:Path -Directory $InstallDir
+if (-not $installDirOnPath) {
+    $quotedInstallDir = Quote-PowerShellSingleQuotedString $InstallDir
+    [Console]::Error.WriteLine("warning: $ScriptName is not on your PATH")
+    [Console]::Error.WriteLine("  Add it for future PowerShell prompts by running:")
+    [Console]::Error.WriteLine("    [Environment]::SetEnvironmentVariable('Path', $quotedInstallDir + ';' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')")
+    $env:Path = "$InstallDir;$env:Path"
+}
+
+$versionOutput = & $ScriptName --version 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+    Die "failed to run $ScriptName --version"
+}
+
+Write-Output "verified $versionOutput"


### PR DESCRIPTION
## Summary
- add a Windows PowerShell installer that downloads the Python runtime artifact from GitHub
- install `gh-pr-context.py` plus a `gh-pr-context.cmd` shim for PowerShell command resolution
- document the Windows install path and Python 3.11+ requirement

## Validation
- `bash test/run.sh` (279 passed, 0 failed)

Refs #56

Reviewers: @claude @coderabbitai @codex