### PR TITLE
Sprint 6: Python commands port (comments, status, logs)

### DIFF
--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -1,22 +1,493 @@
 #!/usr/bin/env python3
+import json
+import os
+import re
+import shlex
+import subprocess
 import sys
+from datetime import datetime, timezone
 
 VERSION = "0.2.5"
 
 
 def die(message):
     print(f"error: {message}", file=sys.stderr)
-    return 1
+    sys.exit(1)
+
+
+def _git_cmd():
+    override = os.environ.get("GH_PR_CONTEXT_GIT")
+    if override:
+        return shlex.split(override)
+    return ["git"]
+
+
+def _gh_cmd():
+    override = os.environ.get("GH_PR_CONTEXT_GH")
+    if override:
+        return shlex.split(override)
+    return ["gh"]
+
+
+def run_cmd(args, timeout=None):
+    result = subprocess.run(
+        args, capture_output=True, text=True, timeout=timeout
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def run_git(*args):
+    out, rc = run_cmd(_git_cmd() + list(args))
+    if rc != 0:
+        die(f"git {' '.join(args)} failed")
+    return out
+
+
+def run_git_ok(*args):
+    return run_cmd(_git_cmd() + list(args))
+
+
+def parse_paginated_json(raw):
+    if not raw or not raw.strip():
+        return []
+    decoder = json.JSONDecoder()
+    pos = 0
+    items = []
+    raw = raw.strip()
+    while pos < len(raw):
+        while pos < len(raw) and raw[pos] in " \t\n\r":
+            pos += 1
+        if pos >= len(raw):
+            break
+        try:
+            obj, end = decoder.raw_decode(raw, pos)
+            if isinstance(obj, list):
+                items.extend(obj)
+            else:
+                items.append(obj)
+            pos = end
+        except json.JSONDecodeError:
+            break
+    return items
+
+
+def gh_api_paginated(endpoint):
+    args = _gh_cmd() + ["api", "--paginate", endpoint]
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None, False
+    return result.stdout, True
+
+
+def gh_api_jq(endpoint, jq_filter):
+    args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None, False
+    return result.stdout.strip().replace("\r", ""), True
+
+
+def check_deps():
+    from shutil import which
+    for cmd in ("gh", "git"):
+        if not which(cmd):
+            die(f"{cmd} is required but not found on PATH")
+    out, rc = run_cmd(["git", "rev-parse", "--git-dir"])
+    if rc != 0:
+        die("not a git repository")
+
+
+def resolve_owner_repo():
+    remote_url = run_git("remote", "get-url", "origin")
+    m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", remote_url)
+    if not m:
+        die("failed to parse owner/repo from remote url")
+    return m.group(1)
+
+
+def resolve_pr_number():
+    branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
+    owner_repo = resolve_owner_repo()
+    owner, repo = owner_repo.split("/", 1)
+    endpoint = f"repos/{owner}/{repo}/pulls?head={owner}:{branch}"
+    val, ok = gh_api_jq(endpoint, ".[0].number")
+    if not ok:
+        die(f"failed to look up PR for branch '{branch}'")
+    if not val or val == "null":
+        die(f"no open PR found for branch '{branch}'")
+    return val
+
+
+def validate_since_format(value):
+    if not value:
+        return
+    if value == "last-commit":
+        return
+    if re.match(r"^[0-9a-fA-F]{7,40}$", value):
+        return
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        ts = f"{value}T00:00:00Z"
+        _validate_iso(ts, value)
+        return
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", value):
+        ts = f"{value}Z"
+        _validate_iso(ts, value)
+        return
+    die(f"invalid --since value: {value} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def _validate_iso(ts, original):
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        formatted = dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        expected = ts.replace("Z", "+00:00")
+        if formatted != expected:
+            raise ValueError
+    except (ValueError, OverflowError):
+        die(f"invalid --since value: {original} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def resolve_since_timestamp(since_input):
+    if not since_input:
+        return ""
+    if since_input == "last-commit":
+        out, rc = run_cmd(["git", "log", "-1", "--format=%ct", "HEAD"])
+        if rc != 0:
+            die("failed to resolve last-commit timestamp")
+        epoch = int(out.strip())
+        dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if re.match(r"^[0-9a-fA-F]{7,40}$", since_input):
+        expanded = ""
+        exp_out, exp_rc = run_git_ok("rev-parse", since_input)
+        if exp_rc == 0:
+            expanded = exp_out.strip()
+        if expanded:
+            epoch_out, log_rc = run_cmd(["git", "log", "-1", "--format=%ct", expanded])
+            if log_rc == 0:
+                epoch = int(epoch_out.strip())
+                dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+                return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        sha_for_api = expanded or since_input
+        owner_repo = resolve_owner_repo()
+        api_date, ok = gh_api_jq(
+            f"repos/{owner_repo}/commits/{sha_for_api}",
+            ".commit.committer.date",
+        )
+        if not ok or not api_date:
+            die(f"unknown commit: {since_input}")
+        try:
+            dt = datetime.fromisoformat(api_date.replace("Z", "+00:00"))
+            return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        except (ValueError, OverflowError):
+            die(f"unknown commit: {since_input}")
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", since_input):
+        ts = f"{since_input}T00:00:00Z"
+        _validate_iso(ts, since_input)
+        return ts
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", since_input):
+        ts = f"{since_input}Z"
+        _validate_iso(ts, since_input)
+        return ts
+    die(f"invalid --since value: {since_input} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def resolve_pr_head_sha(pr_number):
+    owner_repo = resolve_owner_repo()
+    val, ok = gh_api_jq(f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha")
+    if not ok or not val:
+        return None
+    return val
+
+
+def cmd_status(argv):
+    pr_number = ""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg in ("-h", "--help"):
+            usage()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    check_deps()
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = resolve_owner_repo()
+
+    sha = resolve_pr_head_sha(pr_number)
+    if not sha:
+        die("failed to resolve head SHA for PR #{pr_number}")
+
+    checks_raw, ok = gh_api_paginated(f"repos/{owner_repo}/commits/{sha}/check-runs")
+    if not ok:
+        die(f"failed to fetch check runs for SHA {sha}")
+
+    checks_data = parse_paginated_json(checks_raw)
+
+    all_runs = []
+    for page in checks_data:
+        if isinstance(page, dict) and "check_runs" in page:
+            all_runs.extend(page["check_runs"])
+
+    all_runs.sort(key=lambda x: x.get("name", ""))
+
+    lines = []
+    for run in all_runs:
+        parts = [
+            "--- check",
+            f"name: {run['name']}",
+            f"status: {run['status']}",
+        ]
+        if run.get("status") == "completed":
+            parts.append(f"conclusion: {run['conclusion']}")
+        lines.append("\n".join(parts))
+
+    output = "\n".join(lines)
+    if output:
+        print(output)
+
+
+def cmd_logs(argv):
+    pr_number = ""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg in ("-h", "--help"):
+            usage()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    check_deps()
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = resolve_owner_repo()
+
+    sha = resolve_pr_head_sha(pr_number)
+    if not sha:
+        die(f"failed to resolve head SHA for PR #{pr_number}")
+
+    checks_raw, ok = gh_api_paginated(f"repos/{owner_repo}/commits/{sha}/check-runs")
+    if not ok:
+        die(f"failed to fetch check runs for SHA {sha}")
+
+    checks_data = parse_paginated_json(checks_raw)
+
+    all_runs = []
+    for page in checks_data:
+        if isinstance(page, dict) and "check_runs" in page:
+            all_runs.extend(page["check_runs"])
+
+    failed = sorted(
+        [r for r in all_runs if r.get("status") == "completed" and r.get("conclusion") == "failure"],
+        key=lambda x: x.get("name", ""),
+    )
+
+    if not failed:
+        return
+
+    for run in failed:
+        job_id = run["id"]
+        name = run["name"]
+        log_content = ""
+        try:
+            args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
+            result = subprocess.run(args, capture_output=True, text=True)
+            if result.returncode == 0:
+                log_content = result.stdout
+        except Exception:
+            pass
+
+        print("--- log")
+        print(f"name: {name}")
+
+        if not log_content:
+            print("[log not available]")
+            continue
+
+        log_lines = log_content.splitlines()
+        if len(log_lines) > 500:
+            for line in log_lines[:500]:
+                print(line)
+            omitted = len(log_lines) - 500
+            print(f"[truncated: {omitted} lines omitted]")
+        else:
+            print(log_content, end="" if log_content.endswith("\n") else "\n")
+
+
+def cmd_comments(argv):
+    pr_number = ""
+    since_input = ""
+    force_all = False
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg == "--since":
+            if i + 1 >= len(argv):
+                die("missing value for --since")
+            validate_since_format(argv[i + 1])
+            since_input = argv[i + 1]
+            i += 2
+        elif arg == "--all":
+            force_all = True
+            i += 1
+        elif arg in ("-h", "--help"):
+            usage()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    if force_all:
+        since_input = ""
+
+    check_deps()
+
+    since_ref = resolve_since_timestamp(since_input) if since_input else ""
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = resolve_owner_repo()
+
+    review_raw, ok = gh_api_paginated(f"repos/{owner_repo}/pulls/{pr_number}/comments")
+    if not ok:
+        die(f"failed to fetch review comments for PR #{pr_number}")
+
+    review_data = parse_paginated_json(review_raw)
+
+    review_items = []
+    for c in review_data:
+        if c.get("in_reply_to_id") is not None:
+            continue
+        review_items.append({
+            "source": "review-comment",
+            "id": c["id"],
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "path": c.get("path", ""),
+            "line": c.get("line") or 0,
+            "body": c.get("body", ""),
+        })
+
+    review_ids = [str(item["id"]) for item in review_items]
+
+    replies_map = {}
+    for cid in review_ids:
+        endpoint = f"repos/{owner_repo}/pulls/comments/{cid}/replies"
+        replies_raw, ok = gh_api_paginated(endpoint)
+        if not ok:
+            replies_raw = "[]"
+        replies_data = parse_paginated_json(replies_raw)
+
+        if since_ref:
+            replies_data = [r for r in replies_data if r.get("created_at", "") >= since_ref]
+
+        reply_fields = sorted(
+            [
+                {
+                    "author": r["user"]["login"],
+                    "created": r["created_at"],
+                    "body": r.get("body", ""),
+                }
+                for r in replies_data
+            ],
+            key=lambda x: x["created"],
+        )
+        if reply_fields:
+            replies_map[cid] = reply_fields
+
+    for item in review_items:
+        cid = str(item["id"])
+        item["replies"] = replies_map.get(cid, [])
+
+    issue_raw, ok = gh_api_paginated(f"repos/{owner_repo}/issues/{pr_number}/comments")
+    if not ok:
+        die(f"failed to fetch issue comments for PR #{pr_number}")
+
+    issue_data = parse_paginated_json(issue_raw)
+
+    issue_items = []
+    for c in issue_data:
+        issue_items.append({
+            "source": "issue-comment",
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "body": c.get("body", ""),
+        })
+
+    merged = review_items + issue_items
+    merged.sort(key=lambda x: x["created"])
+
+    if since_ref:
+        merged = [c for c in merged if c["created"] >= since_ref]
+
+    lines = []
+    for item in merged:
+        if item["source"] == "review-comment":
+            parts = [
+                "--- review-comment",
+                f"author: {item['author']}",
+                f"created: {item['created']}",
+                f"path: {item['path']}",
+                f"line: {item['line']}",
+                f"body: {item['body']}",
+            ]
+            for reply in item["replies"]:
+                parts.append(">>> reply")
+                parts.append(f"author: {reply['author']}")
+                parts.append(f"created: {reply['created']}")
+                parts.append(f"body: {reply['body']}")
+            lines.append("\n".join(parts))
+        else:
+            parts = [
+                "--- issue-comment",
+                f"author: {item['author']}",
+                f"created: {item['created']}",
+                f"body: {item['body']}",
+            ]
+            lines.append("\n".join(parts))
+
+    output = "\n".join(lines)
+    if output:
+        print(output)
 
 
 def usage():
-    print("usage: gh-pr-context [--version|--help]")
+    print("usage: gh-pr-context <command> [options]")
+    print("")
+    print("commands:")
+    print("  comments   Fetch PR comments")
+    print("  status     Fetch CI check status")
+    print("  logs       Fetch logs for failed CI checks")
+    print("  monitor    Poll for changes to CI status or comments")
     print("")
     print("options:")
+    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
+    print("  --since <ref>   Filter comments by time")
+    print("  --all           Return all comments (default)")
     print("  --version       Show version")
     print("  -h, --help      Show this message")
-    print("")
-    print("note: Windows Python runtime currently supports --version and --help only")
 
 
 def main(argv):
@@ -28,14 +499,25 @@ def main(argv):
         return 1
 
     command = argv[0]
+    rest = argv[1:]
+
     if command == "--version":
         print(f"gh-pr-context {VERSION}")
         return 0
     if command in ("-h", "--help"):
         usage()
         return 0
+    if command == "comments":
+        cmd_comments(rest)
+        return 0
+    if command == "status":
+        cmd_status(rest)
+        return 0
+    if command == "logs":
+        cmd_logs(rest)
+        return 0
 
-    return die("Windows Python runtime currently supports --version and --help only")
+    return die(f"unknown command: {command}")
 
 
 if __name__ == "__main__":

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -67,6 +67,7 @@ def parse_paginated_json(raw):
                 items.append(obj)
             pos = end
         except json.JSONDecodeError:
+            print("warning: incomplete paginated JSON response", file=sys.stderr)
             break
     return items
 
@@ -156,9 +157,12 @@ def resolve_since_timestamp(since_input):
         out, rc = run_cmd(_git_cmd() + ["log", "-1", "--format=%ct", "HEAD"])
         if rc != 0:
             die("failed to resolve last-commit timestamp")
-        epoch = int(out.strip())
-        dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
-        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        try:
+            epoch = int(out.strip())
+            dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+            return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        except (ValueError, OverflowError):
+            die("failed to resolve last-commit timestamp")
     if re.match(r"^[0-9a-fA-F]{7,40}$", since_input):
         expanded = ""
         exp_out, exp_rc = run_git_ok("rev-parse", since_input)
@@ -167,9 +171,12 @@ def resolve_since_timestamp(since_input):
         if expanded:
             epoch_out, log_rc = run_cmd(_git_cmd() + ["log", "-1", "--format=%ct", expanded])
             if log_rc == 0:
-                epoch = int(epoch_out.strip())
-                dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
-                return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+                try:
+                    epoch = int(epoch_out.strip())
+                    dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+                    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+                except (ValueError, OverflowError):
+                    pass
         sha_for_api = expanded or since_input
         owner_repo = resolve_owner_repo()
         api_date, ok = gh_api_jq(
@@ -211,6 +218,8 @@ def cmd_status(argv):
             if i + 1 >= len(argv):
                 die("missing value for --pr")
             pr_number = argv[i + 1]
+            if not pr_number:
+                die("--pr value must not be empty")
             i += 2
         elif arg in ("-h", "--help"):
             usage()
@@ -227,7 +236,7 @@ def cmd_status(argv):
 
     sha = resolve_pr_head_sha(pr_number)
     if not sha:
-        die("failed to resolve head SHA for PR #{pr_number}")
+        die(f"failed to resolve head SHA for PR #{pr_number}")
 
     checks_raw, ok = gh_api_paginated(f"repos/{owner_repo}/commits/{sha}/check-runs")
     if not ok:
@@ -267,6 +276,8 @@ def cmd_logs(argv):
             if i + 1 >= len(argv):
                 die("missing value for --pr")
             pr_number = argv[i + 1]
+            if not pr_number:
+                die("--pr value must not be empty")
             i += 2
         elif arg in ("-h", "--help"):
             usage()
@@ -345,6 +356,8 @@ def cmd_comments(argv):
             if i + 1 >= len(argv):
                 die("missing value for --pr")
             pr_number = argv[i + 1]
+            if not pr_number:
+                die("--pr value must not be empty")
             i += 2
         elif arg == "--since":
             if i + 1 >= len(argv):
@@ -400,6 +413,7 @@ def cmd_comments(argv):
         endpoint = f"repos/{owner_repo}/pulls/comments/{cid}/replies"
         replies_raw, ok = gh_api_paginated(endpoint)
         if not ok:
+            print(f"warning: failed to fetch replies for comment {cid}", file=sys.stderr)
             replies_raw = "[]"
         replies_data = parse_paginated_json(replies_raw)
 

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -89,10 +89,12 @@ def gh_api_jq(endpoint, jq_filter):
 
 def check_deps():
     from shutil import which
-    for cmd in ("gh", "git"):
-        if not which(cmd):
-            die(f"{cmd} is required but not found on PATH")
-    out, rc = run_cmd(["git", "rev-parse", "--git-dir"])
+    git_bin = _git_cmd()[0]
+    gh_bin = _gh_cmd()[0]
+    for label, binary in (("git", git_bin), ("gh", gh_bin)):
+        if not which(binary):
+            die(f"{label} is required but not found on PATH")
+    out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
     if rc != 0:
         die("not a git repository")
 
@@ -151,7 +153,7 @@ def resolve_since_timestamp(since_input):
     if not since_input:
         return ""
     if since_input == "last-commit":
-        out, rc = run_cmd(["git", "log", "-1", "--format=%ct", "HEAD"])
+        out, rc = run_cmd(_git_cmd() + ["log", "-1", "--format=%ct", "HEAD"])
         if rc != 0:
             die("failed to resolve last-commit timestamp")
         epoch = int(out.strip())
@@ -163,7 +165,7 @@ def resolve_since_timestamp(since_input):
         if exp_rc == 0:
             expanded = exp_out.strip()
         if expanded:
-            epoch_out, log_rc = run_cmd(["git", "log", "-1", "--format=%ct", expanded])
+            epoch_out, log_rc = run_cmd(_git_cmd() + ["log", "-1", "--format=%ct", expanded])
             if log_rc == 0:
                 epoch = int(epoch_out.strip())
                 dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
@@ -441,7 +443,7 @@ def cmd_comments(argv):
     merged.sort(key=lambda x: x["created"])
 
     if since_ref:
-        merged = [c for c in merged if c["created"] >= since_ref]
+        merged = [c for c in merged if c["created"] >= since_ref or c.get("replies")]
 
     lines = []
     for item in merged:
@@ -481,7 +483,6 @@ def usage():
     print("  comments   Fetch PR comments")
     print("  status     Fetch CI check status")
     print("  logs       Fetch logs for failed CI checks")
-    print("  monitor    Poll for changes to CI status or comments")
     print("")
     print("options:")
     print("  --pr <number>   PR number (auto-detected from branch if omitted)")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -1,22 +1,354 @@
 #!/usr/bin/env python3
+import json
+import os
+import re
+import shlex
+import subprocess
 import sys
+from datetime import datetime, timezone
 
 VERSION = "0.2.5"
 
 
 def die(message):
     print(f"error: {message}", file=sys.stderr)
-    return 1
+    sys.exit(1)
+
+
+def _git_cmd():
+    override = os.environ.get("GH_PR_CONTEXT_GIT")
+    if override:
+        return shlex.split(override)
+    return ["git"]
+
+
+def _gh_cmd():
+    override = os.environ.get("GH_PR_CONTEXT_GH")
+    if override:
+        return shlex.split(override)
+    return ["gh"]
+
+
+def run_cmd(args, timeout=None):
+    result = subprocess.run(
+        args, capture_output=True, text=True, timeout=timeout
+    )
+    return result.stdout.strip(), result.returncode
+
+
+def run_git(*args):
+    out, rc = run_cmd(_git_cmd() + list(args))
+    if rc != 0:
+        die(f"git {' '.join(args)} failed")
+    return out
+
+
+def run_git_ok(*args):
+    return run_cmd(_git_cmd() + list(args))
+
+
+def parse_paginated_json(raw):
+    if not raw or not raw.strip():
+        return []
+    decoder = json.JSONDecoder()
+    pos = 0
+    items = []
+    raw = raw.strip()
+    while pos < len(raw):
+        while pos < len(raw) and raw[pos] in " \t\n\r":
+            pos += 1
+        if pos >= len(raw):
+            break
+        try:
+            obj, end = decoder.raw_decode(raw, pos)
+            if isinstance(obj, list):
+                items.extend(obj)
+            else:
+                items.append(obj)
+            pos = end
+        except json.JSONDecodeError:
+            break
+    return items
+
+
+def gh_api_paginated(endpoint):
+    args = _gh_cmd() + ["api", "--paginate", endpoint]
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None, False
+    return result.stdout, True
+
+
+def gh_api_jq(endpoint, jq_filter):
+    args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
+    result = subprocess.run(args, capture_output=True, text=True)
+    if result.returncode != 0:
+        return None, False
+    return result.stdout.strip().replace("\r", ""), True
+
+
+def check_deps():
+    from shutil import which
+    for cmd in ("gh", "git"):
+        if not which(cmd):
+            die(f"{cmd} is required but not found on PATH")
+    out, rc = run_cmd(["git", "rev-parse", "--git-dir"])
+    if rc != 0:
+        die("not a git repository")
+
+
+def resolve_owner_repo():
+    remote_url = run_git("remote", "get-url", "origin")
+    m = re.search(r"github\.com[:/](.+?)(?:\.git)?$", remote_url)
+    if not m:
+        die("failed to parse owner/repo from remote url")
+    return m.group(1)
+
+
+def resolve_pr_number():
+    branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
+    owner_repo = resolve_owner_repo()
+    owner, repo = owner_repo.split("/", 1)
+    endpoint = f"repos/{owner}/{repo}/pulls?head={owner}:{branch}"
+    val, ok = gh_api_jq(endpoint, ".[0].number")
+    if not ok:
+        die(f"failed to look up PR for branch '{branch}'")
+    if not val or val == "null":
+        die(f"no open PR found for branch '{branch}'")
+    return val
+
+
+def validate_since_format(value):
+    if not value:
+        return
+    if value == "last-commit":
+        return
+    if re.match(r"^[0-9a-fA-F]{7,40}$", value):
+        return
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", value):
+        ts = f"{value}T00:00:00Z"
+        _validate_iso(ts, value)
+        return
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", value):
+        ts = f"{value}Z"
+        _validate_iso(ts, value)
+        return
+    die(f"invalid --since value: {value} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def _validate_iso(ts, original):
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+        formatted = dt.strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        expected = ts.replace("Z", "+00:00")
+        if formatted != expected:
+            raise ValueError
+    except (ValueError, OverflowError):
+        die(f"invalid --since value: {original} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def resolve_since_timestamp(since_input):
+    if not since_input:
+        return ""
+    if since_input == "last-commit":
+        out, rc = run_cmd(["git", "log", "-1", "--format=%ct", "HEAD"])
+        if rc != 0:
+            die("failed to resolve last-commit timestamp")
+        epoch = int(out.strip())
+        dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+    if re.match(r"^[0-9a-fA-F]{7,40}$", since_input):
+        expanded = ""
+        exp_out, exp_rc = run_git_ok("rev-parse", since_input)
+        if exp_rc == 0:
+            expanded = exp_out.strip()
+        if expanded:
+            epoch_out, log_rc = run_cmd(["git", "log", "-1", "--format=%ct", expanded])
+            if log_rc == 0:
+                epoch = int(epoch_out.strip())
+                dt = datetime.fromtimestamp(epoch, tz=timezone.utc)
+                return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        sha_for_api = expanded or since_input
+        owner_repo = resolve_owner_repo()
+        api_date, ok = gh_api_jq(
+            f"repos/{owner_repo}/commits/{sha_for_api}",
+            ".commit.committer.date",
+        )
+        if not ok or not api_date:
+            die(f"unknown commit: {since_input}")
+        try:
+            dt = datetime.fromisoformat(api_date.replace("Z", "+00:00"))
+            return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        except (ValueError, OverflowError):
+            die(f"unknown commit: {since_input}")
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", since_input):
+        ts = f"{since_input}T00:00:00Z"
+        _validate_iso(ts, since_input)
+        return ts
+    if re.match(r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$", since_input):
+        ts = f"{since_input}Z"
+        _validate_iso(ts, since_input)
+        return ts
+    die(f"invalid --since value: {since_input} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
+
+
+def cmd_comments(argv):
+    pr_number = ""
+    since_input = ""
+    force_all = False
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg == "--since":
+            if i + 1 >= len(argv):
+                die("missing value for --since")
+            validate_since_format(argv[i + 1])
+            since_input = argv[i + 1]
+            i += 2
+        elif arg == "--all":
+            force_all = True
+            i += 1
+        elif arg in ("-h", "--help"):
+            usage()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    if force_all:
+        since_input = ""
+
+    check_deps()
+
+    since_ref = resolve_since_timestamp(since_input) if since_input else ""
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = resolve_owner_repo()
+
+    review_raw, ok = gh_api_paginated(f"repos/{owner_repo}/pulls/{pr_number}/comments")
+    if not ok:
+        die(f"failed to fetch review comments for PR #{pr_number}")
+
+    review_data = parse_paginated_json(review_raw)
+
+    review_items = []
+    for c in review_data:
+        if c.get("in_reply_to_id") is not None:
+            continue
+        review_items.append({
+            "source": "review-comment",
+            "id": c["id"],
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "path": c.get("path", ""),
+            "line": c.get("line") or 0,
+            "body": c.get("body", ""),
+        })
+
+    review_ids = [str(item["id"]) for item in review_items]
+
+    replies_map = {}
+    for cid in review_ids:
+        endpoint = f"repos/{owner_repo}/pulls/comments/{cid}/replies"
+        replies_raw, ok = gh_api_paginated(endpoint)
+        if not ok:
+            replies_raw = "[]"
+        replies_data = parse_paginated_json(replies_raw)
+
+        if since_ref:
+            replies_data = [r for r in replies_data if r.get("created_at", "") >= since_ref]
+
+        reply_fields = sorted(
+            [
+                {
+                    "author": r["user"]["login"],
+                    "created": r["created_at"],
+                    "body": r.get("body", ""),
+                }
+                for r in replies_data
+            ],
+            key=lambda x: x["created"],
+        )
+        if reply_fields:
+            replies_map[cid] = reply_fields
+
+    for item in review_items:
+        cid = str(item["id"])
+        item["replies"] = replies_map.get(cid, [])
+
+    issue_raw, ok = gh_api_paginated(f"repos/{owner_repo}/issues/{pr_number}/comments")
+    if not ok:
+        die(f"failed to fetch issue comments for PR #{pr_number}")
+
+    issue_data = parse_paginated_json(issue_raw)
+
+    issue_items = []
+    for c in issue_data:
+        issue_items.append({
+            "source": "issue-comment",
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "body": c.get("body", ""),
+        })
+
+    merged = review_items + issue_items
+    merged.sort(key=lambda x: x["created"])
+
+    if since_ref:
+        merged = [c for c in merged if c["created"] >= since_ref]
+
+    lines = []
+    for item in merged:
+        if item["source"] == "review-comment":
+            parts = [
+                "--- review-comment",
+                f"author: {item['author']}",
+                f"created: {item['created']}",
+                f"path: {item['path']}",
+                f"line: {item['line']}",
+                f"body: {item['body']}",
+            ]
+            for reply in item["replies"]:
+                parts.append(">>> reply")
+                parts.append(f"author: {reply['author']}")
+                parts.append(f"created: {reply['created']}")
+                parts.append(f"body: {reply['body']}")
+            lines.append("\n".join(parts))
+        else:
+            parts = [
+                "--- issue-comment",
+                f"author: {item['author']}",
+                f"created: {item['created']}",
+                f"body: {item['body']}",
+            ]
+            lines.append("\n".join(parts))
+
+    output = "\n".join(lines)
+    if output:
+        print(output)
 
 
 def usage():
-    print("usage: gh-pr-context [--version|--help]")
+    print("usage: gh-pr-context <command> [options]")
+    print("")
+    print("commands:")
+    print("  comments   Fetch PR comments")
+    print("  status     Fetch CI check status")
+    print("  logs       Fetch logs for failed CI checks")
+    print("  monitor    Poll for changes to CI status or comments")
     print("")
     print("options:")
+    print("  --pr <number>   PR number (auto-detected from branch if omitted)")
+    print("  --since <ref>   Filter comments by time")
+    print("  --all           Return all comments (default)")
     print("  --version       Show version")
     print("  -h, --help      Show this message")
-    print("")
-    print("note: Windows Python runtime currently supports --version and --help only")
 
 
 def main(argv):
@@ -28,11 +360,16 @@ def main(argv):
         return 1
 
     command = argv[0]
+    rest = argv[1:]
+
     if command == "--version":
         print(f"gh-pr-context {VERSION}")
         return 0
     if command in ("-h", "--help"):
         usage()
+        return 0
+    if command == "comments":
+        cmd_comments(rest)
         return 0
 
     return die("Windows Python runtime currently supports --version and --help only")

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -35,8 +35,7 @@ assert_stderr_contains() {
 }
 
 setup_mock_dir() {
-  # Use Windows TEMP so both Git Bash and Python subprocess can access it
-  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+  _MOCK_DIR=$(mktemp -d)
 }
 
 cleanup_mock_dir() {

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -5,7 +5,11 @@
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 python_script="$repo_root/gh-pr-context.py"
-python_cmd="py -3"
+if command -v py >/dev/null 2>&1; then
+  python_cmd="py -3"
+else
+  python_cmd="python3"
+fi
 
 pass=0
 fail=0
@@ -71,11 +75,17 @@ GHSCRIPT
 }
 
 run_python() {
-  # On Windows, Python's subprocess.run("bash") resolves to WSL bash, not Git Bash.
-  # Use the full path to Git Bash with forward-slash Windows paths for the mocks.
-  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
-  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
-  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  if command -v cygpath >/dev/null 2>&1; then
+    # Windows: Python's subprocess.run("bash") resolves to WSL bash, not Git Bash.
+    # Use the full path to Git Bash with forward-slash Windows paths for the mocks.
+    local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+    local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+    local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  else
+    # Linux: mock scripts can be executed directly by bash
+    local git_mock="bash $_MOCK_DIR/git"
+    local gh_mock="bash $_MOCK_DIR/gh"
+  fi
   GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
     $python_cmd "$python_script" "$@"
 }

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -1,0 +1,290 @@
+#!/usr/bin/env bash
+
+# Python comments command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+python_script="$repo_root/gh-pr-context.py"
+python_cmd="py -3"
+
+pass=0
+fail=0
+
+assert_exit() {
+  local expected_exit=$1 desc=$2; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_stderr_contains() {
+  local desc=$1 needle=$2; shift 2
+  local output
+  output=$("$@" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (stderr did not contain: $needle)"
+  fi
+}
+
+setup_mock_dir() {
+  # Use Windows TEMP so both Git Bash and Python subprocess can access it
+  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+}
+
+cleanup_mock_dir() {
+  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+    rm -rf "$_MOCK_DIR"
+  fi
+}
+
+write_git_mock() {
+  cat > "$_MOCK_DIR/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --git-dir") echo ".git" ;;
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$_MOCK_DIR/git"
+}
+
+# Write gh mock. $1 = body of case statement
+write_gh_mock() {
+  local body="$1"
+  cat > "$_MOCK_DIR/gh" << GHSCRIPT
+#!/usr/bin/env bash
+case "\$*" in
+  $body
+  *) exit 1 ;;
+esac
+GHSCRIPT
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+run_python() {
+  # On Windows, Python's subprocess.run("bash") resolves to WSL bash, not Git Bash.
+  # Use the full path to Git Bash with forward-slash Windows paths for the mocks.
+  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
+    $python_cmd "$python_script" "$@"
+}
+
+# --- Tests ---
+
+test_py_comments_empty_pr_no_output() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '
+    *"pulls/42/comments"*) echo '"'"'[]'"'"' ;;
+    *"issues/42/comments"*) echo '"'"'[]'"'"' ;;'
+  local output
+  output=$(run_python comments --pr 42 2>&1) || true
+  cleanup_mock_dir
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty PR should produce no output (got: $output)"
+  fi
+}
+
+test_py_comments_review_only() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '
+    *"pulls/42/comments"*) echo '"'"'[{"id":1,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'"'"' ;;
+    *"issues/42/comments"*) echo '"'"'[]'"'"' ;;
+    *"pulls/comments/"*"/replies"*) echo '"'"'[]'"'"' ;;'
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "review-comment" && echo "$output" | grep -qF "alice"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: review comment output missing expected fields (output: $output)"
+  fi
+}
+
+test_py_comments_issue_only() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '
+    *"pulls/42/comments"*) echo '"'"'[]'"'"' ;;
+    *"issues/42/comments"*) echo '"'"'[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"looks good"}]'"'"' ;;
+    *"pulls/comments/"*"/replies"*) echo '"'"'[]'"'"' ;;'
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "issue-comment" && echo "$output" | grep -qF "bob"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comment output missing expected fields (output: $output)"
+  fi
+}
+
+test_py_comments_sorted_by_date() {
+  setup_mock_dir
+  write_git_mock
+  local review_json='[{"id":2,"user":{"login":"alice"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"review later"}]'
+  local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T10:00:00Z","body":"issue earlier"}]'
+  write_gh_mock "
+    *\"pulls/42/comments\"*) echo '$review_json' ;;
+    *\"issues/42/comments\"*) echo '$issue_json' ;;
+    *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  local first_author
+  first_author=$(echo "$output" | grep -m1 "author:" | head -1 | sed 's/author: //')
+  if [ "$first_author" = "bob" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected bob (issue comment) first, got: $first_author (output: $output)"
+  fi
+}
+
+test_py_comments_review_with_replies() {
+  setup_mock_dir
+  write_git_mock
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
+  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
+  write_gh_mock "
+    *\"pulls/42/comments\"*) echo '$review_json' ;;
+    *\"issues/42/comments\"*) echo '[]' ;;
+    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
+    *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF ">>> reply" \
+    && echo "$output" | grep -qF "author: bob" \
+    && echo "$output" | grep -qF "body: done, fixed" \
+    && echo "$output" | grep -qF "created: 2025-01-01T11:00:00Z"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: review comment with replies missing >>> reply block (output: $output)"
+  fi
+}
+
+test_py_comments_issue_stays_flat() {
+  setup_mock_dir
+  write_git_mock
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
+  local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
+  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"a reply"}]'
+  write_gh_mock "
+    *\"pulls/42/comments\"*) echo '$review_json' ;;
+    *\"issues/42/comments\"*) echo '$issue_json' ;;
+    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
+    *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  local issue_block
+  issue_block=$(echo "$output" | sed -n '/--- issue-comment/,/^---/p')
+  if echo "$issue_block" | grep -qF "bob" \
+    && ! echo "$issue_block" | grep -qF ">>>"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: issue comments should not have >>> markers (output: $output)"
+  fi
+}
+
+test_py_comments_review_no_replies() {
+  setup_mock_dir
+  write_git_mock
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
+  write_gh_mock "
+    *\"pulls/42/comments\"*) echo '$review_json' ;;
+    *\"issues/42/comments\"*) echo '[]' ;;
+    *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
+  local output
+  output=$(run_python comments --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "review-comment" && ! echo "$output" | grep -qF ">>> reply"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: review comment without replies should not have >>> reply (output: $output)"
+  fi
+}
+
+test_py_comments_exits_zero_on_success() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '
+    *"pulls/42/comments"*) echo '"'"'[{"id":1,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"ok"}]'"'"' ;;
+    *"issues/42/comments"*) echo '"'"'[]'"'"' ;;
+    *"pulls/comments/"*"/replies"*) echo '"'"'[]'"'"' ;;'
+  assert_exit 0 "comments exits 0 on success" run_python comments --pr 42
+  cleanup_mock_dir
+}
+
+test_py_comments_help_exits_zero() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '*) exit 1 ;;'
+  assert_exit 0 "comments --help exits 0" run_python comments --help
+  assert_exit 0 "comments -h exits 0" run_python comments -h
+  cleanup_mock_dir
+}
+
+test_py_comments_unknown_option_exits_nonzero() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '*) exit 1 ;;'
+  local exit_code=0
+  run_python comments --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: unknown option should exit non-zero"
+  fi
+}
+
+test_py_comments_missing_pr_value() {
+  assert_stderr_contains "comments --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" comments --pr
+}
+
+# --- Run tests ---
+test_names=(
+  test_py_comments_empty_pr_no_output
+  test_py_comments_review_only
+  test_py_comments_issue_only
+  test_py_comments_sorted_by_date
+  test_py_comments_review_with_replies
+  test_py_comments_issue_stays_flat
+  test_py_comments_review_no_replies
+  test_py_comments_exits_zero_on_success
+  test_py_comments_help_exits_zero
+  test_py_comments_unknown_option_exits_nonzero
+  test_py_comments_missing_pr_value
+)
+
+echo "--- test_python_comments.sh"
+for t in "${test_names[@]}"; do
+  "$t"
+done
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -76,6 +76,16 @@ GHSCRIPT
   chmod +x "$_MOCK_DIR/gh"
 }
 
