### PR TITLE
feat(#59): port monitor status command to Python runtime

### DIFF
--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -3,8 +3,10 @@ import json
 import os
 import re
 import shlex
+import signal
 import subprocess
 import sys
+import time
 from datetime import datetime, timezone
 
 VERSION = "0.2.5"
@@ -312,6 +314,309 @@ def resolve_pr_head_sha(pr_number):
     return val
 
 
+def parse_duration(input_str):
+    if not input_str:
+        die("invalid duration: (empty)")
+    m = re.match(r"^(\d+)(s|m|h)$", input_str)
+    if not m:
+        die(f"invalid duration: {input_str} (expected <number><s|m|h>)")
+    num = int(m.group(1))
+    suffix = m.group(2)
+    if suffix == "s":
+        return num
+    if suffix == "m":
+        return num * 60
+    return num * 3600
+
+
+def _timed_gh_api_paginated(endpoint, timeout_secs=None):
+    args = _gh_cmd() + ["api", "--paginate", endpoint]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout_secs
+        )
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+    if result.returncode != 0:
+        return None, "error"
+    return result.stdout, "ok"
+
+
+def _capture_check_snapshot(owner_repo, sha, timeout_secs=None):
+    checks_raw, status = _timed_gh_api_paginated(
+        f"repos/{owner_repo}/commits/{sha}/check-runs", timeout_secs
+    )
+    if status == "timeout":
+        return None, "timeout"
+    if status != "ok":
+        return None, "error"
+    checks_data = parse_paginated_json(checks_raw)
+    all_runs = []
+    for page in checks_data:
+        if isinstance(page, dict) and "check_runs" in page:
+            all_runs.extend(page["check_runs"])
+    snapshot = sorted(
+        [
+            {
+                "name": r.get("name", ""),
+                "status": r.get("status", ""),
+                "conclusion": r.get("conclusion"),
+            }
+            for r in all_runs
+        ],
+        key=lambda x: x["name"],
+    )
+    return snapshot, "ok"
+
+
+def _compute_status_diff(prev_snapshot, cur_snapshot):
+    prev_by_name = {c["name"]: c for c in prev_snapshot}
+    cur_by_name = {c["name"]: c for c in cur_snapshot}
+    all_names = sorted(set(prev_by_name.keys()) | set(cur_by_name.keys()))
+    changes = []
+    for name in all_names:
+        old = prev_by_name.get(name)
+        new = cur_by_name.get(name)
+        if old is None:
+            changes.append(
+                {
+                    "check": name,
+                    "from": "absent",
+                    "to": new["status"],
+                    "conclusion": new["conclusion"],
+                }
+            )
+        elif new is None:
+            changes.append(
+                {
+                    "check": name,
+                    "from": old["status"],
+                    "to": "absent",
+                    "conclusion": None,
+                }
+            )
+        elif (
+            old["status"] != new["status"]
+            or (old.get("conclusion") or "") != (new.get("conclusion") or "")
+        ):
+            changes.append(
+                {
+                    "check": name,
+                    "from": old["status"],
+                    "to": new["status"],
+                    "conclusion": new["conclusion"],
+                }
+            )
+    return changes
+
+
+def _format_status_changes(changes):
+    parts = []
+    for c in changes:
+        block = [
+            "--- change",
+            "type: status",
+            f"check: {c['check']}",
+            f"from: {c['from']}",
+            f"to: {c['to']}",
+        ]
+        if c.get("conclusion") is not None and c["to"] != "absent":
+            block.append(f"conclusion: {c['conclusion']}")
+        parts.append("\n".join(block))
+    return "\n".join(parts)
+
+
+def _monitor_call_timeout(timeout_secs, start_mono):
+    if timeout_secs is None:
+        return None
+    remaining = timeout_secs - (time.monotonic() - start_mono)
+    if remaining <= 0:
+        return "expired"
+    return remaining
+
+
+def cmd_monitor_status(argv):
+    pr_number = ""
+    interval = 30
+    timeout_input = ""
+    timeout_secs = None
+    check_filter = ""
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg == "--interval":
+            if i + 1 >= len(argv):
+                die("missing value for --interval")
+            interval = argv[i + 1]
+            i += 2
+            if not re.match(r"^[1-9][0-9]*$", interval):
+                die(
+                    f"invalid --interval value: {interval} (expected a positive integer)"
+                )
+            interval = int(interval)
+        elif arg == "--timeout":
+            if i + 1 >= len(argv):
+                die("missing value for --timeout")
+            timeout_input = argv[i + 1]
+            i += 2
+            timeout_secs = parse_duration(timeout_input)
+        elif arg == "--check":
+            if i + 1 >= len(argv):
+                die("missing value for --check")
+            val = argv[i + 1]
+            if not val:
+                die("missing value for --check")
+            if val.startswith("-"):
+                die("missing value for --check")
+            check_filter = val
+            i += 2
+        elif arg in ("-h", "--help"):
+            usage_monitor_status()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    check_deps()
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = get_owner_repo()
+
+    prev_sha = resolve_pr_head_sha(pr_number)
+    if not prev_sha:
+        die(f"failed to resolve head SHA for PR #{pr_number}")
+
+    prev_snapshot, snap_status = _capture_check_snapshot(owner_repo, prev_sha)
+    if snap_status != "ok":
+        die(f"failed to fetch check runs for SHA {prev_sha}")
+    if check_filter:
+        prev_snapshot = [c for c in prev_snapshot if c["name"] == check_filter]
+
+    interrupted = False
+
+    def _handle_signal(signum, frame):
+        nonlocal interrupted
+        interrupted = True
+
+    original_sigint = signal.signal(signal.SIGINT, _handle_signal)
+    original_sigterm = signal.signal(signal.SIGTERM, _handle_signal)
+
+    start_mono = time.monotonic()
+
+    try:
+        while True:
+            if timeout_secs is not None:
+                elapsed = time.monotonic() - start_mono
+                if elapsed >= timeout_secs:
+                    print(
+                        f"monitor timed out after {timeout_input}", file=sys.stderr
+                    )
+                    sys.exit(2)
+
+            sleep_for = interval
+            if timeout_secs is not None:
+                remaining = timeout_secs - (time.monotonic() - start_mono)
+                if remaining < sleep_for:
+                    sleep_for = max(remaining, 0)
+            try:
+                time.sleep(sleep_for)
+            except OSError:
+                pass
+
+            if interrupted:
+                pass
+            elif timeout_secs is not None:
+                elapsed = time.monotonic() - start_mono
+                if elapsed >= timeout_secs:
+                    print(
+                        f"monitor timed out after {timeout_input}", file=sys.stderr
+                    )
+                    sys.exit(2)
+
+            call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+            if call_timeout == "expired":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+
+            cur_sha = resolve_pr_head_sha(pr_number)
+            if cur_sha is None:
+                print(
+                    "gh api call timed out; retrying next poll", file=sys.stderr
+                )
+                if interrupted:
+                    sys.exit(130)
+                continue
+
+            if cur_sha != prev_sha:
+                print("--- change")
+                print("type: new-commit")
+                print(f"sha: {cur_sha}")
+                if interrupted:
+                    sys.exit(130)
+                sys.exit(0)
+
+            call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+            if call_timeout == "expired":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+
+            cur_snapshot, snap_status = _capture_check_snapshot(
+                owner_repo, cur_sha, call_timeout
+            )
+            if snap_status == "timeout":
+                print(
+                    "gh api call timed out; retrying next poll", file=sys.stderr
+                )
+                if interrupted:
+                    sys.exit(130)
+                continue
+            if snap_status != "ok":
+                die("failed to fetch check runs during poll")
+            if check_filter:
+                cur_snapshot = [
+                    c for c in cur_snapshot if c["name"] == check_filter
+                ]
+
+            changes = _compute_status_diff(prev_snapshot, cur_snapshot)
+
+            if changes:
+                print(_format_status_changes(changes))
+                if interrupted:
+                    sys.exit(130)
+                sys.exit(0)
+
+            if interrupted:
+                sys.exit(130)
+
+            prev_sha = cur_sha
+            prev_snapshot = cur_snapshot
+    finally:
+        signal.signal(signal.SIGINT, original_sigint)
+        signal.signal(signal.SIGTERM, original_sigterm)
+
+
+def cmd_monitor(argv):
+    if not argv:
+        die("missing monitor sub-command (see 'gh-pr-context monitor --help')")
+
+    sub_command = argv[0]
+    rest = argv[1:]
+
+    if sub_command == "status":
+        cmd_monitor_status(rest)
+    elif sub_command in ("-h", "--help"):
+        usage_monitor()
+        sys.exit(0)
+    else:
+        die(f"unknown monitor sub-command: {sub_command}")
+
+
 def cmd_status(argv):
     pr_number = ""
     i = 0
