### PR TITLE
Sprint 5 Windows foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Install gh-pr-context
         env:
-          GH_PR_CONTEXT_VERSION: ${{ github.head_ref || github.ref_name }}
+          GH_PR_CONTEXT_VERSION: ${{ github.event.pull_request.head.sha || github.sha }}
           INSTALL_DIR: ${{ runner.temp }}\gh-pr-context-bin
         run: .\install.ps1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Smoke test version command
         run: |
-          $expected = (Select-String -Path .\gh-pr-context -Pattern '^version=').Line -replace '^version="([^"]+)".*$', '$1'
+          $expected = (Select-String -Path .\gh-pr-context.py -Pattern '^VERSION\s*=').Line -replace '^VERSION\s*=\s*"([^"]+)".*$', '$1'
           $actual = gh-pr-context --version
           if ($actual -ne "gh-pr-context $expected") {
             Write-Error "Expected gh-pr-context $expected, got $actual"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,34 @@ jobs:
       - name: Tests
         run: bash test/run.sh
 
+  windows-smoke:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install gh-pr-context
+        env:
+          GH_PR_CONTEXT_VERSION: ${{ github.head_ref || github.ref_name }}
+          INSTALL_DIR: ${{ runner.temp }}\gh-pr-context-bin
+        run: .\install.ps1
+
+      - name: Add install directory to PATH
+        run: Add-Content -Path $env:GITHUB_PATH -Value "${{ runner.temp }}\gh-pr-context-bin"
+
+      - name: Smoke test version command
+        run: |
+          $expected = (Select-String -Path .\gh-pr-context -Pattern '^version=').Line -replace '^version="([^"]+)".*$', '$1'
+          $actual = gh-pr-context --version
+          if ($actual -ne "gh-pr-context $expected") {
+            Write-Error "Expected gh-pr-context $expected, got $actual"
+            exit 1
+          }
+          Write-Output $actual
+
   version-check:
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Invoke-WebRequest https://raw.githubusercontent.com/akepo225/gh-pr-context/maste
 
 The Windows installer requires `gh`, `git`, and Python 3.11+ available as `py`, `python`, or `python3`. It installs the Python entry point and a `gh-pr-context.cmd` shim to `$env:USERPROFILE\.local\bin` by default, or to `$env:INSTALL_DIR` when set. Pin a version with `$env:GH_PR_CONTEXT_VERSION = "v0.2.5"` before running the installer.
 
+Note: native Windows support currently verifies the install path with `gh-pr-context --version`; only `--version` and `--help` are available until full `comments`, `status`, `logs`, and `monitor` command support lands in later Windows slices.
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ For example, to install `v0.2.2`:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.2 bash
 ```
 
+Windows PowerShell install:
+
+```powershell
+Invoke-WebRequest https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.ps1 -OutFile install.ps1
+.\install.ps1
+```
+
+The Windows installer requires `gh`, `git`, and Python 3.11+ available as `py`, `python`, or `python3`. It installs the Python entry point and a `gh-pr-context.cmd` shim to `$env:USERPROFILE\.local\bin` by default, or to `$env:INSTALL_DIR` when set. Pin a version with `$env:GH_PR_CONTEXT_VERSION = "v0.2.5"` before running the installer.
+
 ## Usage
 
 All commands auto-detect the PR from the current branch. Pass `--pr <number>` to target a specific PR.

--- a/README.md
+++ b/README.md
@@ -4,11 +4,26 @@ Token-efficient PR context CLI for LLM coding assistants. Wraps `gh api` to fetc
 
 ## Requirements
 
+All runtimes require:
+
 - [gh](https://cli.github.com/) (authenticated)
+- [git](https://git-scm.com/)
+
+Unix-like Bash runtime:
+
 - [jq](https://jqlang.github.io/jq/)
 - bash 5.1+
 
+Native Windows runtime:
+
+- Python 3.11+ available as `py`, `python`, or `python3`
+- PowerShell for running `install.ps1`
+
+`jq` and Bash are not required for native Windows usage.
+
 ## Install
+
+### Unix-like Bash
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | bash
@@ -38,14 +53,34 @@ For example, to install `v0.2.2`:
 curl -fsSL https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.sh | GH_PR_CONTEXT_VERSION=v0.2.2 bash
 ```
 
-Windows PowerShell install:
+### Windows PowerShell
 
 ```powershell
 Invoke-WebRequest https://raw.githubusercontent.com/akepo225/gh-pr-context/master/install.ps1 -OutFile install.ps1
 .\install.ps1
 ```
 
-The Windows installer requires `gh`, `git`, and Python 3.11+ available as `py`, `python`, or `python3`. It installs the Python entry point and a `gh-pr-context.cmd` shim to `$env:USERPROFILE\.local\bin` by default, or to `$env:INSTALL_DIR` when set. Pin a version with `$env:GH_PR_CONTEXT_VERSION = "v0.2.5"` before running the installer.
+Install to a custom directory:
+
+```powershell
+.\install.ps1 -InstallDir C:\tools
+```
+
+Or use the `INSTALL_DIR` environment variable:
+
+```powershell
+$env:INSTALL_DIR = "C:\tools"
+.\install.ps1
+```
+
+Install a specific version:
+
+```powershell
+$env:GH_PR_CONTEXT_VERSION = "v0.2.5"
+.\install.ps1
+```
+
+The Windows installer downloads `gh-pr-context.py`, creates a `gh-pr-context.cmd` shim, and installs both to `$env:USERPROFILE\.local\bin` by default. If the install directory is not on PATH, it prints the PowerShell command needed to add it persistently.
 
 Note: native Windows support currently verifies the install path with `gh-pr-context --version`; only `--version` and `--help` are available until full `comments`, `status`, `logs`, and `monitor` command support lands in later Windows slices.
 

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -10,20 +10,13 @@ def die(message):
 
 
 def usage():
-    print("usage: gh-pr-context <command> [options]")
-    print("")
-    print("commands:")
-    print("  comments   Fetch PR comments")
-    print("  status     Fetch CI check status")
-    print("  logs       Fetch logs for failed CI checks")
-    print("  monitor    Poll for changes to CI status or comments")
+    print("usage: gh-pr-context [--version|--help]")
     print("")
     print("options:")
-    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
-    print("  --since <ref>   Filter comments by time")
-    print("  --all           Return all comments (default)")
     print("  --version       Show version")
     print("  -h, --help      Show this message")
+    print("")
+    print("note: Windows Python runtime currently supports --version and --help only")
 
 
 def main(argv):
@@ -42,7 +35,7 @@ def main(argv):
         usage()
         return 0
 
-    return die("Windows Python runtime currently supports --version only")
+    return die("Windows Python runtime currently supports --version and --help only")
 
 
 if __name__ == "__main__":

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -1,0 +1,49 @@
+#!/usr/bin/env python3
+import sys
+
+VERSION = "0.2.5"
+
+
+def die(message):
+    print(f"error: {message}", file=sys.stderr)
+    return 1
+
+
+def usage():
+    print("usage: gh-pr-context <command> [options]")
+    print("")
+    print("commands:")
+    print("  comments   Fetch PR comments")
+    print("  status     Fetch CI check status")
+    print("  logs       Fetch logs for failed CI checks")
+    print("  monitor    Poll for changes to CI status or comments")
+    print("")
+    print("options:")
+    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
+    print("  --since <ref>   Filter comments by time")
+    print("  --all           Return all comments (default)")
+    print("  --version       Show version")
+    print("  -h, --help      Show this message")
+
+
+def main(argv):
+    if sys.version_info < (3, 11):
+        return die("python 3.11+ is required")
+
+    if not argv:
+        usage()
+        return 1
+
+    command = argv[0]
+    if command == "--version":
+        print(f"gh-pr-context {VERSION}")
+        return 0
+    if command in ("-h", "--help"):
+        usage()
+        return 0
+
+    return die("Windows Python runtime currently supports --version only")
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/install.ps1
+++ b/install.ps1
@@ -175,9 +175,14 @@ if (-not $installDirOnPath) {
     $env:Path = "$InstallDir;$env:Path"
 }
 
-$versionOutput = & $ScriptName --version 2>$null
-if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+$versionOutput = & $WrapperPath --version 2>$null
+if (
+    $LASTEXITCODE -ne 0 -or
+    [string]::IsNullOrWhiteSpace($versionOutput) -or
+    $versionOutput -notmatch "^$ScriptName\s+\S+"
+) {
     Die "failed to run $ScriptName --version"
 }
 
 Write-Output "verified $versionOutput"
+Write-Output "note: Windows Python runtime currently supports --version and --help only"

--- a/install.ps1
+++ b/install.ps1
@@ -147,8 +147,10 @@ try {
     Die "failed to write to $PythonPath"
 }
 
-$pythonCommand = @($Python.Command) + @($Python.Arguments)
-$pythonInvocation = ($pythonCommand | ForEach-Object { Quote-CmdArgument $_ }) -join " "
+$pythonInvocation = Quote-CmdArgument $Python.Command
+if ($Python.Arguments.Count -gt 0) {
+    $pythonInvocation = "$pythonInvocation $($Python.Arguments -join ' ')"
+}
 $wrapper = @(
     "@echo off",
     "setlocal",

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,183 @@
+[CmdletBinding()]
+param(
+    [string]$InstallDir
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = "Stop"
+
+$Repo = "akepo225/gh-pr-context"
+$ScriptName = "gh-pr-context"
+$PythonArtifact = "gh-pr-context.py"
+$WrapperName = "gh-pr-context.cmd"
+$VersionRef = if ([string]::IsNullOrWhiteSpace($env:GH_PR_CONTEXT_VERSION)) { "master" } else { $env:GH_PR_CONTEXT_VERSION }
+
+function Die {
+    param([string]$Message)
+    [Console]::Error.WriteLine("error: $Message")
+    exit 1
+}
+
+function Require-Command {
+    param([string]$Name)
+    if (-not (Get-Command $Name -ErrorAction SilentlyContinue)) {
+        Die "$Name is required but not found on PATH"
+    }
+}
+
+function Quote-CmdArgument {
+    param([string]$Value)
+    '"' + ($Value -replace '"', '\"') + '"'
+}
+
+function Quote-PowerShellSingleQuotedString {
+    param([string]$Value)
+    "'" + ($Value -replace "'", "''") + "'"
+}
+
+function Test-PathContainsDirectory {
+    param(
+        [string]$PathValue,
+        [string]$Directory
+    )
+
+    if ([string]::IsNullOrWhiteSpace($PathValue)) {
+        return $false
+    }
+
+    $target = [System.IO.Path]::GetFullPath($Directory).TrimEnd('\', '/')
+    foreach ($entry in ($PathValue -split ';')) {
+        if ([string]::IsNullOrWhiteSpace($entry)) {
+            continue
+        }
+        try {
+            $candidate = [System.IO.Path]::GetFullPath([Environment]::ExpandEnvironmentVariables($entry)).TrimEnd('\', '/')
+        } catch {
+            continue
+        }
+        if ([StringComparer]::OrdinalIgnoreCase.Equals($candidate, $target)) {
+            return $true
+        }
+    }
+    return $false
+}
+
+function Test-PythonCandidate {
+    param(
+        [string]$Command,
+        [string[]]$Arguments
+    )
+
+    $resolved = Get-Command $Command -ErrorAction SilentlyContinue
+    if (-not $resolved -or $resolved.CommandType -ne "Application") {
+        return $null
+    }
+
+    $probe = "import sys; sys.exit(0 if sys.version_info >= (3, 11) else 1)"
+    & $Command @Arguments -c $probe *> $null
+    if ($LASTEXITCODE -ne 0) {
+        return $null
+    }
+
+    $commandPath = if ($resolved.Source) { $resolved.Source } else { $Command }
+    [pscustomobject]@{
+        Command = $commandPath
+        Arguments = $Arguments
+    }
+}
+
+function Resolve-Python {
+    $candidates = @(
+        @{ Command = "py"; Arguments = @("-3") },
+        @{ Command = "python"; Arguments = @() },
+        @{ Command = "python3"; Arguments = @() }
+    )
+
+    foreach ($candidate in $candidates) {
+        $python = Test-PythonCandidate -Command $candidate.Command -Arguments $candidate.Arguments
+        if ($python) {
+            return $python
+        }
+    }
+
+    Die "python 3.11+ is required but was not found as py, python, or python3"
+}
+
+if ($VersionRef -notmatch '^[a-zA-Z0-9._/-]+$') {
+    Die "invalid GH_PR_CONTEXT_VERSION: $VersionRef"
+}
+
+if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+    Die "USERPROFILE is not set"
+}
+
+Require-Command "gh"
+Require-Command "git"
+$Python = Resolve-Python
+
+if (-not [string]::IsNullOrWhiteSpace($env:INSTALL_DIR)) {
+    $InstallDir = $env:INSTALL_DIR
+} elseif ([string]::IsNullOrWhiteSpace($InstallDir)) {
+    $InstallDir = Join-Path $env:USERPROFILE ".local\bin"
+}
+
+try {
+    New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+} catch {
+    Die "failed to create directory: $InstallDir"
+}
+
+$RawBase = "https://raw.githubusercontent.com/$Repo/$VersionRef"
+$DownloadUrl = "$RawBase/$PythonArtifact"
+$PythonPath = Join-Path $InstallDir $PythonArtifact
+$WrapperPath = Join-Path $InstallDir $WrapperName
+$TempPath = [System.IO.Path]::GetTempFileName()
+
+try {
+    Invoke-WebRequest -Uri $DownloadUrl -OutFile $TempPath -UseBasicParsing | Out-Null
+} catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Die "failed to download $PythonArtifact"
+}
+
+try {
+    Move-Item -LiteralPath $TempPath -Destination $PythonPath -Force
+} catch {
+    Remove-Item -LiteralPath $TempPath -Force -ErrorAction SilentlyContinue
+    Die "failed to write to $PythonPath"
+}
+
+$pythonCommand = @($Python.Command) + @($Python.Arguments)
+$pythonInvocation = ($pythonCommand | ForEach-Object { Quote-CmdArgument $_ }) -join " "
+$wrapper = @(
+    "@echo off",
+    "setlocal",
+    'set "SCRIPT_DIR=%~dp0"',
+    'set "SCRIPT=%SCRIPT_DIR%gh-pr-context.py"',
+    "$pythonInvocation ""%SCRIPT%"" %*",
+    "exit /b %ERRORLEVEL%"
+) -join "`r`n"
+
+try {
+    Set-Content -LiteralPath $WrapperPath -Value $wrapper -Encoding ASCII
+} catch {
+    Die "failed to write to $WrapperPath"
+}
+
+Write-Output "installed $ScriptName to $WrapperPath"
+
+$installDirOnPath = Test-PathContainsDirectory -PathValue $env:Path -Directory $InstallDir
+if (-not $installDirOnPath) {
+    $quotedInstallDir = Quote-PowerShellSingleQuotedString $InstallDir
+    [Console]::Error.WriteLine("warning: $ScriptName is not on your PATH")
+    [Console]::Error.WriteLine("  Add it for future PowerShell prompts by running:")
+    [Console]::Error.WriteLine("    [Environment]::SetEnvironmentVariable('Path', $quotedInstallDir + ';' + [Environment]::GetEnvironmentVariable('Path', 'User'), 'User')")
+    $env:Path = "$InstallDir;$env:Path"
+}
+
+$versionOutput = & $ScriptName --version 2>$null
+if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($versionOutput)) {
+    Die "failed to run $ScriptName --version"
+}
+
+Write-Output "verified $versionOutput"


### PR DESCRIPTION
## Summary
- deliver Sprint 5 Windows foundation work
- add Windows PowerShell installer and Python `--version` smoke entry point
- add `windows-smoke` GitHub Actions job on `windows-latest`
- fix Windows installer wrapper generation for the `py -3` launcher path

## Included issue PRs
- #80 for #56
- #81 for #60

## Validation
- final `bash test/run.sh` on `sprint/5`: 279 passed, 0 failed
- #81 GitHub checks: `lint-and-test` passed, `windows-smoke` passed, CodeRabbit passed

Closes #56
Closes #60