+# Convert a path for use in mock scripts. On Windows, uses mock_path;
+# on Linux, returns the path unchanged.
+mock_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -m "$1"
+  else
+    echo "$1"
+  fi
+}
+
 run_python() {
   if command -v cygpath >/dev/null 2>&1; then
     local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
@@ -139,7 +149,7 @@ test_py_logs_multiple_failures() {
   echo "build error at line 5" > "$_MOCK_DIR/log_111.txt"
   echo "test assertion failed" > "$_MOCK_DIR/log_222.txt"
   local win_mock_dir
-  win_mock_dir=$(cygpath -m "$_MOCK_DIR")
+  win_mock_dir=$(mock_path "$_MOCK_DIR")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
@@ -166,7 +176,7 @@ test_py_logs_truncation_at_500_lines() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   seq 1 600 > "$_MOCK_DIR/log_111.txt"
   local win_log_file
-  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
@@ -190,7 +200,7 @@ test_py_logs_truncation_notice_format() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   seq 1 600 > "$_MOCK_DIR/log_111.txt"
   local win_log_file
-  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
@@ -212,7 +222,7 @@ test_py_logs_under_500_no_truncation() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   seq 1 10 > "$_MOCK_DIR/log_111.txt"
   local win_log_file
-  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
@@ -269,7 +279,7 @@ test_py_logs_exits_zero() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   echo "error in CI" > "$_MOCK_DIR/log_111.txt"
   local win_log_file
-  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
     *\"check-runs\"*) echo '$check_runs' ;;

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -41,7 +41,7 @@ assert_stderr_contains() {
 }
 
 setup_mock_dir() {
-  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+  _MOCK_DIR=$(mktemp -d)
 }
 
 cleanup_mock_dir() {

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -1,0 +1,326 @@
+#!/usr/bin/env bash
+
+# Python logs command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+python_script="$repo_root/gh-pr-context.py"
+python_cmd="py -3"
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+
+pass=0
+fail=0
+
+assert_exit() {
+  local expected_exit=$1 desc=$2; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_stderr_contains() {
+  local desc=$1 needle=$2; shift 2
+  local output
+  output=$("$@" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (stderr did not contain: $needle)"
+  fi
+}
+
+setup_mock_dir() {
+  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+}
+
+cleanup_mock_dir() {
+  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+    rm -rf "$_MOCK_DIR"
+  fi
+}
+
+write_git_mock() {
+  cat > "$_MOCK_DIR/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --git-dir") echo ".git" ;;
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$_MOCK_DIR/git"
+}
+
+# Write gh mock. $1 = body of case statement
+write_gh_mock() {
+  local body="$1"
+  cat > "$_MOCK_DIR/gh" << GHSCRIPT
+#!/usr/bin/env bash
+case "\$*" in
+  $body
+  *) exit 1 ;;
+esac
+GHSCRIPT
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+run_python() {
+  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
+    $python_cmd "$python_script" "$@"
+}
+
+# --- Tests ---
+
+test_py_logs_failed_check_shows_log() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  local log_content="Running tests...\nTest failed: expected 200 got 500"
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) printf '%s' '$log_content' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF -- "--- log" \
+    && echo "$output" | grep -qF "name: CI" \
+    && echo "$output" | grep -qF "Running tests..." \
+    && echo "$output" | grep -qF "Test failed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: failed check should show log block (output: $output)"
+  fi
+}
+
+test_py_logs_all_passing_no_output() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":2,"check_runs":[{"id":111,"name":"Build","status":"completed","conclusion":"success"},{"id":222,"name":"Test","status":"completed","conclusion":"success"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: all passing checks should produce no output (got: $output)"
+  fi
+}
+
+test_py_logs_multiple_failures() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":2,"check_runs":[{"id":222,"name":"Test","status":"completed","conclusion":"failure"},{"id":111,"name":"Build","status":"completed","conclusion":"failure"}]}'
+  echo "build error at line 5" > "$_MOCK_DIR/log_111.txt"
+  echo "test assertion failed" > "$_MOCK_DIR/log_222.txt"
+  local win_mock_dir
+  win_mock_dir=$(cygpath -m "$_MOCK_DIR")
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) cat '$win_mock_dir/log_111.txt' ;;
+    *\"jobs/222/logs\"*) cat '$win_mock_dir/log_222.txt' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  local log_count
+  log_count=$(echo "$output" | grep -c -- "--- log")
+  if [ "$log_count" -eq 2 ] \
+    && echo "$output" | grep -qF "name: Build" \
+    && echo "$output" | grep -qF "name: Test"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected 2 log blocks for Build and Test (output: $output)"
+  fi
+}
+
+test_py_logs_truncation_at_500_lines() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  seq 1 600 > "$_MOCK_DIR/log_111.txt"
+  local win_log_file
+  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  local content_lines
+  content_lines=$(echo "$output" | grep -v -e "--- log" -e "name:" -e "truncated" | grep -c .)
+  if [ "$content_lines" -le 500 ] && echo "$output" | grep -qF "[truncated:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected at most 500 content lines with truncation notice (content_lines: $content_lines, output: $output)"
+  fi
+}
+
+test_py_logs_truncation_notice_format() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  seq 1 600 > "$_MOCK_DIR/log_111.txt"
+  local win_log_file
+  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "[truncated: 100 lines omitted]"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected '[truncated: 100 lines omitted]' (output: $output)"
+  fi
+}
+
+test_py_logs_under_500_no_truncation() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  seq 1 10 > "$_MOCK_DIR/log_111.txt"
+  local win_log_file
+  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  if ! echo "$output" | grep -q "truncated"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: under 500 lines should not show truncation notice (output: $output)"
+  fi
+}
+
+test_py_logs_log_fetch_fails_shows_placeholder() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python logs --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF -- "--- log" \
+    && echo "$output" | grep -qF "name: CI" \
+    && echo "$output" | grep -qF "[log not available]"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: log fetch failure should show placeholder (output: $output)"
+  fi
+}
+
+test_py_logs_sha_lookup_failure() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '*) exit 1 ;;'
+  local output
+  output=$(run_python logs --pr 42 2>&1) || true
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "failed to resolve head SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA lookup failure should mention 'failed to resolve head SHA' (output: $output)"
+  fi
+}
+
+test_py_logs_exits_zero() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
+  echo "error in CI" > "$_MOCK_DIR/log_111.txt"
+  local win_log_file
+  win_log_file=$(cygpath -m "$_MOCK_DIR/log_111.txt")
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;
+    *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
+  assert_exit 0 "logs exits 0 on success" run_python logs --pr 42
+  cleanup_mock_dir
+}
+
+test_py_logs_help_exits_zero() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '*) exit 1 ;;'
+  assert_exit 0 "logs --help exits 0" run_python logs --help
+  assert_exit 0 "logs -h exits 0" run_python logs -h
+  cleanup_mock_dir
+}
+
+test_py_logs_unknown_option_exits_nonzero() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local exit_code=0
+  run_python logs --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: unknown option should exit non-zero"
+  fi
+}
+
+test_py_logs_missing_pr_value() {
+  assert_stderr_contains "logs --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" logs --pr
+}
+
+# --- Run tests ---
+test_names=(
+  test_py_logs_failed_check_shows_log
+  test_py_logs_all_passing_no_output
+  test_py_logs_multiple_failures
+  test_py_logs_truncation_at_500_lines
+  test_py_logs_truncation_notice_format
+  test_py_logs_under_500_no_truncation
+  test_py_logs_log_fetch_fails_shows_placeholder
+  test_py_logs_sha_lookup_failure
+  test_py_logs_exits_zero
+  test_py_logs_help_exits_zero
+  test_py_logs_unknown_option_exits_nonzero
+  test_py_logs_missing_pr_value
+)
+
+echo "--- test_python_logs.sh"
+for t in "${test_names[@]}"; do
+  "$t"
+done
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -5,7 +5,11 @@
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 python_script="$repo_root/gh-pr-context.py"
-python_cmd="py -3"
+if command -v py >/dev/null 2>&1; then
+  python_cmd="py -3"
+else
+  python_cmd="python3"
+fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
@@ -73,9 +77,14 @@ GHSCRIPT
 }
 
 run_python() {
-  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
-  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
-  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  if command -v cygpath >/dev/null 2>&1; then
+    local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+    local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+    local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  else
+    local git_mock="bash $_MOCK_DIR/git"
+    local gh_mock="bash $_MOCK_DIR/gh"
+  fi
   GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
     $python_cmd "$python_script" "$@"
 }

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -5,7 +5,11 @@
 script_dir="$(cd "$(dirname "$0")" && pwd)"
 repo_root="$(cd "$script_dir/.." && pwd)"
 python_script="$repo_root/gh-pr-context.py"