@@ -610,6 +915,7 @@ def usage():
     print("  comments   Fetch PR comments")
     print("  status     Fetch CI check status")
     print("  logs       Fetch logs for failed CI checks")
+    print("  monitor    Poll for CI/comment changes")
     print("")
     print("options:")
     print("  --pr <number>   PR number (auto-detected from branch if omitted)")
@@ -617,6 +923,30 @@ def usage():
     print("  --all           Return all comments (default)")
     print("  --version       Show version")
     print("  -h, --help      Show this message")
+
+
+def usage_monitor():
+    print("usage: gh-pr-context monitor <sub-command> [options]")
+    print("")
+    print("sub-commands:")
+    print("  status   Poll for check status changes")
+    print("")
+    print("options:")
+    print("  -h, --help   Show this message")
+
+
+def usage_monitor_status():
+    print("usage: gh-pr-context monitor status [options]")
+    print("")
+    print("Poll for check status/conclusion changes and new commits.")
+    print("Exits 0 on change, 1 on error, 2 on timeout, 130 on signal.")
+    print("")
+    print("options:")
+    print("  --pr <number>       PR number (auto-detected from branch if omitted)")
+    print("  --interval <secs>   Poll interval in seconds (default: 30)")
+    print("  --timeout <dur>     Maximum time to poll (e.g. 30s, 5m, 1h)")
+    print("  --check <name>      Only watch the named check")
+    print("  -h, --help          Show this message")
 
 
 def main(argv):
