### PR TITLE
fix(#86): check-run ID vs job ID for log downloads

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -435,9 +435,33 @@ cmd_logs() {
     return 0
   fi
 
-  while IFS=$'\t' read -r id name; do
-    local log_content
-    log_content=$(gh api "repos/$owner_repo/actions/jobs/$id/logs" 2>/dev/null) || log_content=""
+  while IFS=$'\t' read -r check_run_id name; do
+    # Resolve real job IDs from the check-run (check-run IDs ≠ job IDs)
+    local jobs_json
+    jobs_json=$(gh api "repos/$owner_repo/check-runs/$check_run_id/jobs" 2>/dev/null) || jobs_json=""
+    local job_ids
+    if [ -n "$jobs_json" ]; then
+      job_ids=$(echo "$jobs_json" | jq -r '.jobs // [] | map(select(.id)) | .[].id' | tr -d '\r')
+    else
+      job_ids=""
+    fi
+
+    local log_content=""
+    if [ -n "$job_ids" ]; then
+      while IFS= read -r job_id; do
+        [ -n "$job_id" ] || continue
+        local job_log
+        job_log=$(gh api "repos/$owner_repo/actions/jobs/$job_id/logs" 2>/dev/null) || job_log=""
+        if [ -n "$job_log" ]; then
+          if [ -n "$log_content" ]; then
+            log_content="$log_content
+$job_log"
+          else
+            log_content="$job_log"
+          fi
+        fi
+      done <<< "$job_ids"
+    fi
 
     echo "--- log"
     echo "name: $name"

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -316,16 +316,34 @@ def cmd_logs(argv):
         return
 
     for run in failed:
-        job_id = run["id"]
+        check_run_id = run["id"]
         name = run["name"]
-        log_content = ""
+
+        # Resolve real job IDs from the check-run (check-run IDs ≠ job IDs)
+        job_ids = []
         try:
-            args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
-            result = subprocess.run(args, capture_output=True, text=True)
-            if result.returncode == 0:
-                log_content = result.stdout
+            jobs_args = _gh_cmd() + ["api", f"repos/{owner_repo}/check-runs/{check_run_id}/jobs"]
+            jobs_result = subprocess.run(jobs_args, capture_output=True, text=True)
+            if jobs_result.returncode == 0:
+                jobs_data = json.loads(jobs_result.stdout)
+                for job in jobs_data.get("jobs", []):
+                    if "id" in job:
+                        job_ids.append(job["id"])
         except Exception:
             pass
+
+        log_content = ""
+        for job_id in job_ids:
+            try:
+                args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
+                result = subprocess.run(args, capture_output=True, text=True)
+                if result.returncode == 0 and result.stdout:
+                    if log_content:
+                        log_content += "\n" + result.stdout
+                    else:
+                        log_content = result.stdout
+            except Exception:
+                pass
 
         print("--- log")
         print(f"name: {name}")

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -19,6 +19,7 @@ setup_mocks() {
 }
 
 # setup_mocks_logs sets up git/gh mocks where `gh` returns `HEAD_SHA` for `pulls/42`, the first argument as the `check-runs` JSON, and the second argument as the logs content (args: 1 = check-runs JSON, 2 = log content).
+# The mock also serves a synthetic jobs response for /check-runs/{id}/jobs, mapping check-run IDs to job IDs.
 setup_mocks_logs() {
   _MOCK_CHECK_RUNS="$1"
   _MOCK_LOG_CONTENT="$2"
@@ -26,6 +27,12 @@ setup_mocks_logs() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        # Extract check-run ID from the URL and return a matching jobs response
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
       *) exit 1 ;;
@@ -49,6 +56,11 @@ setup_mocks_logs_multi() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*)
         local jid
@@ -72,6 +84,11 @@ setup_mocks_logs_auto() {
     case "$*" in
       *"pulls?head=acme:feature-branch"*) echo '42' ;;
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
       *) exit 1 ;;
@@ -109,6 +126,11 @@ setup_mocks_logs_no_log() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) exit 1 ;;
       *) exit 1 ;;

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -108,6 +108,7 @@ test_py_logs_failed_check_shows_log() {
   local log_content="Running tests...\nTest failed: expected 200 got 500"
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) printf '%s' '$log_content' ;;"
   local output
@@ -152,6 +153,8 @@ test_py_logs_multiple_failures() {
   win_mock_dir=$(mock_path "$_MOCK_DIR")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
+    *\"check-runs/222/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":222}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_mock_dir/log_111.txt' ;;
     *\"jobs/222/logs\"*) cat '$win_mock_dir/log_222.txt' ;;"
@@ -179,6 +182,7 @@ test_py_logs_truncation_at_500_lines() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -203,6 +207,7 @@ test_py_logs_truncation_notice_format() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -225,6 +230,7 @@ test_py_logs_under_500_no_truncation() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -244,6 +250,7 @@ test_py_logs_log_fetch_fails_shows_placeholder() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;"
   local output
   output=$(run_python logs --pr 42 2>&1)
@@ -282,6 +289,7 @@ test_py_logs_exits_zero() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   assert_exit 0 "logs exits 0 on success" run_python logs --pr 42


### PR DESCRIPTION
## Summary

Fixes a bug where both runtimes pass check-run `id` to `/actions/jobs/{id}/logs` — a wrong endpoint that expects actual Actions job IDs, not check-run IDs.

### Root Cause
Check-run IDs and job IDs are distinct. The `/actions/jobs/{id}/logs` endpoint requires a real job ID from the Actions system.

### Fix
For each failed check-run, the code now:
1. Calls `/repos/{owner}/{repo}/check-runs/{check_run_id}/jobs` to resolve real job IDs
2. Downloads logs per job using `/actions/jobs/{job_id}/logs`
3. Concatenates logs when a check-run has multiple jobs

### Edge Cases Handled
- **Zero jobs** (non-Actions checks like status checks): falls through to `[log not available]`
- **Multiple jobs per check-run**: fetches and concatenates all job logs
- **Job with no logs**: keeps existing `[log not available]` fallback

### Files Changed
- `gh-pr-context` (Bash): `cmd_logs()` — added job ID resolution step
- `gh-pr-context.py` (Python): `cmd_logs()` — same fix
- `test/test_logs.sh`: updated mocks to serve `/check-runs/{id}/jobs`
- `test/test_python_logs.sh`: updated mocks similarly

### Testing
All 30 log tests pass (17 bash + 13 Python).

Closes #86

[S7/86] CP1 — pass | check-run vs job ID fix implemented

🤖 Generated with [Claude Code](https://claude.com/claude-code)