-python_cmd="py -3"
+if command -v py >/dev/null 2>&1; then
+  python_cmd="py -3"
+else
+  python_cmd="python3"
+fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
@@ -72,9 +76,14 @@ GHSCRIPT
 }
 
 run_python() {
-  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
-  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
-  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  if command -v cygpath >/dev/null 2>&1; then
+    local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+    local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+    local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  else
+    local git_mock="bash $_MOCK_DIR/git"
+    local gh_mock="bash $_MOCK_DIR/gh"
+  fi
   GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
     $python_cmd "$python_script" "$@"
 }

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -1,0 +1,284 @@
+#!/usr/bin/env bash
+
+# Python status command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+python_script="$repo_root/gh-pr-context.py"
+python_cmd="py -3"
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+
+pass=0
+fail=0
+
+assert_exit() {
+  local expected_exit=$1 desc=$2; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_stderr_contains() {
+  local desc=$1 needle=$2; shift 2
+  local output
+  output=$("$@" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (stderr did not contain: $needle)"
+  fi
+}
+
+setup_mock_dir() {
+  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+}
+
+cleanup_mock_dir() {
+  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+    rm -rf "$_MOCK_DIR"
+  fi
+}
+
+write_git_mock() {
+  cat > "$_MOCK_DIR/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --git-dir") echo ".git" ;;
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$_MOCK_DIR/git"
+}
+
+write_gh_mock() {
+  local body="$1"
+  cat > "$_MOCK_DIR/gh" << GHSCRIPT
+#!/usr/bin/env bash
+case "\$*" in
+  $body
+  *) exit 1 ;;
+esac
+GHSCRIPT
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+run_python() {
+  local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+  local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+  local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
+    $python_cmd "$python_script" "$@"
+}
+
+# --- Tests ---
+
+test_py_status_completed_check() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF -- "--- check" \
+    && echo "$output" | grep -qF "name: CI" \
+    && echo "$output" | grep -qF "status: completed" \
+    && echo "$output" | grep -qF "conclusion: success"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: completed check missing expected fields (output: $output)"
+  fi
+}
+
+test_py_status_in_progress_omits_conclusion() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "status: in_progress" \
+    && ! echo "$output" | grep -qF "conclusion:"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: in_progress check should omit conclusion (output: $output)"
+  fi
+}
+
+test_py_status_sorted_by_name() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":2,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"},{"name":"Alpha","status":"completed","conclusion":"success"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  local first_name
+  first_name=$(echo "$output" | grep -m1 "name:" | sed 's/name: //')
+  if [ "$first_name" = "Alpha" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: expected Alpha first, got: $first_name (output: $output)"
+  fi
+}
+
+test_py_status_empty_checks() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  if [ -z "$output" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: empty check_runs should produce no output (got: $output)"
+  fi
+}
+
+test_py_status_multiple_conclusions() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":3,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"},{"name":"Deploy","status":"completed","conclusion":"cancelled"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "conclusion: success" \
+    && echo "$output" | grep -qF "conclusion: failure" \
+    && echo "$output" | grep -qF "conclusion: cancelled"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: mixed conclusions not all present (output: $output)"
+  fi
+}
+
+test_py_status_sha_lookup_failure() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  write_gh_mock "
+    *\"pulls/42\"*) exit 1 ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1) || true
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "failed to resolve head SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA lookup failure should mention 'failed to resolve head SHA' (output: $output)"
+  fi
+}
+
+test_py_status_exits_zero() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  assert_exit 0 "status exits 0 on success" run_python status --pr 42
+  cleanup_mock_dir
+}
+
+test_py_status_help_exits_zero() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_mock '*) exit 1 ;;'
+  assert_exit 0 "status --help exits 0" run_python status --help
+  assert_exit 0 "status -h exits 0" run_python status -h
+  cleanup_mock_dir
+}
+
+test_py_status_unknown_option_exits_nonzero() {
+  setup_mock_dir
+  write_git_mock
+  local check_runs='{"total_count":0,"check_runs":[]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) echo '$check_runs' ;;"
+  local exit_code=0
+  run_python status --pr 42 --bogus >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: unknown option should exit non-zero"
+  fi
+}
+
+test_py_status_missing_pr_value() {
+  assert_stderr_contains "status --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" status --pr
+}
+
+test_py_status_paginated_merges_all_checks() {
+  setup_mock_dir
+  write_git_mock
+  local page1='{"total_count":3,"check_runs":[{"name":"Zebra","status":"completed","conclusion":"success"}]}'
+  local page2='{"total_count":3,"check_runs":[{"name":"Alpha","status":"completed","conclusion":"failure"}]}'
+  write_gh_mock "
+    *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs\"*) printf '%s\n' '$page1' '$page2' ;;"
+  local output
+  output=$(run_python status --pr 42 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "name: Alpha" \
+    && echo "$output" | grep -qF "name: Zebra"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: paginated response should merge all pages (output: $output)"
+  fi
+}
+
+# --- Run tests ---
+test_names=(
+  test_py_status_completed_check
+  test_py_status_in_progress_omits_conclusion
+  test_py_status_sorted_by_name
+  test_py_status_empty_checks
+  test_py_status_multiple_conclusions
+  test_py_status_sha_lookup_failure
+  test_py_status_exits_zero
+  test_py_status_help_exits_zero
+  test_py_status_unknown_option_exits_nonzero
+  test_py_status_missing_pr_value
+  test_py_status_paginated_merges_all_checks
+)
+
+echo "--- test_python_status.sh"
+for t in "${test_names[@]}"; do
+  "$t"
+done
+
+echo ""
+echo "$pass passed, $fail failed"
+[ "$fail" -eq 0 ]

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -41,7 +41,7 @@ assert_stderr_contains() {
 }
 
 setup_mock_dir() {
-  _MOCK_DIR=$(TMPDIR="$TEMP" mktemp -d)
+  _MOCK_DIR=$(mktemp -d)
 }
 
 cleanup_mock_dir() {


### PR DESCRIPTION
## Summary
- Implements #57 — `comments` command in Python runtime (review comments with reply nesting, issue comments flat, date-sorted, `--since` filtering)
- Implements #58 — `status` and `logs` commands in Python runtime (check-run status, failed-check log fetching with 500-line truncation)
- Adds 37 new tests across `test_python_comments.sh`, `test_python_status.sh`, and `test_python_logs.sh`

## Test plan
- [x] `bash test/test_python_comments.sh` — 12 passed, 0 failed
- [x] `bash test/test_python_status.sh` — 12 passed, 0 failed
- [x] `bash test/test_python_logs.sh` — 13 passed, 0 failed
- [x] CI green on both issue PRs (#83, #84)
- [ ] CI green on this sprint PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)