@@ -644,6 +974,9 @@ def main(argv):
         return 0
     if command == "logs":
         cmd_logs(rest)
+        return 0
+    if command == "monitor":
+        cmd_monitor(rest)
         return 0
 
     return die(f"unknown command: {command}")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -465,6 +465,20 @@ def _monitor_call_timeout(timeout_secs, start_mono):
     return remaining
 
 
+_INTERRUPTIBLE_SLEEP_CHUNK = 0.1
+
+
+def _interruptible_sleep(total, is_interrupted):
+    end = time.monotonic() + total
+    while True:
+        if is_interrupted():
+            return
+        remaining = end - time.monotonic()
+        if remaining <= 0:
+            return
+        time.sleep(min(remaining, _INTERRUPTIBLE_SLEEP_CHUNK))
+
+
 def cmd_monitor_status(argv):
     pr_number = ""
     interval = 30
@@ -555,7 +569,7 @@ def cmd_monitor_status(argv):
                 if remaining < sleep_for:
                     sleep_for = max(remaining, 0)
             try:
-                time.sleep(sleep_for)
+                _interruptible_sleep(sleep_for, lambda: interrupted)
             except OSError:
                 pass
 

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -90,6 +90,23 @@ def gh_api_jq(endpoint, jq_filter):
     return result.stdout.strip().replace("\r", ""), True
 
 
