### PR TITLE
perf(#88): eliminate N+1 reply API calls in comments

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -315,37 +315,20 @@ cmd_comments() {
   local review_json
   review_json=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate) \
     || die "failed to fetch review comments for PR #$pr_number"
-  review_json=$(echo "$review_json" | jq '[.[] | select(.in_reply_to_id == null) | {source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body}]')
 
-  local review_ids
-  review_ids=$(echo "$review_json" | jq -r '.[].id // empty' | tr -d '\r')
-
-  local replies_map="{}"
-  for cid in $review_ids; do
-    local replies_raw
-    if ! replies_raw=$(gh api "repos/$owner_repo/pulls/comments/$cid/replies" --paginate 2>&1); then
-      if [[ "$replies_raw" == *"404"* ]]; then
-        replies_raw="[]"
-      else
-        die "failed to fetch replies for comment $cid: $replies_raw"
-      fi
-    fi
-    if [ -n "$since_ref" ]; then
-      replies_raw=$(echo "$replies_raw" | jq --arg since "$since_ref" '[.[] | select(.created_at >= $since)]')
-    fi
-    local reply_fields
-    reply_fields=$(echo "$replies_raw" | jq '[.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created)')
-    if [ "$reply_fields" = "[]" ] || [ -z "$reply_fields" ]; then
-      continue
-    fi
-    replies_map=$(echo "$replies_map" | jq --arg cid "$cid" --argjson replies "$reply_fields" '. + {($cid): $replies}')
-  done
-
-  if [ "$replies_map" != "{}" ]; then
-    review_json=$(echo "$review_json" | jq --argjson rmap "$replies_map" '[.[] | . + {replies: ($rmap[.id | tostring] // [])}]')
-  else
-    review_json=$(echo "$review_json" | jq '[.[] | . + {replies: []}]')
-  fi
+  # The review comments endpoint already includes replies (they have
+  # in_reply_to_id set). Group replies client-side instead of N+1 API calls.
+  review_json=$(echo "$review_json" | jq --arg since "${since_ref:-}" '
+    # Separate top-level comments from replies
+    (map(select(.in_reply_to_id == null)) | map({source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body})) as $top |
+    # Group replies by their parent ID
+    (map(select(.in_reply_to_id != null))
+      | if ($since | length) > 0 then map(select(.created_at >= $since)) else . end
+      | group_by(.in_reply_to_id)
+      | map({key: (.[0].in_reply_to_id | tostring), value: ([.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created))})
+      | from_entries) as $rmap |
+    $top | map(. + {replies: ($rmap[.id | tostring] // [])})
+  ')
 
   local issue_json
   issue_json=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate) \

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -406,33 +406,25 @@ def cmd_comments(argv):
             "body": c.get("body", ""),
         })
 
-    review_ids = [str(item["id"]) for item in review_items]
-
+    # The review comments endpoint already includes replies (they have
+    # in_reply_to_id set). Group replies client-side instead of N+1 API calls.
     replies_map = {}
-    for cid in review_ids:
-        endpoint = f"repos/{owner_repo}/pulls/comments/{cid}/replies"
-        replies_raw, ok = gh_api_paginated(endpoint)
-        if not ok:
-            print(f"warning: failed to fetch replies for comment {cid}", file=sys.stderr)
-            replies_raw = "[]"
-        replies_data = parse_paginated_json(replies_raw)
+    for c in review_data:
+        parent_id = c.get("in_reply_to_id")
+        if parent_id is None:
+            continue
+        if since_ref and c.get("created_at", "") < since_ref:
+            continue
+        parent_key = str(parent_id)
+        replies_map.setdefault(parent_key, []).append({
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "body": c.get("body", ""),
+        })
 
-        if since_ref:
-            replies_data = [r for r in replies_data if r.get("created_at", "") >= since_ref]
-
-        reply_fields = sorted(
-            [
-                {
-                    "author": r["user"]["login"],
-                    "created": r["created_at"],
-                    "body": r.get("body", ""),
-                }
-                for r in replies_data
-            ],
-            key=lambda x: x["created"],
-        )
-        if reply_fields:
-            replies_map[cid] = reply_fields
+    # Sort each reply group by created_at
+    for cid in replies_map:
+        replies_map[cid].sort(key=lambda x: x["created"])
 
     for item in review_items:
         cid = str(item["id"])

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -257,9 +257,8 @@ test_comments_multiple_review_sorted() {
 
 # test_comments_review_with_replies verifies that the comments command prints a reply block for a review comment that has replies and includes the reply's author, body, and created timestamp.
 test_comments_review_with_replies() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply" \
@@ -276,7 +275,7 @@ test_comments_review_with_replies() {
 # test_comments_review_no_replies verifies that a review comment with no replies is displayed without a ">>> reply" block.
 test_comments_review_no_replies() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "review-comment" && ! echo "$output" | grep -qF ">>> reply"; then
@@ -289,9 +288,8 @@ test_comments_review_no_replies() {
 
 # test_comments_mixed_replies verifies that a review with replies shows a reply block while another review without replies does not.
 test_comments_mixed_replies() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"has replies"},{"id":102,"user":{"login":"carol"},"created_at":"2025-01-01T09:00:00Z","path":"b.sh","line":2,"body":"no replies"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply here"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"has replies"},{"id":102,"user":{"login":"carol"},"created_at":"2025-01-01T09:00:00Z","path":"b.sh","line":2,"body":"no replies"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"reply here"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local alice_block carol_block
@@ -308,10 +306,9 @@ test_comments_mixed_replies() {
 
 # test_comments_issue_stays_flat verifies that issue comments remain flat (no `>>>` reply markers) even when review comments have replies.
 test_comments_issue_stays_flat() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"},{"id":201,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"a reply"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"a reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" "$issue_json" "101:$replies_data"
+  setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 2>&1)
   local issue_block
@@ -327,9 +324,8 @@ test_comments_issue_stays_flat() {
 
 # test_comments_replies_sorted_under_parent verifies that replies to a review are sorted by `created_at` so the earliest reply is shown first.
 test_comments_replies_sorted_under_parent() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"later reply"},{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"earlier reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":202,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"later reply"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"earlier reply"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local first_reply_author
@@ -345,8 +341,7 @@ test_comments_replies_sorted_under_parent() {
 # test_comments_reply_in_main_response_not_duplicated ensures a reply that appears inline in the main review list and also via the replies endpoint is printed exactly once.
 test_comments_reply_in_main_response_not_duplicated() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":102,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline reply"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local reply_count
@@ -479,9 +474,8 @@ test_since_last_commit_includes_equal() {
 # It sets up a parent review with one old and one new reply, runs `comments --pr 42 --since 2025-06-01T00:00:00`,
 # and asserts that only the reply on/after the cutoff appears in the output.
 test_since_filters_replies_too() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","body":"old reply"},{"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","body":"new reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","path":"a.sh","line":1,"body":"old reply"},{"id":202,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","path":"a.sh","line":1,"body":"new reply"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 --since 2025-06-01T00:00:00 2>&1)
   if echo "$output" | grep -qF "carol" \
@@ -519,10 +513,11 @@ test_since_unknown_sha_stderr_message() {
   fi
 }
 
-# test_comments_crlf_in_review_ids verifies that reply fetching works correctly when jq produces Windows-style CRLF output, which leaves trailing \r on comment IDs without the tr -d '\r' strip in cmd_comments.
+# test_comments_crlf_in_review_ids verifies that reply grouping works correctly
+# when jq produces Windows-style CRLF output. With client-side reply grouping,
+# CRLF in IDs no longer affects URL construction (the old N+1 /replies pattern).
 test_comments_crlf_in_review_ids() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
   local issue_json='[]'
 
   _MOCK_PR_REVIEWS="$review_json"
@@ -530,24 +525,13 @@ test_comments_crlf_in_review_ids() {
 
   setup_mocks
   _clear_reply_vars
-  export "_MOCK_REPLY_101=$replies_data"
-  _MOCK_REPLY_IDS="101"
 
   gh() {
     case "$*" in
       *"pulls?head=acme:feature-branch"*) echo '[{"number":42}]' ;;
       *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
       *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
-      *"pulls/comments/"*"/replies"*)
-        if ! echo "$*" | grep -qP 'pulls/comments/\d+/replies'; then
-          echo 'parse error: invalid control character in URL' >&2
-          exit 1
-        fi
-        local cid
-        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-        local var="_MOCK_REPLY_${cid}"
-        echo "${!var:-[]}"
-        ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
       *) exit 1 ;;
     esac
   }

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -170,12 +170,10 @@ test_py_comments_sorted_by_date() {
 test_py_comments_review_with_replies() {
   setup_mock_dir
   write_git_mock
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
   write_gh_mock "
     *\"pulls/42/comments\"*) echo '$review_json' ;;
     *\"issues/42/comments\"*) echo '[]' ;;
-    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
     *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
   local output
   output=$(run_python comments --pr 42 2>&1)
@@ -194,13 +192,11 @@ test_py_comments_review_with_replies() {
 test_py_comments_issue_stays_flat() {
   setup_mock_dir
   write_git_mock
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"},{"id":201,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"a reply"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"a reply"}]'
   write_gh_mock "
     *\"pulls/42/comments\"*) echo '$review_json' ;;
     *\"issues/42/comments\"*) echo '$issue_json' ;;
-    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
     *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
   local output
   output=$(run_python comments --pr 42 2>&1)

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -25,8 +25,9 @@ _clear_reply_vars() {
   _MOCK_REPLY_IDS=""
 }
 
-# setup_mocks_nesting sets up shell mocks and exports mock PR review, issue, and per-comment reply data used by nesting tests.
-# The first argument is PR review JSON, the second is issue comment JSON, and remaining arguments are reply specs of the form `cid:rdata` which are exported as `_MOCK_REPLY_<cid>`.
+# setup_mocks_nesting sets up shell mocks for nesting tests.
+# The first argument is PR review JSON (should include inline replies with in_reply_to_id),
+# the second is issue comment JSON.
 setup_mocks_nesting() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -35,24 +36,11 @@ setup_mocks_nesting() {
   setup_mocks_base
   _clear_reply_vars
 
-  local reply_spec cid rdata
-  for reply_spec in "$@"; do
-    cid="${reply_spec%%:*}"
-    rdata="${reply_spec#*:}"
-    export "_MOCK_REPLY_${cid}=$rdata"
-    _MOCK_REPLY_IDS="$_MOCK_REPLY_IDS $cid"
-  done
-
   gh() {
     case "$*" in
       *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
       *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
-      *"pulls/comments/"*"/replies"*)
-        local cid
-        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-        local var="_MOCK_REPLY_${cid}"
-        echo "${!var:-[]}"
-        ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
       *) exit 1 ;;
     esac
   }
@@ -82,9 +70,8 @@ test_names+=(
 
 # test_nesting_reply_block_present verifies that when a PR review comment has a nested reply, the script output includes the ">>> reply" marker.
 test_nesting_reply_block_present() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply"; then
@@ -96,9 +83,8 @@ test_nesting_reply_block_present() {
 }
 
 test_nesting_reply_appears_after_parent() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local parent_line reply_line
@@ -115,9 +101,8 @@ test_nesting_reply_appears_after_parent() {
 # test_nesting_reply_uses_marker verifies that a nested reply is rendered with the '>>> reply' marker in the script output.
 # Sets up one review and one reply, runs the script for the PR, and passes only if the output contains ">>> reply".
 test_nesting_reply_uses_marker() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"r"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply"; then
@@ -129,9 +114,8 @@ test_nesting_reply_uses_marker() {
 }
 
 test_nesting_reply_contains_author_created_body() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
-  local reply='[{"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","body":"reply body text"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"},{"id":20,"in_reply_to_id":10,"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","path":"a.sh","line":1,"body":"reply body text"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "author: replyuser" \
@@ -150,8 +134,7 @@ test_nesting_in_reply_to_id_not_top_level() {
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
     {"id":11,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline child"}
   ]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline child"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local block_count
@@ -196,11 +179,11 @@ test_nesting_issue_comment_no_reply_marker() {
 test_nesting_multiple_parents_independent_replies() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
-    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"},
+    {"id":30,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"reply to A"},
+    {"id":40,"in_reply_to_id":20,"user":{"login":"dave"},"created_at":"2025-01-01T13:00:00Z","path":"b.sh","line":2,"body":"reply to B"}
   ]'
-  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply to A"}]'
-  local reply20='[{"user":{"login":"dave"},"created_at":"2025-01-01T13:00:00Z","body":"reply to B"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply10" "20:$reply20"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "reply to A" && echo "$output" | grep -qF "reply to B"; then
@@ -215,10 +198,10 @@ test_nesting_multiple_parents_independent_replies() {
 test_nesting_reply_only_under_correct_parent() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
-    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"},
+    {"id":30,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"only for A"}
   ]'
-  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"only for A"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply10"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local parent_b_section
@@ -233,13 +216,13 @@ test_nesting_reply_only_under_correct_parent() {
 
 # test_nesting_replies_sorted_chronologically verifies that replies attached to a review are emitted in ascending order by `created_at` (earliest reply appears first).
 test_nesting_replies_sorted_chronologically() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies='[
-    {"user":{"login":"charlie"},"created_at":"2025-01-03T10:00:00Z","body":"third"},
-    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"second"},
-    {"user":{"login":"alice"},"created_at":"2025-01-01T11:00:00Z","body":"first"}
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
+    {"id":21,"in_reply_to_id":10,"user":{"login":"charlie"},"created_at":"2025-01-03T10:00:00Z","path":"a.sh","line":1,"body":"third"},
+    {"id":22,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"second"},
+    {"id":20,"in_reply_to_id":10,"user":{"login":"alice"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"first"}
   ]'
-  setup_mocks_nesting "$review" '[]' "10:$replies"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local first_reply_body
@@ -254,12 +237,12 @@ test_nesting_replies_sorted_chronologically() {
 
 # test_nesting_multiple_replies_under_one_parent verifies that two reply blocks are rendered under a single parent review comment; increments `pass` if exactly two `>>> reply` markers are found, otherwise increments `fail` and prints a FAIL message with the captured output.
 test_nesting_multiple_replies_under_one_parent() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies='[
-    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"reply one"},
-    {"user":{"login":"carol"},"created_at":"2025-01-03T10:00:00Z","body":"reply two"}
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
+    {"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"reply one"},
+    {"id":21,"in_reply_to_id":10,"user":{"login":"carol"},"created_at":"2025-01-03T10:00:00Z","path":"a.sh","line":1,"body":"reply two"}
   ]'
-  setup_mocks_nesting "$review" '[]' "10:$replies"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local reply_count


### PR DESCRIPTION
Eliminates N+1 per-comment API calls to /replies endpoint by grouping replies client-side from the initial review comments response.

## Root Cause
The review comments endpoint already returns ALL comments including replies (identified by in_reply_to_id). Both runtimes filtered out replies, then made N+1 calls to /replies for each top-level comment — fetching data already present in the initial response.

## Fix
Group replies client-side from the initial response instead of N+1 API calls.

**Bash:** Single jq expression separates top-level comments from replies, groups by in_reply_to_id, builds replies map. Zero /replies calls.

**Python:** Iterate review_data once to collect replies by parent ID, sort each group by created_at. Zero /replies API calls.

## Verification
- Reply ordering by created_at preserved
- --since filtering still works for replies
- /replies endpoint never called (mocks return [], regression would fail tests)

## Testing
- 27 bash comment tests pass
- 11 reply nesting tests pass  
- 12 Python comment tests pass

Closes #88

[S7/88] CP1 - pass | N+1 reply API calls eliminated

Generated with Claude Code