### PR TITLE
feat(#90): Python test strict mode + stderr summaries

### DIFF
--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python comments command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -11,8 +12,17 @@ else
   python_cmd="python3"
 fi
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -43,7 +53,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -274,26 +284,28 @@ test_py_comments_missing_pr_value() {
   assert_stderr_contains "comments --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" comments --pr
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_comments_empty_pr_no_output
-  test_py_comments_review_only
-  test_py_comments_issue_only
-  test_py_comments_sorted_by_date
-  test_py_comments_review_with_replies
-  test_py_comments_issue_stays_flat
-  test_py_comments_review_no_replies
-  test_py_comments_exits_zero_on_success
-  test_py_comments_help_exits_zero
-  test_py_comments_unknown_option_exits_nonzero
-  test_py_comments_missing_pr_value
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_comments_empty_pr_no_output
+    test_py_comments_review_only
+    test_py_comments_issue_only
+    test_py_comments_sorted_by_date
+    test_py_comments_review_with_replies
+    test_py_comments_issue_stays_flat
+    test_py_comments_review_no_replies
+    test_py_comments_exits_zero_on_success
+    test_py_comments_help_exits_zero
+    test_py_comments_unknown_option_exits_nonzero
+    test_py_comments_missing_pr_value
+  )
 
-echo "--- test_python_comments.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_comments.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python logs command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -13,8 +14,17 @@ fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -45,7 +55,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -319,27 +329,29 @@ test_py_logs_missing_pr_value() {
   assert_stderr_contains "logs --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" logs --pr
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_logs_failed_check_shows_log
-  test_py_logs_all_passing_no_output
-  test_py_logs_multiple_failures
-  test_py_logs_truncation_at_500_lines
-  test_py_logs_truncation_notice_format
-  test_py_logs_under_500_no_truncation
-  test_py_logs_log_fetch_fails_shows_placeholder
-  test_py_logs_sha_lookup_failure
-  test_py_logs_exits_zero
-  test_py_logs_help_exits_zero
-  test_py_logs_unknown_option_exits_nonzero
-  test_py_logs_missing_pr_value
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_logs_failed_check_shows_log
+    test_py_logs_all_passing_no_output
+    test_py_logs_multiple_failures
+    test_py_logs_truncation_at_500_lines
+    test_py_logs_truncation_notice_format
+    test_py_logs_under_500_no_truncation
+    test_py_logs_log_fetch_fails_shows_placeholder
+    test_py_logs_sha_lookup_failure
+    test_py_logs_exits_zero
+    test_py_logs_help_exits_zero
+    test_py_logs_unknown_option_exits_nonzero
+    test_py_logs_missing_pr_value
+  )
 
-echo "--- test_python_logs.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_logs.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python status command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -13,8 +14,17 @@ fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -45,7 +55,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -268,26 +278,28 @@ test_py_status_paginated_merges_all_checks() {
   fi
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_status_completed_check
-  test_py_status_in_progress_omits_conclusion
-  test_py_status_sorted_by_name
-  test_py_status_empty_checks
-  test_py_status_multiple_conclusions
-  test_py_status_sha_lookup_failure
-  test_py_status_exits_zero
-  test_py_status_help_exits_zero
-  test_py_status_unknown_option_exits_nonzero
-  test_py_status_missing_pr_value
-  test_py_status_paginated_merges_all_checks
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_status_completed_check
+    test_py_status_in_progress_omits_conclusion
+    test_py_status_sorted_by_name
+    test_py_status_empty_checks
+    test_py_status_multiple_conclusions
+    test_py_status_sha_lookup_failure
+    test_py_status_exits_zero
+    test_py_status_help_exits_zero
+    test_py_status_unknown_option_exits_nonzero
+    test_py_status_missing_pr_value
+    test_py_status_paginated_merges_all_checks
+  )
 
-echo "--- test_python_status.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_status.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi


### PR DESCRIPTION
## Summary

Adds `set -euo pipefail` and stderr failure summaries to the three Python test files (`test_python_comments.sh`, `test_python_status.sh`, `test_python_logs.sh`).

### Changes
- **Strict mode**: `set -euo pipefail` after shebang in all three files
- **Counter isolation**: `pass=${pass:-0}` / `fail=${fail:-0}` — avoids resetting global counters when sourced by `run.sh`
- **Nounset safety**: `_MOCK_DIR=""` initialization + `${_MOCK_DIR:-}` in cleanup
- **Stderr summary trap**: `_summary_on_exit()` prints `FAILED: N test(s) failed, M passed` to stderr on non-zero exit
- **Main guard**: `if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then` — prevents double-execution when sourced by `run.sh`, and prevents `[ "$fail" -eq 0 ]` from killing the test runner early
- **Stderr redirect**: Final summary line `N passed, M failed` redirected to stderr

### Testing
All 37 Python tests pass with strict mode enabled:
- `test_python_comments.sh`: 12 passed, 0 failed
- `test_python_status.sh`: 12 passed, 0 failed  
- `test_python_logs.sh`: 13 passed, 0 failed

Closes #90

[S7/90] CP1 — pass | strict mode + stderr summaries implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)