+def _timed_gh_api_jq(endpoint, jq_filter, timeout_secs=None):
+    """Like gh_api_jq but with a subprocess timeout.
+
+    Returns (value, status) where status is "ok", "timeout", or "error".
+    """
+    args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
+    try:
+        result = subprocess.run(
+            args, capture_output=True, text=True, timeout=timeout_secs
+        )
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+    if result.returncode != 0:
+        return None, "error"
+    return result.stdout.strip().replace("\r", ""), "ok"
+
+
 def _setup_git_env():
     """Resolve worktree gitdir when git rev-parse --git-dir fails.
 
@@ -306,12 +323,21 @@ def resolve_since_timestamp(since_input):
     die(f"invalid --since value: {since_input} (expected: last-commit, <7-40 char SHA>, YYYY-MM-DD, or YYYY-MM-DDTHH:mm:ss)")
 
 
-def resolve_pr_head_sha(pr_number):
+def resolve_pr_head_sha(pr_number, timeout_secs=None):
     owner_repo = get_owner_repo()
+    if timeout_secs is not None:
+        val, status = _timed_gh_api_jq(
+            f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha", timeout_secs
+        )
+        if status == "timeout":
+            return None, "timeout"
+        if status == "error" or not val:
+            return None, "error"
+        return val, "ok"
     val, ok = gh_api_jq(f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha")
     if not ok or not val:
-        return None
-    return val
+        return None, "error"
+    return val, "ok"
 
 
 def parse_duration(input_str):
@@ -370,8 +396,12 @@ def _capture_check_snapshot(owner_repo, sha, timeout_secs=None):
 
 
 def _compute_status_diff(prev_snapshot, cur_snapshot):
-    prev_by_name = {c["name"]: c for c in prev_snapshot}
-    cur_by_name = {c["name"]: c for c in cur_snapshot}
+    prev_by_name = {}
+    for c in prev_snapshot:
+        prev_by_name.setdefault(c["name"], c)
+    cur_by_name = {}
+    for c in cur_snapshot:
+        cur_by_name.setdefault(c["name"], c)
     all_names = sorted(set(prev_by_name.keys()) | set(cur_by_name.keys()))
     changes = []
     for name in all_names:
@@ -488,8 +518,8 @@ def cmd_monitor_status(argv):
 
     owner_repo = get_owner_repo()
 
-    prev_sha = resolve_pr_head_sha(pr_number)
-    if not prev_sha:
+    prev_sha, sha_status = resolve_pr_head_sha(pr_number)
+    if sha_status != "ok":
         die(f"failed to resolve head SHA for PR #{pr_number}")
 
     prev_snapshot, snap_status = _capture_check_snapshot(owner_repo, prev_sha)
@@ -544,14 +574,16 @@ def cmd_monitor_status(argv):
                 print(f"monitor timed out after {timeout_input}", file=sys.stderr)
                 sys.exit(2)
 
-            cur_sha = resolve_pr_head_sha(pr_number)
-            if cur_sha is None:
+            cur_sha, sha_status = resolve_pr_head_sha(pr_number, call_timeout)
+            if sha_status == "timeout":
                 print(
                     "gh api call timed out; retrying next poll", file=sys.stderr
                 )
                 if interrupted:
                     sys.exit(130)
                 continue
+            if sha_status != "ok":
+                die(f"failed to re-resolve head SHA for PR #{pr_number}")
 
             if cur_sha != prev_sha:
                 print("--- change")
@@ -642,8 +674,8 @@ def cmd_status(argv):
 
     owner_repo = get_owner_repo()
 
-    sha = resolve_pr_head_sha(pr_number)
-    if not sha:
+    sha, sha_status = resolve_pr_head_sha(pr_number)
+    if sha_status != "ok":
         die(f"failed to resolve head SHA for PR #{pr_number}")
 
     checks_raw, ok = gh_api_paginated(f"repos/{owner_repo}/commits/{sha}/check-runs")
@@ -700,8 +732,8 @@ def cmd_logs(argv):
 
     owner_repo = get_owner_repo()
 
-    sha = resolve_pr_head_sha(pr_number)
-    if not sha:
+    sha, sha_status = resolve_pr_head_sha(pr_number)
+    if sha_status != "ok":
         die(f"failed to resolve head SHA for PR #{pr_number}")
 
     checks_raw, ok = gh_api_paginated(f"repos/{owner_repo}/commits/{sha}/check-runs")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -977,7 +977,7 @@ def usage_monitor_status():
     print("  --pr <number>       PR number (auto-detected from branch if omitted)")
     print("  --interval <secs>   Poll interval in seconds (default: 30)")
     print("  --timeout <dur>     Maximum time to poll (e.g. 30s, 5m, 1h)")
-    print("  --check <name>      Only watch the named check")
+    print("  --check <name>      Only watch the named check (case-sensitive)")
     print("  -h, --help          Show this message")
 
 

--- a/test/test_python_monitor_status.sh
+++ b/test/test_python_monitor_status.sh
@@ -197,37 +197,6 @@ GHEOF
   chmod +x "$_MOCK_DIR/gh"
 }
 
-write_gh_no_change_mock() {
-  cat > "$_MOCK_DIR/gh" << GHEOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
-  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
-  *"check-runs"*)
-    echo '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
-    ;;
-  *) exit 1 ;;
-esac
-GHEOF
-  chmod +x "$_MOCK_DIR/gh"
-}
-
-write_gh_static_mock() {
-  local check_data="$1"
-  cat > "$_MOCK_DIR/gh" << GHEOF
-#!/usr/bin/env bash
-case "\$*" in
-  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
-  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
-  *"check-runs"*)
-    printf '%s' '$check_data'
-    ;;
-  *) exit 1 ;;
-esac
-GHEOF
-  chmod +x "$_MOCK_DIR/gh"
-}
-
 run_python() {
   if command -v cygpath >/dev/null 2>&1; then
     local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'

--- a/test/test_python_monitor_status.sh
+++ b/test/test_python_monitor_status.sh
@@ -1,0 +1,751 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+python_script="$repo_root/gh-pr-context.py"
+if command -v py >/dev/null 2>&1; then
+  python_cmd="py -3"
+else
+  python_cmd="python3"
+fi
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+assert_exit() {
+  local expected_exit=$1 desc=$2; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_stderr_contains() {
+  local desc=$1 needle=$2; shift 2
+  local output
+  output=$("$@" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (stderr did not contain: $needle)"
+  fi
+}
+
+setup_mock_dir() {
+  _MOCK_DIR=$(mktemp -d)
+}
+
+cleanup_mock_dir() {
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
+    rm -rf "$_MOCK_DIR"
+  fi
+}
+
+write_git_mock() {
+  cat > "$_MOCK_DIR/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --git-dir") echo ".git" ;;
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$_MOCK_DIR/git"
+}
+
+write_gh_stateful_mock() {
+  local initial_check="$1"
+  local changed_check="$2"
+  local sha_first="${3:-$HEAD_SHA}"
+  local sha_subsequent="${4:-$HEAD_SHA}"
+  echo 0 > "$_MOCK_DIR/counter"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+esac
+call_num=\$(cat $_MOCK_DIR/counter)
+call_num=\$((call_num + 1))
+echo "\$call_num" > "$_MOCK_DIR/counter"
+case "\$*" in
+  *"pulls/42"*"--jq"*)
+    if [ "\$call_num" -le 1 ]; then
+      echo '$sha_first'
+    else
+      echo '$sha_subsequent'
+    fi
+    ;;
+  *"check-runs"*)
+    if [ "\$call_num" -le 2 ]; then
+      printf '%s' '$initial_check'
+    else
+      printf '%s' '$changed_check'
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_auto_detect_mock() {
+  local initial_check="$1"
+  local changed_check="$2"
+  echo 0 > "$_MOCK_DIR/counter"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+esac
+call_num=\$(cat $_MOCK_DIR/counter)
+call_num=\$((call_num + 1))
+echo "\$call_num" > "$_MOCK_DIR/counter"
+case "\$*" in
+  *"pulls?head=acme:feature-branch"*"--jq"*) echo '42' ;;
+  *"pulls/42"*"--jq"*)
+    echo '$HEAD_SHA'
+    ;;
+  *"check-runs"*)
+    if [ "\$call_num" -le 3 ]; then
+      printf '%s' '$initial_check'
+    else
+      printf '%s' '$changed_check'
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_no_pr_mock() {
+  cat > "$_MOCK_DIR/gh" << 'GH_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false' ;;
+  *"pulls?head=acme:feature-branch"*"--jq"*) echo '' ;;
+  *) exit 1 ;;
+esac
+GH_EOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_api_failure_mock() {
+  local initial_check="$1"
+  echo 0 > "$_MOCK_DIR/counter"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+esac
+call_num=\$(cat $_MOCK_DIR/counter)
+call_num=\$((call_num + 1))
+echo "\$call_num" > "$_MOCK_DIR/counter"
+case "\$*" in
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    if [ "\$call_num" -le 2 ]; then
+      printf '%s' '$initial_check'
+    else
+      exit 1
+    fi
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_no_change_mock() {
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    echo '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_static_mock() {
+  local check_data="$1"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    printf '%s' '$check_data'
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_no_change_mock() {
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    echo '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_static_mock() {
+  local check_data="$1"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    printf '%s' '$check_data'
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+run_python() {
+  if command -v cygpath >/dev/null 2>&1; then
+    local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+    local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+    local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  else
+    local git_mock="bash $_MOCK_DIR/git"
+    local gh_mock="bash $_MOCK_DIR/gh"
+  fi
+  GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
+    timeout 15 $python_cmd "$python_script" "$@"
+}
+
+run_python_no_mock() {
+  $python_cmd "$python_script" "$@"
+}
+
+# --- Tests ---
+
+test_py_monitor_status_single_check_change() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: completed" \
+    && echo "$output" | grep -qF "conclusion: success"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: single check change (output: $output)"
+  fi
+}
+
+test_py_monitor_status_multiple_changes_sorted() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"Test","status":"queued","conclusion":null}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  local first_check
+  first_check=$(echo "$output" | grep -m1 "check:" | sed 's/check: //' | tr -d '\r')
+  local second_check
+  second_check=$(echo "$output" | grep "check:" | sed 's/check: //' | tail -1 | tr -d '\r')
+  if [ "$first_check" = "Build" ] && [ "$second_check" = "Test" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: multiple changes not sorted (first=$first_check, second=$second_check, output: $output)"
+  fi
+}
+
+test_py_monitor_status_new_check_appearing() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"},{"name":"Lint","status":"in_progress","conclusion":null}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "check: Lint" \
+    && echo "$output" | grep -qF "from: absent" \
+    && echo "$output" | grep -qF "to: in_progress"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: new check appearing (output: $output)"
+  fi
+}
+
+test_py_monitor_status_check_disappearing() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":2,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"},{"name":"Lint","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "check: Lint" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: absent"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: check disappearing (output: $output)"
+  fi
+}
+
+test_py_monitor_status_sha_change() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  write_gh_stateful_mock "$initial" "$initial" "$HEAD_SHA" "$NEW_SHA"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF -- "--- change" \
+    && echo "$output" | grep -qF "type: new-commit" \
+    && echo "$output" | grep -qF "sha: $NEW_SHA"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA change detection (output: $output)"
+  fi
+}
+
+test_py_monitor_status_explicit_pr() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: explicit --pr 42 should succeed (exit: $exit_code)"
+  fi
+}
+
+test_py_monitor_status_auto_detect() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_auto_detect_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "check: CI"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: auto-detect PR should work (output: $output)"
+  fi
+}
+
+test_py_monitor_status_no_pr_exits_nonzero() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_no_pr_mock
+  local exit_code=0
+  run_python monitor status --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR should exit non-zero"
+  fi
+}
+
+test_py_monitor_status_no_pr_stderr_message() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_no_pr_mock
+  local output
+  output=$(run_python monitor status --interval 1 2>&1) || true
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "no open PR found"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no PR should mention 'no open PR found' (output: $output)"
+  fi
+}
+
+test_py_monitor_status_api_failure_exits_nonzero() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  write_gh_api_failure_mock "$initial"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -ne 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: API failure should exit non-zero"
+  fi
+}
+
+test_py_monitor_no_subcommand_exits_nonzero() {
+  assert_exit 1 "monitor with no subcommand exits 1" run_python_no_mock monitor
+}
+
+test_py_monitor_help_exits_zero() {
+  assert_exit 0 "monitor --help exits 0" run_python_no_mock monitor --help
+  assert_exit 0 "monitor -h exits 0" run_python_no_mock monitor -h
+}
+
+test_py_monitor_status_help_exits_zero() {
+  assert_exit 0 "monitor status --help exits 0" run_python_no_mock monitor status --help
+  assert_exit 0 "monitor status -h exits 0" run_python_no_mock monitor status -h
+}
+
+test_py_monitor_status_unknown_option_exits_nonzero() {
+  assert_exit 1 "monitor status unknown option exits 1" run_python_no_mock monitor status --bogus
+}
+
+test_py_monitor_status_missing_pr_value_exits_nonzero() {
+  assert_stderr_contains "status --pr without value gives clear message" "missing value for --pr" run_python_no_mock monitor status --pr
+}
+
+test_py_monitor_status_missing_interval_value_exits_nonzero() {
+  assert_stderr_contains "status --interval without value gives clear message" "missing value for --interval" run_python_no_mock monitor status --interval
+}
+
+test_py_monitor_status_invalid_interval_exits_nonzero() {
+  assert_stderr_contains "status --interval abc gives clear message" "invalid --interval value: abc" run_python_no_mock monitor status --interval abc
+}
+
+test_py_monitor_status_zero_interval_exits_nonzero() {
+  assert_stderr_contains "status --interval 0 gives clear message" "invalid --interval value: 0" run_python_no_mock monitor status --interval 0
+}
+
+test_py_monitor_status_negative_interval_exits_nonzero() {
+  assert_stderr_contains "status --interval -1 gives clear message" "invalid --interval value: -1" run_python_no_mock monitor status --interval -1
+}
+
+test_py_monitor_status_timeout_exits_two() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_no_change_mock
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --timeout 3s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout should exit 2 (got $exit_code)"
+  fi
+}
+
+test_py_monitor_status_timeout_stderr_message() {
+  setup_mock_dir
+  write_git_mock
+  write_gh_no_change_mock
+  local stderr_output
+  stderr_output=$(run_python monitor status --pr 42 --interval 1 --timeout 2s 2>&1 >/dev/null) || true
+  cleanup_mock_dir
+  if echo "$stderr_output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout stderr should contain 'monitor timed out after 2s' (got: $stderr_output)"
+  fi
+}
+
+test_py_monitor_status_timeout_minutes() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --timeout 5m >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --timeout 5m should be accepted (got exit $exit_code)"
+  fi
+}
+
+test_py_monitor_status_timeout_hours() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --timeout 1h >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --timeout 1h should be accepted (got exit $exit_code)"
+  fi
+}
+
+test_py_monitor_status_no_timeout_preserves_behavior() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 0 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: no timeout should detect change and exit 0 (got exit $exit_code)"
+  fi
+}
+
+test_py_monitor_status_missing_timeout_value_exits_nonzero() {
+  assert_stderr_contains "status --timeout without value gives clear message" "missing value for --timeout" run_python_no_mock monitor status --timeout
+}
+
+test_py_monitor_status_invalid_timeout_exits_nonzero() {
+  assert_stderr_contains "status --timeout abc gives clear message" "invalid duration" run_python_no_mock monitor status --timeout abc
+}
+
+test_py_monitor_status_help_shows_timeout() {
+  local output
+  output=$(run_python_no_mock monitor status --help 2>&1)
+  if echo "$output" | grep -qF -- "--timeout"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --help should list --timeout (output: $output)"
+  fi
+}
+
+test_py_monitor_status_check_missing_value_flag() {
+  assert_stderr_contains "--check followed by flag gives clear message" "missing value for --check" run_python_no_mock monitor status --check --timeout 30s
+}
+
+test_py_monitor_status_check_missing_value_last() {
+  assert_stderr_contains "--check as last arg gives clear message" "missing value for --check" run_python_no_mock monitor status --check
+}
+
+test_py_monitor_status_check_empty_value_rejected() {
+  assert_stderr_contains "--check empty gives clear message" "missing value for --check" run_python_no_mock monitor status --check ""
+}
+
+test_py_monitor_status_check_filters_to_named_check() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"CI","status":"completed","conclusion":"failure"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 --check CI 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: completed" \
+    && echo "$output" | grep -qF "conclusion: failure" \
+    && ! echo "$output" | grep -qF "check: Build"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check should filter to named check only (output: $output)"
+  fi
+}
+
+test_py_monitor_status_check_ignores_other_changes() {
+  setup_mock_dir
+  write_git_mock
+  local check_data='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"CI","status":"in_progress","conclusion":null}]}'
+  write_gh_static_mock "$check_data"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --check CI --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check CI should not detect Build change, should timeout exit 2 (got $exit_code)"
+  fi
+}
+
+test_py_monitor_status_check_appears_after_delay() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 --check CI 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "from: absent" \
+    && echo "$output" | grep -qF "to: in_progress" \
+    && ! echo "$output" | grep -qF "check: Build"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check should show from: absent for delayed check (output: $output)"
+  fi
+}
+
+test_py_monitor_status_check_timeout_missing_check() {
+  setup_mock_dir
+  write_git_mock
+  local check_data='{"total_count":1,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null}]}'
+  write_gh_static_mock "$check_data"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --check CI --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check with missing check and --timeout should exit 2 (got $exit_code)"
+  fi
+}
+
+test_py_monitor_status_check_case_sensitive() {
+  setup_mock_dir
+  write_git_mock
+  local check_data='{"total_count":1,"check_runs":[{"name":"ci","status":"in_progress","conclusion":null}]}'
+  write_gh_static_mock "$check_data"
+  local exit_code=0
+  run_python monitor status --pr 42 --interval 1 --check CI --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: --check CI should not match ci, should timeout exit 2 (got $exit_code)"
+  fi
+}
+
+test_py_monitor_status_help_shows_check() {
+  local output
+  output=$(run_python_no_mock monitor status --help 2>&1)
+  if echo "$output" | grep -qF -- "--check"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor status --help should list --check (output: $output)"
+  fi
+}
+
+test_py_usage_lists_monitor() {
+  local output
+  output=$(run_python_no_mock --help 2>&1)
+  if echo "$output" | grep -qF "monitor"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: usage should list monitor command"
+  fi
+}
+
+test_names+=(
+  test_py_monitor_status_single_check_change
+  test_py_monitor_status_multiple_changes_sorted
+  test_py_monitor_status_new_check_appearing
+  test_py_monitor_status_check_disappearing
+  test_py_monitor_status_sha_change
+  test_py_monitor_status_explicit_pr
+  test_py_monitor_status_auto_detect
+  test_py_monitor_status_no_pr_exits_nonzero
+  test_py_monitor_status_no_pr_stderr_message
+  test_py_monitor_status_api_failure_exits_nonzero
+  test_py_monitor_no_subcommand_exits_nonzero
+  test_py_monitor_help_exits_zero
+  test_py_monitor_status_help_exits_zero
+  test_py_monitor_status_unknown_option_exits_nonzero
+  test_py_monitor_status_missing_pr_value_exits_nonzero
+  test_py_monitor_status_missing_interval_value_exits_nonzero
+  test_py_monitor_status_invalid_interval_exits_nonzero
+  test_py_monitor_status_zero_interval_exits_nonzero
+  test_py_monitor_status_negative_interval_exits_nonzero
+  test_py_monitor_status_timeout_exits_two
+  test_py_monitor_status_timeout_stderr_message
+  test_py_monitor_status_timeout_minutes
+  test_py_monitor_status_timeout_hours
+  test_py_monitor_status_no_timeout_preserves_behavior
+  test_py_monitor_status_missing_timeout_value_exits_nonzero
+  test_py_monitor_status_invalid_timeout_exits_nonzero
+  test_py_monitor_status_help_shows_timeout
+  test_py_monitor_status_check_missing_value_flag
+  test_py_monitor_status_check_missing_value_last
+  test_py_monitor_status_check_empty_value_rejected
+  test_py_monitor_status_check_filters_to_named_check
+  test_py_monitor_status_check_ignores_other_changes
+  test_py_monitor_status_check_appears_after_delay
+  test_py_monitor_status_check_timeout_missing_check
+  test_py_monitor_status_check_case_sensitive
+  test_py_monitor_status_help_shows_check
+  test_py_usage_lists_monitor
+)
+
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+
+  _summary_on_exit() {
+    local rc=$?
+    if [ "$rc" -ne 0 ] || [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: exit ${rc}, ${fail:-0} test(s) failed, ${pass:-0} passed" >&2
+    fi
+    exit "$rc"
+  }
+  trap _summary_on_exit EXIT
+
+  echo "--- test_python_monitor_status.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
+
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi

--- a/test/test_python_monitor_status.sh
+++ b/test/test_python_monitor_status.sh
@@ -656,6 +656,62 @@ test_py_usage_lists_monitor() {
   fi
 }
 
+test_py_monitor_status_sha_error_dies() {
+  setup_mock_dir
+  write_git_mock
+  echo 0 > "$_MOCK_DIR/counter"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+esac
+call_num=\$(cat $_MOCK_DIR/counter)
+call_num=\$((call_num + 1))
+echo "\$call_num" > "$_MOCK_DIR/counter"
+case "\$*" in
+  *"pulls/42"*"--jq"*)
+    if [ "\$call_num" -le 1 ]; then
+      echo '$HEAD_SHA'
+    else
+      exit 1
+    fi
+    ;;
+  *"check-runs"*)
+    echo '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+    ;;
+  *) exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1) && rc=0 || rc=$?
+  cleanup_mock_dir
+  if [ "$rc" -ne 0 ] && echo "$output" | grep -qi "failed.*head SHA\|failed.*re-resolve"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: SHA auth error should die, not retry (rc=$rc, output: $output)"
+  fi
+}
+
+test_py_monitor_status_duplicate_check_keeps_first() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":2,"check_runs":[{"name":"CI","status":"queued","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"CI","status":"queued","conclusion":null},{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock "$initial" "$changed"
+  local output
+  output=$(run_python monitor status --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "from: queued" \
+    && echo "$output" | grep -qF "to: completed"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: duplicate check name should keep first occurrence (output: $output)"
+  fi
+}
+
 test_names+=(
   test_py_monitor_status_single_check_change
   test_py_monitor_status_multiple_changes_sorted
@@ -694,6 +750,8 @@ test_names+=(
   test_py_monitor_status_check_case_sensitive
   test_py_monitor_status_help_shows_check
   test_py_usage_lists_monitor
+  test_py_monitor_status_sha_error_dies
+  test_py_monitor_status_duplicate_check_keeps_first
 )
 
 # --- Run tests (only when executed directly, not sourced) ---

--- a/test/test_python_monitor_status.sh
+++ b/test/test_python_monitor_status.sh
@@ -698,7 +698,7 @@ test_py_monitor_status_duplicate_check_keeps_first() {
   setup_mock_dir
   write_git_mock
   local initial='{"total_count":2,"check_runs":[{"name":"CI","status":"queued","conclusion":null},{"name":"CI","status":"in_progress","conclusion":null}]}'
-  local changed='{"total_count":2,"check_runs":[{"name":"CI","status":"queued","conclusion":null},{"name":"CI","status":"completed","conclusion":"success"}]}'
+  local changed='{"total_count":2,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"},{"name":"CI","status":"queued","conclusion":null}]}'
   write_gh_stateful_mock "$initial" "$changed"
   local output
   output=$(run_python monitor status --pr 42 --interval 1 2>&1)


### PR DESCRIPTION
## Summary

Ports the monitor status sub-command to gh-pr-context.py for native PowerShell/Windows support.

Closes #59

## What changed

**gh-pr-context.py** — Added monitor status polling loop and supporting functions:
- parse_duration() — Duration string parser (30s, 5m, 1h to seconds)
- _timed_gh_api_paginated() — gh api calls with subprocess timeout support
- _capture_check_snapshot() — Normalized check-run snapshot for diffing
- _compute_status_diff() — Full outer join over check names (matches bash jq logic)
- _format_status_changes() — Terse change output formatting
- cmd_monitor_status() — Polling loop with --pr, --interval, --timeout, --check
- cmd_monitor() — Sub-command dispatcher
- Updated usage() and main() to route monitor command

**test/test_python_monitor_status.sh** — 39 tests covering:
- Single/multiple check transitions, sorted output
- New checks appearing, checks disappearing
- SHA change (new-commit) detection
- Explicit --pr and auto-detect PR
- No PR error, API failure error
- --interval validation (invalid/zero/negative)
- --timeout (exit 2 on timeout, stderr message, minutes/hours parsing)
- --check filter (named check only, case-sensitive, absent check, ignores others)
- Help/usage exits 0, unknown options exit non-zero

## How tested

- 356 tests pass (317 existing + 39 new)
- No lint/typecheck tools in this project (bash + Python single-file)

## Acceptance criteria (from #59)

- [x] gh-pr-context monitor status works from PowerShell
- [x] --interval flag respected
- [x] --pr flag respected
- [x] Detects check status/conclusion transitions
- [x] Detects new commits pushed to the PR
- [x] Exits 0 on change, exits 1 on error (matching bash behavior)
- [x] Output format matches the bash version exactly

## Follow-up issues

- #97 — Port monitor comments command
- #98 — Port monitor --all command
