### PR TITLE
Sprint 7: test strict mode, check-run/job fix, fork detection, worktree gitdir, N+1 elimination

### DIFF
--- a/gh-pr-context
+++ b/gh-pr-context
@@ -315,37 +315,20 @@ cmd_comments() {
   local review_json
   review_json=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate) \
     || die "failed to fetch review comments for PR #$pr_number"
-  review_json=$(echo "$review_json" | jq '[.[] | select(.in_reply_to_id == null) | {source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body}]')
 
-  local review_ids
-  review_ids=$(echo "$review_json" | jq -r '.[].id // empty' | tr -d '\r')
-
-  local replies_map="{}"
-  for cid in $review_ids; do
-    local replies_raw
-    if ! replies_raw=$(gh api "repos/$owner_repo/pulls/comments/$cid/replies" --paginate 2>&1); then
-      if [[ "$replies_raw" == *"404"* ]]; then
-        replies_raw="[]"
-      else
-        die "failed to fetch replies for comment $cid: $replies_raw"
-      fi
-    fi
-    if [ -n "$since_ref" ]; then
-      replies_raw=$(echo "$replies_raw" | jq --arg since "$since_ref" '[.[] | select(.created_at >= $since)]')
-    fi
-    local reply_fields
-    reply_fields=$(echo "$replies_raw" | jq '[.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created)')
-    if [ "$reply_fields" = "[]" ] || [ -z "$reply_fields" ]; then
-      continue
-    fi
-    replies_map=$(echo "$replies_map" | jq --arg cid "$cid" --argjson replies "$reply_fields" '. + {($cid): $replies}')
-  done
-
-  if [ "$replies_map" != "{}" ]; then
-    review_json=$(echo "$review_json" | jq --argjson rmap "$replies_map" '[.[] | . + {replies: ($rmap[.id | tostring] // [])}]')
-  else
-    review_json=$(echo "$review_json" | jq '[.[] | . + {replies: []}]')
-  fi
+  # The review comments endpoint already includes replies (they have
+  # in_reply_to_id set). Group replies client-side instead of N+1 API calls.
+  review_json=$(echo "$review_json" | jq --arg since "${since_ref:-}" '
+    # Separate top-level comments from replies
+    (map(select(.in_reply_to_id == null)) | map({source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body})) as $top |
+    # Group replies by their parent ID
+    (map(select(.in_reply_to_id != null))
+      | if ($since | length) > 0 then map(select(.created_at >= $since)) else . end
+      | group_by(.in_reply_to_id)
+      | map({key: (.[0].in_reply_to_id | tostring), value: ([.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created))})
+      | from_entries) as $rmap |
+    $top | map(. + {replies: ($rmap[.id | tostring] // [])})
+  ')
 
   local issue_json
   issue_json=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate) \

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -162,13 +162,28 @@ resolve_owner_repo() {
 
 # resolved_owner_repo returns the owner/repo to use for API endpoints.
 # After resolve_pr_number sets _RESOLVED_OWNER_REPO (e.g. to the parent repo
-# on forks), this function returns that value. Otherwise falls back to origin.
+# on forks), this function returns that value. Otherwise detects fork and
+# caches the parent repo. Falls back to origin if not a fork.
 resolved_owner_repo() {
   if [ -n "${_RESOLVED_OWNER_REPO:-}" ]; then
     echo "$_RESOLVED_OWNER_REPO"
-  else
-    resolve_owner_repo
+    return
   fi
+  local owner_repo
+  owner_repo=$(resolve_owner_repo)
+  local is_fork
+  is_fork=$(gh api "repos/$owner_repo" --jq '.fork' 2>/dev/null) || is_fork="false"
+  if [ "$is_fork" = "true" ]; then
+    local parent
+    parent=$(gh api "repos/$owner_repo" --jq '.parent.full_name' 2>/dev/null) || parent=""
+    if [ -n "$parent" ]; then
+      _RESOLVED_OWNER_REPO="$parent"
+      echo "$parent"
+      return
+    fi
+  fi
+  _RESOLVED_OWNER_REPO="$owner_repo"
+  echo "$owner_repo"
 }
 
 # resolve_pr_number prints the open PR number for the current branch. The
@@ -218,7 +233,7 @@ resolve_pr_head_sha() {
   local pr_number=$1
   local timeout_secs="${2:-}"
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
   _timed_gh_api "$timeout_secs" "repos/$owner_repo/pulls/$pr_number" --paginate --jq '.head.sha' | tr -d '\r'
 }
 
@@ -367,7 +382,7 @@ cmd_comments() {
   merged=$(printf '%s\n%s\n' "$review_json" "$issue_json" | jq -s 'flatten | sort_by(.created)')
 
   if [ -n "$since_ref" ]; then
-    merged=$(echo "$merged" | jq --arg since "$since_ref" '[.[] | select(.created >= $since)]')
+    merged=$(echo "$merged" | jq --arg since "$since_ref" '[.[] | select(.created >= $since or ((.replies // []) | length) > 0)]')
   fi
 
   echo "$merged" | jq -r '.[] | if .source == "review-comment" then "--- review-comment\nauthor: \(.author)\ncreated: \(.created)\npath: \(.path)\nline: \(.line)\nbody: \(.body)" + (if (.replies | length) > 0 then "\n" + (.replies | map(">>> reply\nauthor: \(.author)\ncreated: \(.created)\nbody: \(.body)") | join("\n")) else "" end) else "--- issue-comment\nauthor: \(.author)\ncreated: \(.created)\nbody: \(.body)" end'

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -160,6 +160,17 @@ resolve_owner_repo() {
   echo "$owner_repo"
 }
 
+# resolved_owner_repo returns the owner/repo to use for API endpoints.
+# After resolve_pr_number sets _RESOLVED_OWNER_REPO (e.g. to the parent repo
+# on forks), this function returns that value. Otherwise falls back to origin.
+resolved_owner_repo() {
+  if [ -n "${_RESOLVED_OWNER_REPO:-}" ]; then
+    echo "$_RESOLVED_OWNER_REPO"
+  else
+    resolve_owner_repo
+  fi
+}
+
 # resolve_pr_number prints the open PR number for the current branch. The
 # optional timeout argument is passed through to _timed_gh_api.
 resolve_pr_number() {
@@ -196,6 +207,8 @@ resolve_pr_number() {
   if [ -z "$pr_data" ] || [ "$pr_data" = "null" ]; then
     die "no open PR found for branch '$branch'"
   fi
+  # Export the endpoint repo so callers use the parent for forks.
+  _RESOLVED_OWNER_REPO="$endpoint_owner_repo"
   echo "$pr_data"
 }
 
@@ -325,7 +338,7 @@ cmd_comments() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local review_json
   review_json=$(gh api "repos/$owner_repo/pulls/$pr_number/comments" --paginate) \
@@ -381,7 +394,7 @@ cmd_status() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local sha
   sha=$(resolve_pr_head_sha "$pr_number") \
@@ -416,7 +429,7 @@ cmd_logs() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local sha
   sha=$(resolve_pr_head_sha "$pr_number" 2>/dev/null) \
@@ -680,7 +693,7 @@ cmd_monitor_status() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local prev_sha
   prev_sha=$(resolve_pr_head_sha "$pr_number") \
@@ -830,7 +843,7 @@ cmd_monitor_comments() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local _monitor_interrupted=0
   trap '_monitor_interrupted=1' INT TERM

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -168,13 +168,11 @@ resolve_pr_number() {
   branch=$(git rev-parse --abbrev-ref HEAD) || die "failed to determine current branch"
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  local owner=${owner_repo%%/*}
-  local repo=${owner_repo#*/}
+  local head_owner=${owner_repo%%/*}
 
   # On forks, PRs live on the upstream (parent) repo. Detect fork and
   # use parent for endpoint path + fork owner for head= filter.
   local endpoint_owner_repo="$owner_repo"
-  local head_owner="$owner"
   local is_fork
   is_fork=$(gh api "repos/$owner_repo" --jq '.fork' 2>/dev/null) || is_fork="false"
   if [ "$is_fork" = "true" ]; then

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -365,11 +365,12 @@ cmd_comments() {
 
   # The review comments endpoint already includes replies (they have
   # in_reply_to_id set). Group replies client-side instead of N+1 API calls.
-  review_json=$(echo "$review_json" | jq --arg since "${since_ref:-}" '
+  review_json=$(echo "$review_json" | jq -s --arg since "${since_ref:-}" '
+    add as $all |
     # Separate top-level comments from replies
-    (map(select(.in_reply_to_id == null)) | map({source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body})) as $top |
+    ($all | map(select(.in_reply_to_id == null)) | map({source: "review-comment", id: .id, author: .user.login, created: .created_at, path: .path, line: (.line // 0), body: .body})) as $top |
     # Group replies by their parent ID
-    (map(select(.in_reply_to_id != null))
+    ($all | map(select(.in_reply_to_id != null))
       | if ($since | length) > 0 then map(select(.created_at >= $since)) else . end
       | group_by(.in_reply_to_id)
       | map({key: (.[0].in_reply_to_id | tostring), value: ([.[] | {author: .user.login, created: .created_at, body: .body}] | sort_by(.created))})
@@ -380,7 +381,7 @@ cmd_comments() {
   local issue_json
   issue_json=$(gh api "repos/$owner_repo/issues/$pr_number/comments" --paginate) \
     || die "failed to fetch issue comments for PR #$pr_number"
-  issue_json=$(echo "$issue_json" | jq '[.[] | {source: "issue-comment", author: .user.login, created: .created_at, body: .body}]')
+  issue_json=$(echo "$issue_json" | jq -s '[add | .[] | {source: "issue-comment", author: .user.login, created: .created_at, body: .body}]')
 
   local merged
   merged=$(printf '%s\n%s\n' "$review_json" "$issue_json" | jq -s 'flatten | sort_by(.created)')

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -170,8 +170,25 @@ resolve_pr_number() {
   owner_repo=$(resolve_owner_repo)
   local owner=${owner_repo%%/*}
   local repo=${owner_repo#*/}
+
+  # On forks, PRs live on the upstream (parent) repo. Detect fork and
+  # use parent for endpoint path + fork owner for head= filter.
+  local endpoint_owner_repo="$owner_repo"
+  local head_owner="$owner"
+  local is_fork
+  is_fork=$(gh api "repos/$owner_repo" --jq '.fork' 2>/dev/null) || is_fork="false"
+  if [ "$is_fork" = "true" ]; then
+    local parent
+    parent=$(gh api "repos/$owner_repo" --jq '.parent.full_name' 2>/dev/null) || parent=""
+    if [ -n "$parent" ]; then
+      endpoint_owner_repo="$parent"
+    fi
+  fi
+
+  local endpoint_owner=${endpoint_owner_repo%%/*}
+  local endpoint_repo=${endpoint_owner_repo#*/}
   local pr_data rc
-  if pr_data=$(_timed_gh_api "$timeout_secs" "repos/$owner/$repo/pulls?head=$owner:$branch" --paginate --jq '.[0].number' | tr -d '\r'); then
+  if pr_data=$(_timed_gh_api "$timeout_secs" "repos/$endpoint_owner/$endpoint_repo/pulls?head=$head_owner:$branch" --paginate --jq '.[0].number' | tr -d '\r'); then
     :
   else
     rc=$?

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -171,15 +171,19 @@ resolved_owner_repo() {
   fi
   local owner_repo
   owner_repo=$(resolve_owner_repo)
-  local is_fork
-  is_fork=$(gh api "repos/$owner_repo" --jq '.fork' 2>/dev/null) || is_fork="false"
-  if [ "$is_fork" = "true" ]; then
-    local parent
-    parent=$(gh api "repos/$owner_repo" --jq '.parent.full_name' 2>/dev/null) || parent=""
-    if [ -n "$parent" ]; then
-      _RESOLVED_OWNER_REPO="$parent"
-      echo "$parent"
-      return
+  local repo_json
+  repo_json=$(gh api "repos/$owner_repo" 2>/dev/null) || repo_json=""
+  if [ -n "$repo_json" ]; then
+    local is_fork
+    is_fork=$(echo "$repo_json" | jq -r '.fork // "false"' 2>/dev/null) || is_fork="false"
+    if [ "$is_fork" = "true" ]; then
+      local parent
+      parent=$(echo "$repo_json" | jq -r '.parent.full_name // ""' 2>/dev/null) || parent=""
+      if [ -n "$parent" ]; then
+        _RESOLVED_OWNER_REPO="$parent"
+        echo "$parent"
+        return
+      fi
     fi
   fi
   _RESOLVED_OWNER_REPO="$owner_repo"

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -435,9 +435,33 @@ cmd_logs() {
     return 0
   fi
 
-  while IFS=$'\t' read -r id name; do
-    local log_content
-    log_content=$(gh api "repos/$owner_repo/actions/jobs/$id/logs" 2>/dev/null) || log_content=""
+  while IFS=$'\t' read -r check_run_id name; do
+    # Resolve real job IDs from the check-run (check-run IDs ≠ job IDs)
+    local jobs_json
+    jobs_json=$(gh api "repos/$owner_repo/check-runs/$check_run_id/jobs" 2>/dev/null) || jobs_json=""
+    local job_ids
+    if [ -n "$jobs_json" ]; then
+      job_ids=$(echo "$jobs_json" | jq -r '.jobs // [] | map(select(.id)) | .[].id' | tr -d '\r')
+    else
+      job_ids=""
+    fi
+
+    local log_content=""
+    if [ -n "$job_ids" ]; then
+      while IFS= read -r job_id; do
+        [ -n "$job_id" ] || continue
+        local job_log
+        job_log=$(gh api "repos/$owner_repo/actions/jobs/$job_id/logs" 2>/dev/null) || job_log=""
+        if [ -n "$job_log" ]; then
+          if [ -n "$log_content" ]; then
+            log_content="$log_content
+$job_log"
+          else
+            log_content="$job_log"
+          fi
+        fi
+      done <<< "$job_ids"
+    fi
 
     echo "--- log"
     echo "name: $name"

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -977,7 +977,7 @@ cmd_monitor_all() {
   fi
 
   local owner_repo
-  owner_repo=$(resolve_owner_repo)
+  owner_repo=$(resolved_owner_repo)
 
   local prev_sha
   if ! call_timeout=$(monitor_call_timeout "$timeout_secs" "$timeout_input"); then

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -112,7 +112,8 @@ def _setup_git_env():
 
     git_file = os.path.join(work_tree, ".git")
     try:
-        content = open(git_file).read().strip()
+        with open(git_file, "r") as f:
+            content = f.read().strip()
     except OSError:
         return
 
@@ -178,7 +179,7 @@ def resolve_pr_number():
     global _resolved_owner_repo
     branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
     owner_repo = resolve_owner_repo()
-    owner, repo = owner_repo.split("/", 1)
+    owner, _repo = owner_repo.split("/", 1)
 
     # On forks, PRs live on the upstream (parent) repo. Detect fork and
     # use parent for endpoint path + fork owner for head= filter.

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -406,33 +406,25 @@ def cmd_comments(argv):
             "body": c.get("body", ""),
         })
 
-    review_ids = [str(item["id"]) for item in review_items]
-
+    # The review comments endpoint already includes replies (they have
+    # in_reply_to_id set). Group replies client-side instead of N+1 API calls.
     replies_map = {}
-    for cid in review_ids:
-        endpoint = f"repos/{owner_repo}/pulls/comments/{cid}/replies"
-        replies_raw, ok = gh_api_paginated(endpoint)
-        if not ok:
-            print(f"warning: failed to fetch replies for comment {cid}", file=sys.stderr)
-            replies_raw = "[]"
-        replies_data = parse_paginated_json(replies_raw)
+    for c in review_data:
+        parent_id = c.get("in_reply_to_id")
+        if parent_id is None:
+            continue
+        if since_ref and c.get("created_at", "") < since_ref:
+            continue
+        parent_key = str(parent_id)
+        replies_map.setdefault(parent_key, []).append({
+            "author": c["user"]["login"],
+            "created": c["created_at"],
+            "body": c.get("body", ""),
+        })
 
-        if since_ref:
-            replies_data = [r for r in replies_data if r.get("created_at", "") >= since_ref]
-
-        reply_fields = sorted(
-            [
-                {
-                    "author": r["user"]["login"],
-                    "created": r["created_at"],
-                    "body": r.get("body", ""),
-                }
-                for r in replies_data
-            ],
-            key=lambda x: x["created"],
-        )
-        if reply_fields:
-            replies_map[cid] = reply_fields
+    # Sort each reply group by created_at
+    for cid in replies_map:
+        replies_map[cid].sort(key=lambda x: x["created"])
 
     for item in review_items:
         cid = str(item["id"])

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -112,7 +112,22 @@ def resolve_pr_number():
     branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
     owner_repo = resolve_owner_repo()
     owner, repo = owner_repo.split("/", 1)
-    endpoint = f"repos/{owner}/{repo}/pulls?head={owner}:{branch}"
+
+    # On forks, PRs live on the upstream (parent) repo. Detect fork and
+    # use parent for endpoint path + fork owner for head= filter.
+    endpoint_owner_repo = owner_repo
+    head_owner = owner
+    try:
+        is_fork_val, ok = gh_api_jq(f"repos/{owner_repo}", ".fork")
+        if ok and is_fork_val == "true":
+            parent_val, pok = gh_api_jq(f"repos/{owner_repo}", ".parent.full_name")
+            if pok and parent_val and parent_val != "null":
+                endpoint_owner_repo = parent_val
+    except Exception:
+        pass  # fallback to current behavior
+
+    endpoint_owner, endpoint_repo = endpoint_owner_repo.split("/", 1)
+    endpoint = f"repos/{endpoint_owner}/{endpoint_repo}/pulls?head={head_owner}:{branch}"
     val, ok = gh_api_jq(endpoint, ".[0].number")
     if not ok:
         die(f"failed to look up PR for branch '{branch}'")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -96,7 +96,7 @@ def _setup_git_env():
     2. Worktree with Windows absolute path (C:/...): convert to /mnt/c/...
     3. Worktree with relative gitdir: resolve relative to worktree root.
     """
-    out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+    _out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
     if rc == 0:
         return  # git works, nothing to do
 
@@ -131,7 +131,7 @@ def _setup_git_env():
         if os.path.isdir(resolved):
             os.environ["GIT_DIR"] = resolved
             os.environ["GIT_WORK_TREE"] = work_tree
-            out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+            _out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
             if rc == 0:
                 return
             os.environ.pop("GIT_DIR", None)
@@ -143,7 +143,7 @@ def _setup_git_env():
         if os.path.isdir(abs_path):
             os.environ["GIT_DIR"] = abs_path
             os.environ["GIT_WORK_TREE"] = work_tree
-            out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+            _out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
             if rc == 0:
                 return
             os.environ.pop("GIT_DIR", None)
@@ -171,7 +171,11 @@ def resolve_owner_repo():
     return m.group(1)
 
 
+_resolved_owner_repo = None
+
+
 def resolve_pr_number():
+    global _resolved_owner_repo
     branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
     owner_repo = resolve_owner_repo()
     owner, repo = owner_repo.split("/", 1)
@@ -189,6 +193,7 @@ def resolve_pr_number():
     except Exception:
         pass  # fallback to current behavior
 
+    _resolved_owner_repo = endpoint_owner_repo
     endpoint_owner, endpoint_repo = endpoint_owner_repo.split("/", 1)
     endpoint = f"repos/{endpoint_owner}/{endpoint_repo}/pulls?head={head_owner}:{branch}"
     val, ok = gh_api_jq(endpoint, ".[0].number")
@@ -197,6 +202,17 @@ def resolve_pr_number():
     if not val or val == "null":
         die(f"no open PR found for branch '{branch}'")
     return val
+
+
+def get_owner_repo():
+    """Return the resolved owner/repo for API endpoints.
+
+    After resolve_pr_number sets _resolved_owner_repo (e.g. to the parent
+    repo on forks), this returns that value. Otherwise falls back to origin.
+    """
+    if _resolved_owner_repo is not None:
+        return _resolved_owner_repo
+    return resolve_owner_repo()
 
 
 def validate_since_format(value):
@@ -310,7 +326,7 @@ def cmd_status(argv):
     if not pr_number:
         pr_number = resolve_pr_number()
 
-    owner_repo = resolve_owner_repo()
+    owner_repo = get_owner_repo()
 
     sha = resolve_pr_head_sha(pr_number)
     if not sha:
@@ -368,7 +384,7 @@ def cmd_logs(argv):
     if not pr_number:
         pr_number = resolve_pr_number()
 
-    owner_repo = resolve_owner_repo()
+    owner_repo = get_owner_repo()
 
     sha = resolve_pr_head_sha(pr_number)
     if not sha:
@@ -480,7 +496,7 @@ def cmd_comments(argv):
     if not pr_number:
         pr_number = resolve_pr_number()
 
-    owner_repo = resolve_owner_repo()
+    owner_repo = get_owner_repo()
 
     review_raw, ok = gh_api_paginated(f"repos/{owner_repo}/pulls/{pr_number}/comments")
     if not ok:

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -205,15 +205,33 @@ def resolve_pr_number():
     return val
 
 
+def _detect_fork_parent(owner_repo):
+    """Detect if owner_repo is a fork and return the parent repo, or the
+    original if not a fork. Caches the result in _resolved_owner_repo."""
+    global _resolved_owner_repo
+    try:
+        is_fork_val, ok = gh_api_jq(f"repos/{owner_repo}", ".fork")
+        if ok and is_fork_val == "true":
+            parent_val, pok = gh_api_jq(f"repos/{owner_repo}", ".parent.full_name")
+            if pok and parent_val and parent_val != "null":
+                _resolved_owner_repo = parent_val
+                return parent_val
+    except Exception:
+        pass
+    _resolved_owner_repo = owner_repo
+    return owner_repo
+
+
 def get_owner_repo():
     """Return the resolved owner/repo for API endpoints.
 
     After resolve_pr_number sets _resolved_owner_repo (e.g. to the parent
-    repo on forks), this returns that value. Otherwise falls back to origin.
+    repo on forks), this returns that value. Otherwise detects fork and
+    caches the parent repo. Falls back to origin if not a fork.
     """
     if _resolved_owner_repo is not None:
         return _resolved_owner_repo
-    return resolve_owner_repo()
+    return _detect_fork_parent(resolve_owner_repo())
 
 
 def validate_since_format(value):
@@ -297,7 +315,7 @@ def resolve_since_timestamp(since_input):
 
 
 def resolve_pr_head_sha(pr_number):
-    owner_repo = resolve_owner_repo()
+    owner_repo = get_owner_repo()
     val, ok = gh_api_jq(f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha")
     if not ok or not val:
         return None

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -316,16 +316,34 @@ def cmd_logs(argv):
         return
 
     for run in failed:
-        job_id = run["id"]
+        check_run_id = run["id"]
         name = run["name"]
-        log_content = ""
+
+        # Resolve real job IDs from the check-run (check-run IDs ≠ job IDs)
+        job_ids = []
         try:
-            args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
-            result = subprocess.run(args, capture_output=True, text=True)
-            if result.returncode == 0:
-                log_content = result.stdout
+            jobs_args = _gh_cmd() + ["api", f"repos/{owner_repo}/check-runs/{check_run_id}/jobs"]
+            jobs_result = subprocess.run(jobs_args, capture_output=True, text=True)
+            if jobs_result.returncode == 0:
+                jobs_data = json.loads(jobs_result.stdout)
+                for job in jobs_data.get("jobs", []):
+                    if "id" in job:
+                        job_ids.append(job["id"])
         except Exception:
             pass
+
+        log_content = ""
+        for job_id in job_ids:
+            try:
+                args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
+                result = subprocess.run(args, capture_output=True, text=True)
+                if result.returncode == 0 and result.stdout:
+                    if log_content:
+                        log_content += "\n" + result.stdout
+                    else:
+                        log_content = result.stdout
+            except Exception:
+                pass
 
         print("--- log")
         print(f"name: {name}")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -88,6 +88,68 @@ def gh_api_jq(endpoint, jq_filter):
     return result.stdout.strip().replace("\r", ""), True
 
 
+def _setup_git_env():
+    """Resolve worktree gitdir when git rev-parse --git-dir fails.
+
+    Handles three cases:
+    1. Normal repo: git works, nothing to do.
+    2. Worktree with Windows absolute path (C:/...): convert to /mnt/c/...
+    3. Worktree with relative gitdir: resolve relative to worktree root.
+    """
+    out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+    if rc == 0:
+        return  # git works, nothing to do
+
+    # Walk up to find the worktree root where .git is a file
+    work_tree = os.getcwd()
+    while work_tree != os.path.dirname(work_tree):
+        git_file = os.path.join(work_tree, ".git")
+        if os.path.isfile(git_file):
+            break
+        work_tree = os.path.dirname(work_tree)
+    else:
+        return  # no .git file found
+
+    git_file = os.path.join(work_tree, ".git")
+    try:
+        content = open(git_file).read().strip()
+    except OSError:
+        return
+
+    # Parse "gitdir: <path>"
+    m = re.match(r"^gitdir:\s+(.+)$", content)
+    if not m:
+        return
+    gitdir_path = m.group(1).strip()
+
+    # Case 1: Windows absolute path (C:/...) → WSL /mnt/c/...
+    win_match = re.match(r"^([A-Za-z]):(/.*)$", gitdir_path)
+    if win_match:
+        drive = win_match.group(1).lower()
+        rest = win_match.group(2)
+        resolved = f"/mnt/{drive}{rest}"
+        if os.path.isdir(resolved):
+            os.environ["GIT_DIR"] = resolved
+            os.environ["GIT_WORK_TREE"] = work_tree
+            out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+            if rc == 0:
+                return
+            os.environ.pop("GIT_DIR", None)
+            os.environ.pop("GIT_WORK_TREE", None)
+
+    # Case 2: Non-absolute path → resolve relative to worktree root
+    if not os.path.isabs(gitdir_path):
+        abs_path = os.path.normpath(os.path.join(work_tree, gitdir_path))
+        if os.path.isdir(abs_path):
+            os.environ["GIT_DIR"] = abs_path
+            os.environ["GIT_WORK_TREE"] = work_tree
+            out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
+            if rc == 0:
+                return
+            os.environ.pop("GIT_DIR", None)
+            os.environ.pop("GIT_WORK_TREE", None)
+
+
 def check_deps():
     from shutil import which
     git_bin = _git_cmd()[0]
@@ -95,9 +157,10 @@ def check_deps():
     for label, binary in (("git", git_bin), ("gh", gh_bin)):
         if not which(binary):
             die(f"{label} is required but not found on PATH")
+    _setup_git_env()
     out, rc = run_cmd(_git_cmd() + ["rev-parse", "--git-dir"])
     if rc != 0:
-        die("not a git repository")
+        die("not a git repository (or worktree path could not be resolved)")
 
 
 def resolve_owner_repo():

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -179,22 +179,12 @@ def resolve_pr_number():
     global _resolved_owner_repo
     branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
     owner_repo = resolve_owner_repo()
-    owner, _repo = owner_repo.split("/", 1)
+    head_owner, _ = owner_repo.split("/", 1)
 
     # On forks, PRs live on the upstream (parent) repo. Detect fork and
     # use parent for endpoint path + fork owner for head= filter.
-    endpoint_owner_repo = owner_repo
-    head_owner = owner
-    try:
-        is_fork_val, ok = gh_api_jq(f"repos/{owner_repo}", ".fork")
-        if ok and is_fork_val == "true":
-            parent_val, pok = gh_api_jq(f"repos/{owner_repo}", ".parent.full_name")
-            if pok and parent_val and parent_val != "null":
-                endpoint_owner_repo = parent_val
-    except Exception:
-        pass  # fallback to current behavior
+    endpoint_owner_repo = _detect_fork_parent(owner_repo)
 
-    _resolved_owner_repo = endpoint_owner_repo
     endpoint_owner, endpoint_repo = endpoint_owner_repo.split("/", 1)
     endpoint = f"repos/{endpoint_owner}/{endpoint_repo}/pulls?head={head_owner}:{branch}"
     val, ok = gh_api_jq(endpoint, ".[0].number")
@@ -216,8 +206,8 @@ def _detect_fork_parent(owner_repo):
             if pok and parent_val and parent_val != "null":
                 _resolved_owner_repo = parent_val
                 return parent_val
-    except Exception:
-        pass
+    except (OSError, subprocess.SubprocessError) as exc:
+        print(f"warning: fork detection failed for {owner_repo}: {exc}", file=sys.stderr)
     _resolved_owner_repo = owner_repo
     return owner_repo
 

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -56,39 +56,6 @@ setup_mocks_with_pr() {
   }
 }
 
-# setup_mocks_with_pr_and_replies sets up git/gh mock functions for a pull request: the first argument is the JSON array for review comments, the second is the JSON array for issue comments, and any additional arguments are reply specs in the form "<comment_id>:<json>" which are exported as _MOCK_REPLY_<comment_id> and tracked in _MOCK_REPLY_IDS.
-setup_mocks_with_pr_and_replies() {
-  _MOCK_PR_REVIEWS="$1"
-  _MOCK_PR_ISSUES="$2"
-  shift 2
-
-  setup_mocks
-  _clear_reply_vars
-
-  local reply_spec cid rdata
-  for reply_spec in "$@"; do
-    cid="${reply_spec%%:*}"
-    rdata="${reply_spec#*:}"
-    export "_MOCK_REPLY_${cid}=$rdata"
-    _MOCK_REPLY_IDS="$_MOCK_REPLY_IDS $cid"
-  done
-
-  gh() {
-    case "$*" in
-      *"pulls?head=acme:feature-branch"*) echo '[{"number":42}]' ;;
-      *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
-      *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
-      *"pulls/comments/"*"/replies"*)
-        local cid
-        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-        local var="_MOCK_REPLY_${cid}"
-        echo "${!var:-[]}"
-        ;;
-      *) exit 1 ;;
-    esac
-  }
-}
-
 # run_script runs the test script under the current mock environment.
 # It exports the mocked git/gh functions and the mock state variables, then invokes bash on $script with any provided arguments.
 run_script() {
@@ -338,7 +305,9 @@ test_comments_replies_sorted_under_parent() {
   fi
 }
 
-# test_comments_reply_in_main_response_not_duplicated ensures a reply that appears inline in the main review list and also via the replies endpoint is printed exactly once.
+# test_comments_reply_in_main_response_not_duplicated verifies that an inline
+# reply (with in_reply_to_id set) is grouped under its parent and printed
+# exactly once via client-side grouping.
 test_comments_reply_in_main_response_not_duplicated() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":102,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline reply"}]'
   setup_mocks_with_pr "$review_json" '[]'

--- a/test/test_comments.sh
+++ b/test/test_comments.sh
@@ -257,9 +257,8 @@ test_comments_multiple_review_sorted() {
 
 # test_comments_review_with_replies verifies that the comments command prints a reply block for a review comment that has replies and includes the reply's author, body, and created timestamp.
 test_comments_review_with_replies() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply" \
@@ -276,7 +275,7 @@ test_comments_review_with_replies() {
 # test_comments_review_no_replies verifies that a review comment with no replies is displayed without a ">>> reply" block.
 test_comments_review_no_replies() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "review-comment" && ! echo "$output" | grep -qF ">>> reply"; then
@@ -289,9 +288,8 @@ test_comments_review_no_replies() {
 
 # test_comments_mixed_replies verifies that a review with replies shows a reply block while another review without replies does not.
 test_comments_mixed_replies() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"has replies"},{"id":102,"user":{"login":"carol"},"created_at":"2025-01-01T09:00:00Z","path":"b.sh","line":2,"body":"no replies"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply here"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"has replies"},{"id":102,"user":{"login":"carol"},"created_at":"2025-01-01T09:00:00Z","path":"b.sh","line":2,"body":"no replies"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"reply here"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local alice_block carol_block
@@ -308,10 +306,9 @@ test_comments_mixed_replies() {
 
 # test_comments_issue_stays_flat verifies that issue comments remain flat (no `>>>` reply markers) even when review comments have replies.
 test_comments_issue_stays_flat() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"},{"id":201,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"a reply"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"a reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" "$issue_json" "101:$replies_data"
+  setup_mocks_with_pr "$review_json" "$issue_json"
   local output
   output=$(run_script comments --pr 42 2>&1)
   local issue_block
@@ -327,9 +324,8 @@ test_comments_issue_stays_flat() {
 
 # test_comments_replies_sorted_under_parent verifies that replies to a review are sorted by `created_at` so the earliest reply is shown first.
 test_comments_replies_sorted_under_parent() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"later reply"},{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"earlier reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":202,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"later reply"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"earlier reply"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local first_reply_author
@@ -345,8 +341,7 @@ test_comments_replies_sorted_under_parent() {
 # test_comments_reply_in_main_response_not_duplicated ensures a reply that appears inline in the main review list and also via the replies endpoint is printed exactly once.
 test_comments_reply_in_main_response_not_duplicated() {
   local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":102,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline reply"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local reply_count
@@ -479,9 +474,8 @@ test_since_last_commit_includes_equal() {
 # It sets up a parent review with one old and one new reply, runs `comments --pr 42 --since 2025-06-01T00:00:00`,
 # and asserts that only the reply on/after the cutoff appears in the output.
 test_since_filters_replies_too() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","body":"old reply"},{"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","body":"new reply"}]'
-  setup_mocks_with_pr_and_replies "$review_json" '[]' "101:$replies_data"
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-07-01T10:00:00Z","path":"a.sh","line":1,"body":"new parent"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-05-01T10:00:00Z","path":"a.sh","line":1,"body":"old reply"},{"id":202,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-08-01T10:00:00Z","path":"a.sh","line":1,"body":"new reply"}]'
+  setup_mocks_with_pr "$review_json" '[]'
   local output
   output=$(run_script comments --pr 42 --since 2025-06-01T00:00:00 2>&1)
   if echo "$output" | grep -qF "carol" \
@@ -519,10 +513,11 @@ test_since_unknown_sha_stderr_message() {
   fi
 }
 
-# test_comments_crlf_in_review_ids verifies that reply fetching works correctly when jq produces Windows-style CRLF output, which leaves trailing \r on comment IDs without the tr -d '\r' strip in cmd_comments.
+# test_comments_crlf_in_review_ids verifies that reply grouping works correctly
+# when jq produces Windows-style CRLF output. With client-side reply grouping,
+# CRLF in IDs no longer affects URL construction (the old N+1 /replies pattern).
 test_comments_crlf_in_review_ids() {
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
   local issue_json='[]'
 
   _MOCK_PR_REVIEWS="$review_json"
@@ -530,24 +525,13 @@ test_comments_crlf_in_review_ids() {
 
   setup_mocks
   _clear_reply_vars
-  export "_MOCK_REPLY_101=$replies_data"
-  _MOCK_REPLY_IDS="101"
 
   gh() {
     case "$*" in
       *"pulls?head=acme:feature-branch"*) echo '[{"number":42}]' ;;
       *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
       *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
-      *"pulls/comments/"*"/replies"*)
-        if ! echo "$*" | grep -qP 'pulls/comments/\d+/replies'; then
-          echo 'parse error: invalid control character in URL' >&2
-          exit 1
-        fi
-        local cid
-        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-        local var="_MOCK_REPLY_${cid}"
-        echo "${!var:-[]}"
-        ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
       *) exit 1 ;;
     esac
   }

--- a/test/test_logs.sh
+++ b/test/test_logs.sh
@@ -19,6 +19,7 @@ setup_mocks() {
 }
 
 # setup_mocks_logs sets up git/gh mocks where `gh` returns `HEAD_SHA` for `pulls/42`, the first argument as the `check-runs` JSON, and the second argument as the logs content (args: 1 = check-runs JSON, 2 = log content).
+# The mock also serves a synthetic jobs response for /check-runs/{id}/jobs, mapping check-run IDs to job IDs.
 setup_mocks_logs() {
   _MOCK_CHECK_RUNS="$1"
   _MOCK_LOG_CONTENT="$2"
@@ -26,6 +27,12 @@ setup_mocks_logs() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        # Extract check-run ID from the URL and return a matching jobs response
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
       *) exit 1 ;;
@@ -49,6 +56,11 @@ setup_mocks_logs_multi() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*)
         local jid
@@ -72,6 +84,11 @@ setup_mocks_logs_auto() {
     case "$*" in
       *"pulls?head=acme:feature-branch"*) echo '42' ;;
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) printf '%s' "$_MOCK_LOG_CONTENT" ;;
       *) exit 1 ;;
@@ -109,6 +126,11 @@ setup_mocks_logs_no_log() {
   gh() {
     case "$*" in
       *"pulls/42"*) echo "$HEAD_SHA" ;;
+      *"check-runs/"*"jobs"*)
+        local cr_id
+        cr_id=$(echo "$*" | sed -E 's/.*check-runs\/([0-9]+)\/jobs.*/\1/')
+        echo "{\"total_count\":1,\"jobs\":[{\"id\":${cr_id}}]}"
+        ;;
       *"check-runs"*) echo "$_MOCK_CHECK_RUNS" ;;
       *"logs"*) exit 1 ;;
       *) exit 1 ;;

--- a/test/test_monitor_all.sh
+++ b/test/test_monitor_all.sh
@@ -73,6 +73,7 @@ setup_counter_files() {
 }
 
 setup_mocks() {
+  _RESOLVED_OWNER_REPO="acme/widgets"
   git() {
     case "$*" in
       "rev-parse --git-dir") echo ".git" ;;
@@ -416,6 +417,7 @@ run_script() {
   export _MOCK_INITIAL_CHECKS _MOCK_CHANGED_CHECKS
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
   export _MOCK_SHA_COUNTER_FILE _MOCK_CHECK_COUNTER_FILE _MOCK_REVIEW_COUNTER_FILE _MOCK_ISSUE_COUNTER_FILE
+  export _RESOLVED_OWNER_REPO
   timeout 15 bash "$script" "$@" </dev/null
 }
 

--- a/test/test_monitor_comments.sh
+++ b/test/test_monitor_comments.sh
@@ -21,6 +21,7 @@ _mock_call_should_timeout() {
 }
 
 setup_mocks() {
+  _RESOLVED_OWNER_REPO="acme/widgets"
   git() {
     case "$*" in
       "rev-parse --git-dir") echo ".git" ;;
@@ -85,6 +86,9 @@ setup_mocks_monitor_comments_auto_detect() {
   echo 0 > "$_MOCK_COUNTER_FILE"
   setup_mocks
   gh() {
+    case "$*" in
+      "api repos/acme/widgets --jq"*) echo 'false'; return ;;
+    esac
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
@@ -267,6 +271,7 @@ run_script() {
   export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
   export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE _MOCK_TIMEOUT_CALLS
+  export _RESOLVED_OWNER_REPO
   timeout 15 bash "$script" "$@" </dev/null
 }
 
@@ -274,6 +279,7 @@ run_script_with_real_sleep() {
   export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
   export _MOCK_REVIEWS _MOCK_ISSUES _MOCK_COUNTER_FILE _MOCK_TIMEOUT_CALLS
+  export _RESOLVED_OWNER_REPO
   timeout 15 bash "$script" "$@" </dev/null
 }
 

--- a/test/test_monitor_signal.sh
+++ b/test/test_monitor_signal.sh
@@ -35,6 +35,7 @@ _export_signal_mocks() {
   export _MOCK_INITIAL _MOCK_CHANGED
   export _MOCK_INITIAL_REVIEWS _MOCK_INITIAL_ISSUES _MOCK_CHANGED_REVIEWS _MOCK_CHANGED_ISSUES
   export _MOCK_REVIEWS _MOCK_ISSUES
+  export _RESOLVED_OWNER_REPO
 }
 
 cleanup_signal_tmpdir() {
@@ -73,6 +74,7 @@ test_names+=(
 test_signal_status_with_change_exits_130() {
   _skip_check "signal status with change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
   _MOCK_CHANGED='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   _MOCK_COUNTER_FILE=$(mktemp)
@@ -124,6 +126,7 @@ test_signal_status_with_change_exits_130() {
 test_signal_status_no_change_exits_130_silent() {
   _skip_check "signal status no change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
   sleep() { command sleep "$@"; }
   git() {
@@ -160,6 +163,7 @@ test_signal_status_no_change_exits_130_silent() {
 test_signal_status_sigterm_with_change_exits_130() {
   _skip_check "signal SIGTERM status with change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_INITIAL='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
   _MOCK_CHANGED='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"CI","status":"completed","conclusion":"failure"}]}'
   _MOCK_COUNTER_FILE=$(mktemp)
@@ -211,6 +215,7 @@ test_signal_status_sigterm_with_change_exits_130() {
 test_signal_comments_with_change_exits_130() {
   _skip_check "signal comments with change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_INITIAL_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
   _MOCK_INITIAL_ISSUES='[]'
   _MOCK_CHANGED_REVIEWS='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
@@ -274,6 +279,7 @@ test_signal_comments_with_change_exits_130() {
 test_signal_comments_no_change_exits_130_silent() {
   _skip_check "signal comments no change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
   _MOCK_ISSUES='[{"id":201}]'
   sleep() { command sleep "$@"; }
@@ -315,6 +321,7 @@ test_signal_comments_no_change_exits_130_silent() {
 test_signal_comments_sigterm_no_change_exits_130() {
   _skip_check "signal SIGTERM comments no change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_REVIEWS='[{"id":101,"in_reply_to_id":null}]'
   _MOCK_ISSUES='[{"id":201}]'
   sleep() { command sleep "$@"; }
@@ -357,6 +364,7 @@ test_signal_comments_sigterm_no_change_exits_130() {
 test_signal_all_with_change_exits_130() {
   _skip_check "signal all with change" && return 0
 
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_INITIAL='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
   _MOCK_CHANGED='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
   _MOCK_INITIAL_REVIEWS='[]'

--- a/test/test_monitor_status.sh
+++ b/test/test_monitor_status.sh
@@ -28,6 +28,7 @@ _mock_call_should_timeout() {
 # `git` responds with fixed repo URL and branch values for known invocations and exits
 # nonzero for others; `gh` defaults to fail closed; `sleep` is a no-op so polling tests complete instantly.
 setup_mocks() {
+  _RESOLVED_OWNER_REPO="acme/widgets"
   _MOCK_TIMEOUT_CALLS=""
   git() {
     case "$*" in
@@ -112,6 +113,9 @@ setup_mocks_monitor_auto_detect() {
   echo 0 > "$_MOCK_COUNTER_FILE"
   setup_mocks
   gh() {
+    case "$*" in
+      "api repos/acme/widgets --jq"*) echo 'false'; return ;;
+    esac
     local call_num
     call_num=$(_mock_counter_next)
     case "$*" in
@@ -257,12 +261,14 @@ setup_mocks_monitor_no_change() {
 run_script_with_real_sleep() {
   export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export _RESOLVED_OWNER_REPO
   timeout 15 bash "$script" "$@" </dev/null
 }
 
 run_script() {
   export -f git gh sleep _mock_counter_next _mock_call_should_timeout
   export _MOCK_INITIAL _MOCK_CHANGED _MOCK_TIMEOUT_CALLS HEAD_SHA NEW_SHA _MOCK_COUNTER_FILE
+  export _RESOLVED_OWNER_REPO
   timeout 15 bash "$script" "$@" </dev/null
 }
 

--- a/test/test_output_formatter.sh
+++ b/test/test_output_formatter.sh
@@ -236,9 +236,8 @@ test_fmt_issue_comment_no_raw_json() {
 
 # test_fmt_reply_marker verifies that a reply comment is emitted with a single-line ">>> reply" marker.
 test_fmt_reply_marker() {
-  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"a reply"}]'
-  setup_mocks_comments_with_reply "$review" "$reply"
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":78,"in_reply_to_id":77,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"a reply"}]'
+  setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qxF ">>> reply"; then
@@ -251,9 +250,8 @@ test_fmt_reply_marker() {
 
 # test_fmt_reply_fields verifies that a reply block contains the `author`, `created`, and `body` fields.
 test_fmt_reply_fields() {
-  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local reply='[{"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","body":"the reply body"}]'
-  setup_mocks_comments_with_reply "$review" "$reply"
+  local review='[{"id":77,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":78,"in_reply_to_id":77,"user":{"login":"replyauthor"},"created_at":"2025-03-15T09:00:00Z","path":"a.sh","line":1,"body":"the reply body"}]'
+  setup_mocks_comments "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "author: replyauthor" \

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -84,6 +84,7 @@ test_names+=(
   test_pr_resolution_no_pr_found_stderr_message
   test_pr_resolution_api_fail_exits_nonzero
   test_pr_resolution_api_fail_stderr_message
+  test_pr_resolution_fork_uses_parent_for_endpoint
 )
 
 # test_pr_resolution_auto_detect_comments verifies that auto-detect resolves PR 99 and that running `comments` succeeds; it updates the global `pass`/`fail` counters and prints a failure message with the exit code when it fails.
@@ -213,5 +214,46 @@ test_pr_resolution_api_fail_stderr_message() {
   else
     fail=$((fail + 1))
     echo "FAIL: API failure should emit a failure message (output: $output)"
+  fi
+}
+
+# setup_mocks_fork sets up mocks where origin points to a fork (forkuser/widgets),
+# the repo API reports .fork=true and .parent.full_name=acme/widgets.
+# PR lookup uses parent repo with fork owner as head filter.
+setup_mocks_fork() {
+  git() {
+    case "$*" in
+      "rev-parse --git-dir") echo ".git" ;;
+      "remote get-url origin") echo "https://github.com/forkuser/widgets.git" ;;
+      "rev-parse --abbrev-ref HEAD") echo "my-feature" ;;
+      *) exit 1 ;;
+    esac
+  }
+  gh() {
+    case "$*" in
+      *"repos/forkuser/widgets"*.fork*) echo "true" ;;
+      *"repos/forkuser/widgets"*.parent*) echo "acme/widgets" ;;
+      *"pulls?head=forkuser:my-feature"*) echo '77' ;;
+      *"pulls/77/comments"*) echo '[]' ;;
+      *"issues/77/comments"*) echo '[]' ;;
+      *"pulls/77"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+      *"check-runs"*) echo '{"total_count":0,"check_runs":[]}' ;;
+      *) exit 1 ;;
+    esac
+  }
+}
+
+# test_pr_resolution_fork_uses_parent_for_endpoint verifies that when origin
+# is a fork, auto-detection queries the parent repo (acme/widgets) with the
+# fork owner (forkuser) as the head filter.
+test_pr_resolution_fork_uses_parent_for_endpoint() {
+  setup_mocks_fork
+  local exit_code=0
+  run_script comments >/dev/null 2>&1 || exit_code=$?
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: fork auto-detect should resolve PR via parent repo (exit: $exit_code)"
   fi
 }

--- a/test/test_pr_resolution.sh
+++ b/test/test_pr_resolution.sh
@@ -231,13 +231,13 @@ setup_mocks_fork() {
   }
   gh() {
     case "$*" in
-      *"repos/forkuser/widgets"*.fork*) echo "true" ;;
-      *"repos/forkuser/widgets"*.parent*) echo "acme/widgets" ;;
-      *"pulls?head=forkuser:my-feature"*) echo '77' ;;
-      *"pulls/77/comments"*) echo '[]' ;;
-      *"issues/77/comments"*) echo '[]' ;;
-      *"pulls/77"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
-      *"check-runs"*) echo '{"total_count":0,"check_runs":[]}' ;;
+      *"repos/forkuser/widgets"*--jq*.fork*) echo "true" ;;
+      *"repos/forkuser/widgets"*--jq*.parent*) echo "acme/widgets" ;;
+      *"repos/acme/widgets/pulls?head=forkuser:my-feature"*) echo '77' ;;
+      *"repos/acme/widgets/pulls/77/comments"*) echo '[]' ;;
+      *"repos/acme/widgets/issues/77/comments"*) echo '[]' ;;
+      *"repos/acme/widgets/pulls/77"*) echo "cccccccccccccccccccccccccccccccccccccccc" ;;
+      *"repos/acme/widgets/commits/"*"check-runs"*) echo '{"total_count":0,"check_runs":[]}' ;;
       *) exit 1 ;;
     esac
   }

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -290,9 +290,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   set -euo pipefail
 
   _summary_on_exit() {
-    if [ "${fail:-0}" -gt 0 ]; then
-      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    local rc=$?
+    if [ "$rc" -ne 0 ] || [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: exit ${rc}, ${fail:-0} test(s) failed, ${pass:-0} passed" >&2
     fi
+    exit "$rc"
   }
   trap _summary_on_exit EXIT
 

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -170,12 +170,10 @@ test_py_comments_sorted_by_date() {
 test_py_comments_review_with_replies() {
   setup_mock_dir
   write_git_mock
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"}]'
-  local replies_data='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"done, fixed"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"src/main.sh","line":5,"body":"nit: use double quotes"},{"id":201,"in_reply_to_id":101,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"src/main.sh","line":5,"body":"done, fixed"}]'
   write_gh_mock "
     *\"pulls/42/comments\"*) echo '$review_json' ;;
     *\"issues/42/comments\"*) echo '[]' ;;
-    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
     *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
   local output
   output=$(run_python comments --pr 42 2>&1)
@@ -194,13 +192,11 @@ test_py_comments_review_with_replies() {
 test_py_comments_issue_stays_flat() {
   setup_mock_dir
   write_git_mock
-  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"}]'
+  local review_json='[{"id":101,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"review"},{"id":201,"in_reply_to_id":101,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"a.sh","line":1,"body":"a reply"}]'
   local issue_json='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"issue comment"}]'
-  local replies_data='[{"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","body":"a reply"}]'
   write_gh_mock "
     *\"pulls/42/comments\"*) echo '$review_json' ;;
     *\"issues/42/comments\"*) echo '$issue_json' ;;
-    *\"pulls/comments/101/replies\"*) echo '$replies_data' ;;
     *\"pulls/comments/\"*\"/replies\"*) echo '[]' ;;"
   local output
   output=$(run_python comments --pr 42 2>&1)

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python comments command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -11,8 +12,17 @@ else
   python_cmd="python3"
 fi
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -43,7 +53,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -274,26 +284,28 @@ test_py_comments_missing_pr_value() {
   assert_stderr_contains "comments --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" comments --pr
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_comments_empty_pr_no_output
-  test_py_comments_review_only
-  test_py_comments_issue_only
-  test_py_comments_sorted_by_date
-  test_py_comments_review_with_replies
-  test_py_comments_issue_stays_flat
-  test_py_comments_review_no_replies
-  test_py_comments_exits_zero_on_success
-  test_py_comments_help_exits_zero
-  test_py_comments_unknown_option_exits_nonzero
-  test_py_comments_missing_pr_value
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_comments_empty_pr_no_output
+    test_py_comments_review_only
+    test_py_comments_issue_only
+    test_py_comments_sorted_by_date
+    test_py_comments_review_with_replies
+    test_py_comments_issue_stays_flat
+    test_py_comments_review_no_replies
+    test_py_comments_exits_zero_on_success
+    test_py_comments_help_exits_zero
+    test_py_comments_unknown_option_exits_nonzero
+    test_py_comments_missing_pr_value
+  )
 
-echo "--- test_python_comments.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_comments.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -18,7 +18,6 @@ _MOCK_DIR=""
 
 _summary_on_exit() {
   if [ "${fail:-0}" -gt 0 ]; then
-    echo "" >&2
     echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
   fi
 }

--- a/test/test_python_comments.sh
+++ b/test/test_python_comments.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # Python comments command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -15,13 +14,6 @@ fi
 pass=${pass:-0}
 fail=${fail:-0}
 _MOCK_DIR=""
-
-_summary_on_exit() {
-  if [ "${fail:-0}" -gt 0 ]; then
-    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
-  fi
-}
-trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -279,21 +271,30 @@ test_py_comments_missing_pr_value() {
   assert_stderr_contains "comments --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" comments --pr
 }
 
+test_names+=(
+  test_py_comments_empty_pr_no_output
+  test_py_comments_review_only
+  test_py_comments_issue_only
+  test_py_comments_sorted_by_date
+  test_py_comments_review_with_replies
+  test_py_comments_issue_stays_flat
+  test_py_comments_review_no_replies
+  test_py_comments_exits_zero_on_success
+  test_py_comments_help_exits_zero
+  test_py_comments_unknown_option_exits_nonzero
+  test_py_comments_missing_pr_value
+)
+
 # --- Run tests (only when executed directly, not sourced) ---
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  test_names=(
-    test_py_comments_empty_pr_no_output
-    test_py_comments_review_only
-    test_py_comments_issue_only
-    test_py_comments_sorted_by_date
-    test_py_comments_review_with_replies
-    test_py_comments_issue_stays_flat
-    test_py_comments_review_no_replies
-    test_py_comments_exits_zero_on_success
-    test_py_comments_help_exits_zero
-    test_py_comments_unknown_option_exits_nonzero
-    test_py_comments_missing_pr_value
-  )
+  set -euo pipefail
+
+  _summary_on_exit() {
+    if [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    fi
+  }
+  trap _summary_on_exit EXIT
 
   echo "--- test_python_comments.sh"
   for t in "${test_names[@]}"; do

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -108,6 +108,7 @@ test_py_logs_failed_check_shows_log() {
   local log_content="Running tests...\nTest failed: expected 200 got 500"
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) printf '%s' '$log_content' ;;"
   local output
@@ -152,6 +153,8 @@ test_py_logs_multiple_failures() {
   win_mock_dir=$(mock_path "$_MOCK_DIR")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
+    *\"check-runs/222/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":222}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_mock_dir/log_111.txt' ;;
     *\"jobs/222/logs\"*) cat '$win_mock_dir/log_222.txt' ;;"
@@ -179,6 +182,7 @@ test_py_logs_truncation_at_500_lines() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -203,6 +207,7 @@ test_py_logs_truncation_notice_format() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -225,6 +230,7 @@ test_py_logs_under_500_no_truncation() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   local output
@@ -244,6 +250,7 @@ test_py_logs_log_fetch_fails_shows_placeholder() {
   local check_runs='{"total_count":1,"check_runs":[{"id":111,"name":"CI","status":"completed","conclusion":"failure"}]}'
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;"
   local output
   output=$(run_python logs --pr 42 2>&1)
@@ -282,6 +289,7 @@ test_py_logs_exits_zero() {
   win_log_file=$(mock_path "$_MOCK_DIR/log_111.txt")
   write_gh_mock "
     *\"pulls/42\"*) echo '$HEAD_SHA' ;;
+    *\"check-runs/111/jobs\"*) echo '{\"total_count\":1,\"jobs\":[{\"id\":111}]}' ;;
     *\"check-runs\"*) echo '$check_runs' ;;
     *\"jobs/111/logs\"*) cat '$win_log_file' ;;"
   assert_exit 0 "logs exits 0 on success" run_python logs --pr 42

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # Python logs command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -17,13 +16,6 @@ HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 pass=${pass:-0}
 fail=${fail:-0}
 _MOCK_DIR=""
-
-_summary_on_exit() {
-  if [ "${fail:-0}" -gt 0 ]; then
-    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
-  fi
-}
-trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -336,22 +328,31 @@ test_py_logs_missing_pr_value() {
   assert_stderr_contains "logs --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" logs --pr
 }
 
+test_names+=(
+  test_py_logs_failed_check_shows_log
+  test_py_logs_all_passing_no_output
+  test_py_logs_multiple_failures
+  test_py_logs_truncation_at_500_lines
+  test_py_logs_truncation_notice_format
+  test_py_logs_under_500_no_truncation
+  test_py_logs_log_fetch_fails_shows_placeholder
+  test_py_logs_sha_lookup_failure
+  test_py_logs_exits_zero
+  test_py_logs_help_exits_zero
+  test_py_logs_unknown_option_exits_nonzero
+  test_py_logs_missing_pr_value
+)
+
 # --- Run tests (only when executed directly, not sourced) ---
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  test_names=(
-    test_py_logs_failed_check_shows_log
-    test_py_logs_all_passing_no_output
-    test_py_logs_multiple_failures
-    test_py_logs_truncation_at_500_lines
-    test_py_logs_truncation_notice_format
-    test_py_logs_under_500_no_truncation
-    test_py_logs_log_fetch_fails_shows_placeholder
-    test_py_logs_sha_lookup_failure
-    test_py_logs_exits_zero
-    test_py_logs_help_exits_zero
-    test_py_logs_unknown_option_exits_nonzero
-    test_py_logs_missing_pr_value
-  )
+  set -euo pipefail
+
+  _summary_on_exit() {
+    if [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    fi
+  }
+  trap _summary_on_exit EXIT
 
   echo "--- test_python_logs.sh"
   for t in "${test_names[@]}"; do

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -20,7 +20,6 @@ _MOCK_DIR=""
 
 _summary_on_exit() {
   if [ "${fail:-0}" -gt 0 ]; then
-    echo "" >&2
     echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
   fi
 }

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python logs command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -13,8 +14,17 @@ fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -45,7 +55,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -319,27 +329,29 @@ test_py_logs_missing_pr_value() {
   assert_stderr_contains "logs --pr without value gives clear message" "missing value for --pr" $python_cmd "$python_script" logs --pr
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_logs_failed_check_shows_log
-  test_py_logs_all_passing_no_output
-  test_py_logs_multiple_failures
-  test_py_logs_truncation_at_500_lines
-  test_py_logs_truncation_notice_format
-  test_py_logs_under_500_no_truncation
-  test_py_logs_log_fetch_fails_shows_placeholder
-  test_py_logs_sha_lookup_failure
-  test_py_logs_exits_zero
-  test_py_logs_help_exits_zero
-  test_py_logs_unknown_option_exits_nonzero
-  test_py_logs_missing_pr_value
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_logs_failed_check_shows_log
+    test_py_logs_all_passing_no_output
+    test_py_logs_multiple_failures
+    test_py_logs_truncation_at_500_lines
+    test_py_logs_truncation_notice_format
+    test_py_logs_under_500_no_truncation
+    test_py_logs_log_fetch_fails_shows_placeholder
+    test_py_logs_sha_lookup_failure
+    test_py_logs_exits_zero
+    test_py_logs_help_exits_zero
+    test_py_logs_unknown_option_exits_nonzero
+    test_py_logs_missing_pr_value
+  )
 
-echo "--- test_python_logs.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_logs.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_python_logs.sh
+++ b/test/test_python_logs.sh
@@ -348,9 +348,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   set -euo pipefail
 
   _summary_on_exit() {
-    if [ "${fail:-0}" -gt 0 ]; then
-      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    local rc=$?
+    if [ "$rc" -ne 0 ] || [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: exit ${rc}, ${fail:-0} test(s) failed, ${pass:-0} passed" >&2
     fi
+    exit "$rc"
   }
   trap _summary_on_exit EXIT
 

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
-set -euo pipefail
 
 # Python status command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -17,13 +16,6 @@ HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 pass=${pass:-0}
 fail=${fail:-0}
 _MOCK_DIR=""
-
-_summary_on_exit() {
-  if [ "${fail:-0}" -gt 0 ]; then
-    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
-  fi
-}
-trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -277,21 +269,30 @@ test_py_status_paginated_merges_all_checks() {
   fi
 }
 
+test_names+=(
+  test_py_status_completed_check
+  test_py_status_in_progress_omits_conclusion
+  test_py_status_sorted_by_name
+  test_py_status_empty_checks
+  test_py_status_multiple_conclusions
+  test_py_status_sha_lookup_failure
+  test_py_status_exits_zero
+  test_py_status_help_exits_zero
+  test_py_status_unknown_option_exits_nonzero
+  test_py_status_missing_pr_value
+  test_py_status_paginated_merges_all_checks
+)
+
 # --- Run tests (only when executed directly, not sourced) ---
 if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
-  test_names=(
-    test_py_status_completed_check
-    test_py_status_in_progress_omits_conclusion
-    test_py_status_sorted_by_name
-    test_py_status_empty_checks
-    test_py_status_multiple_conclusions
-    test_py_status_sha_lookup_failure
-    test_py_status_exits_zero
-    test_py_status_help_exits_zero
-    test_py_status_unknown_option_exits_nonzero
-    test_py_status_missing_pr_value
-    test_py_status_paginated_merges_all_checks
-  )
+  set -euo pipefail
+
+  _summary_on_exit() {
+    if [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    fi
+  }
+  trap _summary_on_exit EXIT
 
   echo "--- test_python_status.sh"
   for t in "${test_names[@]}"; do

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -20,7 +20,6 @@ _MOCK_DIR=""
 
 _summary_on_exit() {
   if [ "${fail:-0}" -gt 0 ]; then
-    echo "" >&2
     echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
   fi
 }

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -288,9 +288,11 @@ if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
   set -euo pipefail
 
   _summary_on_exit() {
-    if [ "${fail:-0}" -gt 0 ]; then
-      echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+    local rc=$?
+    if [ "$rc" -ne 0 ] || [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: exit ${rc}, ${fail:-0} test(s) failed, ${pass:-0} passed" >&2
     fi
+    exit "$rc"
   }
   trap _summary_on_exit EXIT
 

--- a/test/test_python_status.sh
+++ b/test/test_python_status.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -euo pipefail
 
 # Python status command tests using mock executables via GH_PR_CONTEXT_GH/GIT env vars.
 
@@ -13,8 +14,17 @@ fi
 
 HEAD_SHA="abc123def456abc123def456abc123def456abc1"
 
-pass=0
-fail=0
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+_summary_on_exit() {
+  if [ "${fail:-0}" -gt 0 ]; then
+    echo "" >&2
+    echo "FAILED: ${fail} test(s) failed, ${pass} passed" >&2
+  fi
+}
+trap _summary_on_exit EXIT
 
 assert_exit() {
   local expected_exit=$1 desc=$2; shift 2
@@ -45,7 +55,7 @@ setup_mock_dir() {
 }
 
 cleanup_mock_dir() {
-  if [ -n "$_MOCK_DIR" ] && [ -d "$_MOCK_DIR" ]; then
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
     rm -rf "$_MOCK_DIR"
   fi
 }
@@ -268,26 +278,28 @@ test_py_status_paginated_merges_all_checks() {
   fi
 }
 
-# --- Run tests ---
-test_names=(
-  test_py_status_completed_check
-  test_py_status_in_progress_omits_conclusion
-  test_py_status_sorted_by_name
-  test_py_status_empty_checks
-  test_py_status_multiple_conclusions
-  test_py_status_sha_lookup_failure
-  test_py_status_exits_zero
-  test_py_status_help_exits_zero
-  test_py_status_unknown_option_exits_nonzero
-  test_py_status_missing_pr_value
-  test_py_status_paginated_merges_all_checks
-)
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  test_names=(
+    test_py_status_completed_check
+    test_py_status_in_progress_omits_conclusion
+    test_py_status_sorted_by_name
+    test_py_status_empty_checks
+    test_py_status_multiple_conclusions
+    test_py_status_sha_lookup_failure
+    test_py_status_exits_zero
+    test_py_status_help_exits_zero
+    test_py_status_unknown_option_exits_nonzero
+    test_py_status_missing_pr_value
+    test_py_status_paginated_merges_all_checks
+  )
 
-echo "--- test_python_status.sh"
-for t in "${test_names[@]}"; do
-  "$t"
-done
+  echo "--- test_python_status.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
 
-echo ""
-echo "$pass passed, $fail failed"
-[ "$fail" -eq 0 ]
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -15,26 +15,14 @@ setup_mocks_base() {
   }
 }
 
-_MOCK_REPLY_IDS=""
-
-# _clear_reply_vars unsets all per-reply `_MOCK_REPLY_<id>` variables and clears the `_MOCK_REPLY_IDS` list.
-_clear_reply_vars() {
-  for cid in $_MOCK_REPLY_IDS; do
-    unset "_MOCK_REPLY_${cid}" 2>/dev/null || true
-  done
-  _MOCK_REPLY_IDS=""
-}
-
 # setup_mocks_nesting sets up shell mocks for nesting tests.
 # The first argument is PR review JSON (should include inline replies with in_reply_to_id),
 # the second is issue comment JSON.
 setup_mocks_nesting() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
-  shift 2
 
   setup_mocks_base
-  _clear_reply_vars
 
   gh() {
     case "$*" in
@@ -50,7 +38,6 @@ setup_mocks_nesting() {
 run_script() {
   export -f git gh
   export _MOCK_PR_REVIEWS _MOCK_PR_ISSUES
-  # _MOCK_REPLY_* vars are exported by setup_mocks_nesting
   timeout 15 bash "$script" "$@" </dev/null
 }
 

--- a/test/test_reply_nesting.sh
+++ b/test/test_reply_nesting.sh
@@ -25,8 +25,9 @@ _clear_reply_vars() {
   _MOCK_REPLY_IDS=""
 }
 
-# setup_mocks_nesting sets up shell mocks and exports mock PR review, issue, and per-comment reply data used by nesting tests.
-# The first argument is PR review JSON, the second is issue comment JSON, and remaining arguments are reply specs of the form `cid:rdata` which are exported as `_MOCK_REPLY_<cid>`.
+# setup_mocks_nesting sets up shell mocks for nesting tests.
+# The first argument is PR review JSON (should include inline replies with in_reply_to_id),
+# the second is issue comment JSON.
 setup_mocks_nesting() {
   _MOCK_PR_REVIEWS="$1"
   _MOCK_PR_ISSUES="$2"
@@ -35,24 +36,11 @@ setup_mocks_nesting() {
   setup_mocks_base
   _clear_reply_vars
 
-  local reply_spec cid rdata
-  for reply_spec in "$@"; do
-    cid="${reply_spec%%:*}"
-    rdata="${reply_spec#*:}"
-    export "_MOCK_REPLY_${cid}=$rdata"
-    _MOCK_REPLY_IDS="$_MOCK_REPLY_IDS $cid"
-  done
-
   gh() {
     case "$*" in
       *"pulls/42/comments"*) echo "$_MOCK_PR_REVIEWS" ;;
       *"issues/42/comments"*) echo "$_MOCK_PR_ISSUES" ;;
-      *"pulls/comments/"*"/replies"*)
-        local cid
-        cid=$(echo "$*" | sed -E 's/.*pulls\/comments\/([0-9]+)\/replies.*/\1/')
-        local var="_MOCK_REPLY_${cid}"
-        echo "${!var:-[]}"
-        ;;
+      *"pulls/comments/"*"/replies"*) echo '[]' ;;
       *) exit 1 ;;
     esac
   }
@@ -82,9 +70,8 @@ test_names+=(
 
 # test_nesting_reply_block_present verifies that when a PR review comment has a nested reply, the script output includes the ">>> reply" marker.
 test_nesting_reply_block_present() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply"; then
@@ -96,9 +83,8 @@ test_nesting_reply_block_present() {
 }
 
 test_nesting_reply_appears_after_parent() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"nested reply"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent comment"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"nested reply"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local parent_line reply_line
@@ -115,9 +101,8 @@ test_nesting_reply_appears_after_parent() {
 # test_nesting_reply_uses_marker verifies that a nested reply is rendered with the '>>> reply' marker in the script output.
 # Sets up one review and one reply, runs the script for the PR, and passes only if the output contains ">>> reply".
 test_nesting_reply_uses_marker() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"r"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"},{"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"r"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF ">>> reply"; then
@@ -129,9 +114,8 @@ test_nesting_reply_uses_marker() {
 }
 
 test_nesting_reply_contains_author_created_body() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"}]'
-  local reply='[{"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","body":"reply body text"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"p"},{"id":20,"in_reply_to_id":10,"user":{"login":"replyuser"},"created_at":"2025-06-01T08:00:00Z","path":"a.sh","line":1,"body":"reply body text"}]'
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "author: replyuser" \
@@ -150,8 +134,7 @@ test_nesting_in_reply_to_id_not_top_level() {
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
     {"id":11,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"inline child"}
   ]'
-  local reply='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"inline child"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local block_count
@@ -196,11 +179,11 @@ test_nesting_issue_comment_no_reply_marker() {
 test_nesting_multiple_parents_independent_replies() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
-    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"},
+    {"id":30,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"reply to A"},
+    {"id":40,"in_reply_to_id":20,"user":{"login":"dave"},"created_at":"2025-01-01T13:00:00Z","path":"b.sh","line":2,"body":"reply to B"}
   ]'
-  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"reply to A"}]'
-  local reply20='[{"user":{"login":"dave"},"created_at":"2025-01-01T13:00:00Z","body":"reply to B"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply10" "20:$reply20"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   if echo "$output" | grep -qF "reply to A" && echo "$output" | grep -qF "reply to B"; then
@@ -215,10 +198,10 @@ test_nesting_multiple_parents_independent_replies() {
 test_nesting_reply_only_under_correct_parent() {
   local review='[
     {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent A"},
-    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"}
+    {"id":20,"user":{"login":"carol"},"created_at":"2025-01-01T12:00:00Z","path":"b.sh","line":2,"body":"parent B"},
+    {"id":30,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"only for A"}
   ]'
-  local reply10='[{"user":{"login":"bob"},"created_at":"2025-01-01T11:00:00Z","body":"only for A"}]'
-  setup_mocks_nesting "$review" '[]' "10:$reply10"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local parent_b_section
@@ -233,13 +216,13 @@ test_nesting_reply_only_under_correct_parent() {
 
 # test_nesting_replies_sorted_chronologically verifies that replies attached to a review are emitted in ascending order by `created_at` (earliest reply appears first).
 test_nesting_replies_sorted_chronologically() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies='[
-    {"user":{"login":"charlie"},"created_at":"2025-01-03T10:00:00Z","body":"third"},
-    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"second"},
-    {"user":{"login":"alice"},"created_at":"2025-01-01T11:00:00Z","body":"first"}
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
+    {"id":21,"in_reply_to_id":10,"user":{"login":"charlie"},"created_at":"2025-01-03T10:00:00Z","path":"a.sh","line":1,"body":"third"},
+    {"id":22,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"second"},
+    {"id":20,"in_reply_to_id":10,"user":{"login":"alice"},"created_at":"2025-01-01T11:00:00Z","path":"a.sh","line":1,"body":"first"}
   ]'
-  setup_mocks_nesting "$review" '[]' "10:$replies"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local first_reply_body
@@ -254,12 +237,12 @@ test_nesting_replies_sorted_chronologically() {
 
 # test_nesting_multiple_replies_under_one_parent verifies that two reply blocks are rendered under a single parent review comment; increments `pass` if exactly two `>>> reply` markers are found, otherwise increments `fail` and prints a FAIL message with the captured output.
 test_nesting_multiple_replies_under_one_parent() {
-  local review='[{"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"}]'
-  local replies='[
-    {"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","body":"reply one"},
-    {"user":{"login":"carol"},"created_at":"2025-01-03T10:00:00Z","body":"reply two"}
+  local review='[
+    {"id":10,"user":{"login":"alice"},"created_at":"2025-01-01T10:00:00Z","path":"a.sh","line":1,"body":"parent"},
+    {"id":20,"in_reply_to_id":10,"user":{"login":"bob"},"created_at":"2025-01-02T10:00:00Z","path":"a.sh","line":1,"body":"reply one"},
+    {"id":21,"in_reply_to_id":10,"user":{"login":"carol"},"created_at":"2025-01-03T10:00:00Z","path":"a.sh","line":1,"body":"reply two"}
   ]'
-  setup_mocks_nesting "$review" '[]' "10:$replies"
+  setup_mocks_nesting "$review" '[]'
   local output
   output=$(run_script comments --pr 42 2>&1)
   local reply_count


### PR DESCRIPTION
## Sprint 7 Summary

All issues found during Sprint 6 review. Fixes both runtimes where applicable.

### Issues
- Closes #90 — Python test strict mode + stderr summaries
- Closes #86 — Check-run ID vs job ID for log downloads (bug, both runtimes)
- Closes #89 — Fork-based PR auto-detection (bug, both runtimes)
- Closes #87 — Worktree-aware gitdir in Python runtime
- Closes #88 — Eliminate N+1 reply API calls in comments (both runtimes)

### Changes
| Issue | Size | Scope | Description |
|-------|------|-------|-------------|
| #90 | S | test | Added `set -euo pipefail`, counter isolation, stderr summary trap to Python test files |
| #86 | S | bug | Resolve check-run IDs to real job IDs via `/check-runs/{id}/jobs` before downloading logs |
| #89 | S | bug | Detect fork repos via API, query parent repo for PRs, propagate parent to all endpoints |
| #87 | M | feat | Port bash `setup_git_env()` to Python — handles .git files, gitdir: parsing, Windows paths |
| #88 | M | perf | Group replies client-side from initial endpoint instead of N+1 `/replies` calls |

### Review fixes applied
- Removed unused shellcheck SC2034 variable
- Propagated fork parent repo to all subsequent API calls (CodeRabbit P2)
- Prefixed unused unpack variables with `_`
- Removed extra blank stderr line per CodeRabbit review

### Testing
- All 37 Python tests pass on merged branch
- All bash tests pass (comments, reply nesting, logs, PR resolution)
- CI green on all 5 issue PRs (#91–#95) after review fixes