### PR TITLE
feat: add monitor --all to Python CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.6
+
+- **monitor --all (Python)** — New sub-command in Python runtime to poll for both CI check status changes and new PR comments in a single loop; output parity with the existing bash implementation.
+
 ## v0.2.5
 
 - **monitor comments** — New sub-command to poll for new review and issue comments on a PR, reporting `type: new-comment` with `count` on change.

--- a/gh-pr-context
+++ b/gh-pr-context
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-version="0.2.5"
+version="0.2.6"
 
 die() {
   echo "error: $1" >&2

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -276,15 +276,12 @@ def _detect_fork_parent(owner_repo, call_timeout=None):
                 return parent_val, "ok"
         _resolved_owner_repo = owner_repo
         return owner_repo, "ok"
-    try:
-        is_fork_val, ok = gh_api_jq(f"repos/{owner_repo}", ".fork")
-        if ok and is_fork_val == "true":
-            parent_val, pok = gh_api_jq(f"repos/{owner_repo}", ".parent.full_name")
-            if pok and parent_val and parent_val != "null":
-                _resolved_owner_repo = parent_val
-                return parent_val
-    except (OSError, subprocess.SubprocessError) as exc:
-        print(f"warning: fork detection failed for {owner_repo}: {exc}", file=sys.stderr)
+    is_fork_val, status = _timed_gh_api_jq(f"repos/{owner_repo}", ".fork", None)
+    if status == "ok" and is_fork_val == "true":
+        parent_val, pstatus = _timed_gh_api_jq(f"repos/{owner_repo}", ".parent.full_name", None)
+        if pstatus == "ok" and parent_val and parent_val != "null":
+            _resolved_owner_repo = parent_val
+            return parent_val
     _resolved_owner_repo = owner_repo
     return owner_repo
 
@@ -976,8 +973,9 @@ def cmd_monitor_all(argv):
     if call_timeout == "expired":
         print(f"monitor timed out after {timeout_input}", file=sys.stderr)
         sys.exit(2)
+    owner_repo_result = get_owner_repo(call_timeout)
     if call_timeout is not None:
-        owner_repo, repo_status = get_owner_repo(call_timeout)
+        owner_repo, repo_status = owner_repo_result
         if repo_status == "timeout":
             print(f"monitor timed out after {timeout_input}", file=sys.stderr)
             sys.exit(2)
@@ -986,7 +984,7 @@ def cmd_monitor_all(argv):
                 sys.exit(130)
             die("failed to resolve owner/repo")
     else:
-        owner_repo = get_owner_repo()
+        owner_repo = owner_repo_result
 
     try:
         call_timeout = _monitor_call_timeout(timeout_secs, start_mono)

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -253,11 +253,15 @@ def _detect_fork_parent(owner_repo, call_timeout=None):
         is_fork_val, status = _timed_gh_api_jq(f"repos/{owner_repo}", ".fork", call_timeout)
         if status == "timeout":
             return owner_repo, "timeout"
-        if status == "ok" and is_fork_val == "true":
+        if status == "error":
+            return owner_repo, "error"
+        if is_fork_val == "true":
             parent_val, pstatus = _timed_gh_api_jq(f"repos/{owner_repo}", ".parent.full_name", call_timeout)
             if pstatus == "timeout":
                 return owner_repo, "timeout"
-            if pstatus == "ok" and parent_val and parent_val != "null":
+            if pstatus == "error":
+                return owner_repo, "error"
+            if parent_val and parent_val != "null":
                 _resolved_owner_repo = parent_val
                 return parent_val, "ok"
         _resolved_owner_repo = owner_repo
@@ -377,17 +381,12 @@ def resolve_since_timestamp(since_input):
 
 def resolve_pr_head_sha(pr_number, timeout_secs=None):
     owner_repo = get_owner_repo()
-    if timeout_secs is not None:
-        val, status = _timed_gh_api_jq(
-            f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha", timeout_secs
-        )
-        if status == "timeout":
-            return None, "timeout"
-        if status == "error" or not val:
-            return None, "error"
-        return val, "ok"
-    val, ok = gh_api_jq(f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha")
-    if not ok or not val:
+    val, status = _timed_gh_api_jq(
+        f"repos/{owner_repo}/pulls/{pr_number}", ".head.sha", timeout_secs
+    )
+    if status == "timeout":
+        return None, "timeout"
+    if status == "error" or not val:
         return None, "error"
     return val, "ok"
 
@@ -957,6 +956,8 @@ def cmd_monitor_all(argv):
                 print(f"monitor timed out after {timeout_input}", file=sys.stderr)
                 sys.exit(2)
             if pr_status != "ok":
+                if interrupted:
+                    sys.exit(130)
                 die("failed to resolve PR number")
         else:
             pr_number = pr_number_result

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -234,8 +234,8 @@ def resolve_pr_number(call_timeout=None):
         if status != "ok":
             return None, "error"
     else:
-        val, ok = gh_api_jq(endpoint, ".[0].number")
-        if not ok:
+        val, status = _timed_gh_api_jq(endpoint, ".[0].number", None)
+        if status != "ok":
             die(f"failed to look up PR for branch '{branch}'")
     if not val or val == "null":
         if call_timeout is not None:

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -971,6 +971,10 @@ def cmd_monitor_all(argv):
         if repo_status == "timeout":
             print(f"monitor timed out after {timeout_input}", file=sys.stderr)
             sys.exit(2)
+        if repo_status != "ok":
+            if interrupted:
+                sys.exit(130)
+            die("failed to resolve owner/repo")
     else:
         owner_repo = get_owner_repo()
 

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -196,30 +196,63 @@ def resolve_owner_repo():
 _resolved_owner_repo = None
 
 
-def resolve_pr_number():
+def resolve_pr_number(call_timeout=None):
     global _resolved_owner_repo
     branch = run_git("rev-parse", "--abbrev-ref", "HEAD")
     owner_repo = resolve_owner_repo()
     head_owner, _ = owner_repo.split("/", 1)
 
-    # On forks, PRs live on the upstream (parent) repo. Detect fork and
-    # use parent for endpoint path + fork owner for head= filter.
-    endpoint_owner_repo = _detect_fork_parent(owner_repo)
+    if call_timeout is not None:
+        endpoint_owner_repo, det_status = _detect_fork_parent(owner_repo, call_timeout)
+        if det_status == "timeout":
+            return None, "timeout"
+    else:
+        endpoint_owner_repo = _detect_fork_parent(owner_repo)
 
     endpoint_owner, endpoint_repo = endpoint_owner_repo.split("/", 1)
     endpoint = f"repos/{endpoint_owner}/{endpoint_repo}/pulls?head={head_owner}:{branch}"
-    val, ok = gh_api_jq(endpoint, ".[0].number")
-    if not ok:
-        die(f"failed to look up PR for branch '{branch}'")
+
+    if call_timeout is not None:
+        val, status = _timed_gh_api_jq(endpoint, ".[0].number", call_timeout)
+        if status == "timeout":
+            return None, "timeout"
+        if status != "ok":
+            return None, "error"
+    else:
+        val, ok = gh_api_jq(endpoint, ".[0].number")
+        if not ok:
+            die(f"failed to look up PR for branch '{branch}'")
     if not val or val == "null":
+        if call_timeout is not None:
+            return None, "error"
         die(f"no open PR found for branch '{branch}'")
+    if call_timeout is not None:
+        return val, "ok"
     return val
 
 
-def _detect_fork_parent(owner_repo):
+def _detect_fork_parent(owner_repo, call_timeout=None):
     """Detect if owner_repo is a fork and return the parent repo, or the
-    original if not a fork. Caches the result in _resolved_owner_repo."""
+    original if not a fork. Caches the result in _resolved_owner_repo.
+
+    When call_timeout is provided, uses _timed_gh_api_jq and returns
+    (result, status) where status is "ok" or "timeout".
+    When call_timeout is None, returns a plain string (backward compat).
+    """
     global _resolved_owner_repo
+    if call_timeout is not None:
+        is_fork_val, status = _timed_gh_api_jq(f"repos/{owner_repo}", ".fork", call_timeout)
+        if status == "timeout":
+            return owner_repo, "timeout"
+        if status == "ok" and is_fork_val == "true":
+            parent_val, pstatus = _timed_gh_api_jq(f"repos/{owner_repo}", ".parent.full_name", call_timeout)
+            if pstatus == "timeout":
+                return owner_repo, "timeout"
+            if pstatus == "ok" and parent_val and parent_val != "null":
+                _resolved_owner_repo = parent_val
+                return parent_val, "ok"
+        _resolved_owner_repo = owner_repo
+        return owner_repo, "ok"
     try:
         is_fork_val, ok = gh_api_jq(f"repos/{owner_repo}", ".fork")
         if ok and is_fork_val == "true":
@@ -233,16 +266,24 @@ def _detect_fork_parent(owner_repo):
     return owner_repo
 
 
-def get_owner_repo():
+def get_owner_repo(call_timeout=None):
     """Return the resolved owner/repo for API endpoints.
 
     After resolve_pr_number sets _resolved_owner_repo (e.g. to the parent
     repo on forks), this returns that value. Otherwise detects fork and
     caches the parent repo. Falls back to origin if not a fork.
+
+    When call_timeout is provided, returns (result, status) where status
+    is "ok" or "timeout". Otherwise returns a plain string.
     """
     if _resolved_owner_repo is not None:
+        if call_timeout is not None:
+            return _resolved_owner_repo, "ok"
         return _resolved_owner_repo
-    return _detect_fork_parent(resolve_owner_repo())
+    result = _detect_fork_parent(resolve_owner_repo(), call_timeout)
+    if call_timeout is not None:
+        return result
+    return result
 
 
 def validate_since_format(value):
@@ -882,11 +923,6 @@ def cmd_monitor_all(argv):
 
     check_deps()
 
-    if not pr_number:
-        pr_number = resolve_pr_number()
-
-    owner_repo = get_owner_repo()
-
     interrupted = False
 
     def _handle_signal(signum, frame):
@@ -899,6 +935,34 @@ def cmd_monitor_all(argv):
     original_sigterm = signal.signal(signal.SIGTERM, _handle_signal)
 
     start_mono = time.monotonic()
+
+    if not pr_number:
+        call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+        if call_timeout == "expired":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+        pr_number_result = resolve_pr_number(call_timeout)
+        if call_timeout is not None:
+            pr_number, pr_status = pr_number_result
+            if pr_status == "timeout":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+            if pr_status != "ok":
+                die("failed to resolve PR number")
+        else:
+            pr_number = pr_number_result
+
+    call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+    if call_timeout == "expired":
+        print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+        sys.exit(2)
+    if call_timeout is not None:
+        owner_repo, repo_status = get_owner_repo(call_timeout)
+        if repo_status == "timeout":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+    else:
+        owner_repo = get_owner_repo()
 
     try:
         call_timeout = _monitor_call_timeout(timeout_secs, start_mono)

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -1062,6 +1062,8 @@ def cmd_monitor_all(argv):
                     sys.exit(130)
                 continue
             if sha_status != "ok":
+                if interrupted:
+                    sys.exit(130)
                 die(f"failed to re-resolve head SHA for PR #{pr_number}")
 
             if cur_sha != prev_sha:
@@ -1088,6 +1090,8 @@ def cmd_monitor_all(argv):
                     sys.exit(130)
                 continue
             if snap_status != "ok":
+                if interrupted:
+                    sys.exit(130)
                 die("failed to fetch check runs during poll")
 
             call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
@@ -1106,6 +1110,8 @@ def cmd_monitor_all(argv):
                     sys.exit(130)
                 continue
             if snap_status != "ok":
+                if interrupted:
+                    sys.exit(130)
                 die("failed to fetch comments during poll")
 
             status_changes = _compute_status_diff(

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -9,7 +9,7 @@ import sys
 import time
 from datetime import datetime, timezone
 
-VERSION = "0.2.5"
+VERSION = "0.2.6"
 
 _active_subprocess = None
 
@@ -697,6 +697,8 @@ def cmd_monitor(argv):
         cmd_monitor_status(rest)
     elif sub_command == "comments":
         cmd_monitor_comments(rest)
+    elif sub_command == "--all":
+        cmd_monitor_all(rest)
     elif sub_command in ("-h", "--help"):
         usage_monitor()
         sys.exit(0)
@@ -836,6 +838,193 @@ def cmd_monitor_comments(argv):
 
             if interrupted:
                 sys.exit(130)
+    finally:
+        signal.signal(signal.SIGINT, original_sigint)
+        signal.signal(signal.SIGTERM, original_sigterm)
+
+
+def cmd_monitor_all(argv):
+    pr_number = ""
+    interval = 30
+    timeout_input = ""
+    timeout_secs = None
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--pr":
+            if i + 1 >= len(argv):
+                die("missing value for --pr")
+            pr_number = argv[i + 1]
+            i += 2
+        elif arg == "--interval":
+            if i + 1 >= len(argv):
+                die("missing value for --interval")
+            interval = argv[i + 1]
+            i += 2
+            if not re.match(r"^[1-9][0-9]*$", interval):
+                die(
+                    f"invalid --interval value: {interval} (expected a positive integer)"
+                )
+            interval = int(interval)
+        elif arg == "--timeout":
+            if i + 1 >= len(argv):
+                die("missing value for --timeout")
+            timeout_input = argv[i + 1]
+            i += 2
+            timeout_secs = parse_duration(timeout_input)
+        elif arg == "--check":
+            die("unknown option: --check (only valid with monitor status)")
+        elif arg in ("-h", "--help"):
+            usage_monitor_all()
+            sys.exit(0)
+        else:
+            die(f"unknown option: {arg}")
+
+    check_deps()
+
+    if not pr_number:
+        pr_number = resolve_pr_number()
+
+    owner_repo = get_owner_repo()
+
+    prev_sha, sha_status = resolve_pr_head_sha(pr_number)
+    if sha_status != "ok":
+        die(f"failed to resolve head SHA for PR #{pr_number}")
+
+    prev_status_snapshot, snap_status = _capture_check_snapshot(owner_repo, prev_sha)
+    if snap_status != "ok":
+        die(f"failed to fetch check runs for commit {prev_sha}")
+
+    initial_comment_snapshot, snap_status = _capture_comment_id_snapshot(
+        owner_repo, pr_number
+    )
+    if snap_status != "ok":
+        die(f"failed to fetch comments for PR #{pr_number}")
+
+    interrupted = False
+
+    def _handle_signal(signum, frame):
+        nonlocal interrupted
+        interrupted = True
+        if _active_subprocess is not None:
+            _active_subprocess.kill()
+
+    original_sigint = signal.signal(signal.SIGINT, _handle_signal)
+    original_sigterm = signal.signal(signal.SIGTERM, _handle_signal)
+
+    start_mono = time.monotonic()
+
+    try:
+        while True:
+            if timeout_secs is not None:
+                elapsed = time.monotonic() - start_mono
+                if elapsed >= timeout_secs:
+                    print(
+                        f"monitor timed out after {timeout_input}", file=sys.stderr
+                    )
+                    sys.exit(2)
+
+            sleep_for = interval
+            if timeout_secs is not None:
+                remaining = timeout_secs - (time.monotonic() - start_mono)
+                if remaining < sleep_for:
+                    sleep_for = max(remaining, 0)
+            try:
+                _interruptible_sleep(sleep_for, lambda: interrupted)
+            except OSError:
+                pass
+
+            if interrupted:
+                pass
+            elif timeout_secs is not None:
+                elapsed = time.monotonic() - start_mono
+                if elapsed >= timeout_secs:
+                    print(
+                        f"monitor timed out after {timeout_input}", file=sys.stderr
+                    )
+                    sys.exit(2)
+
+            call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+            if call_timeout == "expired":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+
+            cur_sha, sha_status = resolve_pr_head_sha(pr_number, call_timeout)
+            if sha_status == "timeout":
+                print(
+                    "gh api call timed out; retrying next poll", file=sys.stderr
+                )
+                if interrupted:
+                    sys.exit(130)
+                continue
+            if sha_status != "ok":
+                die(f"failed to re-resolve head SHA for PR #{pr_number}")
+
+            if cur_sha != prev_sha:
+                print("--- change")
+                print("type: new-commit")
+                print(f"sha: {cur_sha}")
+                if interrupted:
+                    sys.exit(130)
+                sys.exit(0)
+
+            call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+            if call_timeout == "expired":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+
+            cur_status_snapshot, snap_status = _capture_check_snapshot(
+                owner_repo, cur_sha, call_timeout
+            )
+            if snap_status == "timeout":
+                print(
+                    "gh api call timed out; retrying next poll", file=sys.stderr
+                )
+                if interrupted:
+                    sys.exit(130)
+                continue
+            if snap_status != "ok":
+                die("failed to fetch check runs during poll")
+
+            call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+            if call_timeout == "expired":
+                print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+                sys.exit(2)
+
+            cur_comment_snapshot, snap_status = _capture_comment_id_snapshot(
+                owner_repo, pr_number, call_timeout
+            )
+            if snap_status == "timeout":
+                print(
+                    "gh api call timed out; retrying next poll", file=sys.stderr
+                )
+                if interrupted:
+                    sys.exit(130)
+                continue
+            if snap_status != "ok":
+                die("failed to fetch comments during poll")
+
+            status_changes = _compute_status_diff(
+                prev_status_snapshot, cur_status_snapshot
+            )
+            new_comment_ids = cur_comment_snapshot - initial_comment_snapshot
+
+            if status_changes:
+                print(_format_status_changes(status_changes))
+            if new_comment_ids:
+                print("--- change")
+                print("type: new-comment")
+                print(f"count: {len(new_comment_ids)}")
+            if status_changes or new_comment_ids:
+                if interrupted:
+                    sys.exit(130)
+                sys.exit(0)
+
+            if interrupted:
+                sys.exit(130)
+
+            prev_sha = cur_sha
+            prev_status_snapshot = cur_status_snapshot
     finally:
         signal.signal(signal.SIGINT, original_sigint)
         signal.signal(signal.SIGTERM, original_sigterm)
@@ -1150,11 +1339,12 @@ def usage():
 
 
 def usage_monitor():
-    print("usage: gh-pr-context monitor <sub-command> [options]")
+    print("usage: gh-pr-context monitor <sub-command|--all> [options]")
     print("")
     print("sub-commands:")
     print("  status    Poll for check status changes")
     print("  comments  Poll for new comments")
+    print("  --all     Poll for both status and comment changes")
     print("")
     print("options:")
     print("  -h, --help   Show this message")
@@ -1178,6 +1368,19 @@ def usage_monitor_comments():
     print("usage: gh-pr-context monitor comments [options]")
     print("")
     print("Poll for new top-level review and issue comments.")
+    print("Exits 0 on change, 1 on error, 2 on timeout, 130 on signal.")
+    print("")
+    print("options:")
+    print("  --pr <number>       PR number (auto-detected from branch if omitted)")
+    print("  --interval <secs>   Poll interval in seconds (default: 30)")
+    print("  --timeout <dur>     Maximum time to poll (e.g. 30s, 5m, 1h)")
+    print("  -h, --help          Show this message")
+
+
+def usage_monitor_all():
+    print("usage: gh-pr-context monitor --all [options]")
+    print("")
+    print("Poll for both check status changes and new comments.")
     print("Exits 0 on change, 1 on error, 2 on timeout, 130 on signal.")
     print("")
     print("options:")

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -212,8 +212,14 @@ def resolve_pr_number(call_timeout=None):
     head_owner, _ = owner_repo.split("/", 1)
 
     if call_timeout is not None:
+        pre_detect_mono = time.monotonic()
         endpoint_owner_repo, det_status = _detect_fork_parent(owner_repo, call_timeout)
         if det_status == "timeout":
+            return None, "timeout"
+        if det_status != "ok":
+            return None, "error"
+        remaining = call_timeout - (time.monotonic() - pre_detect_mono)
+        if remaining <= 0:
             return None, "timeout"
     else:
         endpoint_owner_repo = _detect_fork_parent(owner_repo)
@@ -222,7 +228,7 @@ def resolve_pr_number(call_timeout=None):
     endpoint = f"repos/{endpoint_owner}/{endpoint_repo}/pulls?head={head_owner}:{branch}"
 
     if call_timeout is not None:
-        val, status = _timed_gh_api_jq(endpoint, ".[0].number", call_timeout)
+        val, status = _timed_gh_api_jq(endpoint, ".[0].number", remaining)
         if status == "timeout":
             return None, "timeout"
         if status != "ok":

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -250,13 +250,17 @@ def _detect_fork_parent(owner_repo, call_timeout=None):
     """
     global _resolved_owner_repo
     if call_timeout is not None:
+        before_fork = time.monotonic()
         is_fork_val, status = _timed_gh_api_jq(f"repos/{owner_repo}", ".fork", call_timeout)
         if status == "timeout":
             return owner_repo, "timeout"
         if status == "error":
             return owner_repo, "error"
         if is_fork_val == "true":
-            parent_val, pstatus = _timed_gh_api_jq(f"repos/{owner_repo}", ".parent.full_name", call_timeout)
+            remaining = call_timeout - (time.monotonic() - before_fork)
+            if remaining <= 0:
+                return owner_repo, "timeout"
+            parent_val, pstatus = _timed_gh_api_jq(f"repos/{owner_repo}", ".parent.full_name", remaining)
             if pstatus == "timeout":
                 return owner_repo, "timeout"
             if pstatus == "error":

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -887,20 +887,6 @@ def cmd_monitor_all(argv):
 
     owner_repo = get_owner_repo()
 
-    prev_sha, sha_status = resolve_pr_head_sha(pr_number)
-    if sha_status != "ok":
-        die(f"failed to resolve head SHA for PR #{pr_number}")
-
-    prev_status_snapshot, snap_status = _capture_check_snapshot(owner_repo, prev_sha)
-    if snap_status != "ok":
-        die(f"failed to fetch check runs for commit {prev_sha}")
-
-    initial_comment_snapshot, snap_status = _capture_comment_id_snapshot(
-        owner_repo, pr_number
-    )
-    if snap_status != "ok":
-        die(f"failed to fetch comments for PR #{pr_number}")
-
     interrupted = False
 
     def _handle_signal(signum, frame):
@@ -915,6 +901,44 @@ def cmd_monitor_all(argv):
     start_mono = time.monotonic()
 
     try:
+        call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+        if call_timeout == "expired":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+
+        prev_sha, sha_status = resolve_pr_head_sha(pr_number, call_timeout)
+        if sha_status == "timeout":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+        if sha_status != "ok":
+            die(f"failed to resolve head SHA for PR #{pr_number}")
+
+        call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+        if call_timeout == "expired":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+
+        prev_status_snapshot, snap_status = _capture_check_snapshot(owner_repo, prev_sha, call_timeout)
+        if snap_status == "timeout":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+        if snap_status != "ok":
+            die(f"failed to fetch check runs for commit {prev_sha}")
+
+        call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
+        if call_timeout == "expired":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+
+        initial_comment_snapshot, snap_status = _capture_comment_id_snapshot(
+            owner_repo, pr_number, call_timeout
+        )
+        if snap_status == "timeout":
+            print(f"monitor timed out after {timeout_input}", file=sys.stderr)
+            sys.exit(2)
+        if snap_status != "ok":
+            die(f"failed to fetch comments for PR #{pr_number}")
+
         while True:
             if timeout_secs is not None:
                 elapsed = time.monotonic() - start_mono

--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -95,18 +95,27 @@ def gh_api_jq(endpoint, jq_filter):
 def _timed_gh_api_jq(endpoint, jq_filter, timeout_secs=None):
     """Like gh_api_jq but with a subprocess timeout.
 
-    Returns (value, status) where status is "ok", "timeout", or "error".
+    Uses Popen + _active_subprocess so the monitor signal handler can
+    kill the in-flight gh process.  Returns (value, status) where
+    status is "ok", "timeout", or "error".
     """
+    global _active_subprocess
     args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
+    proc = subprocess.Popen(
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
+    _active_subprocess = proc
     try:
-        result = subprocess.run(
-            args, capture_output=True, text=True, timeout=timeout_secs
-        )
+        stdout, _ = proc.communicate(timeout=timeout_secs)
     except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.communicate()
         return None, "timeout"
-    if result.returncode != 0:
+    finally:
+        _active_subprocess = None
+    if proc.returncode != 0:
         return None, "error"
-    return result.stdout.strip().replace("\r", ""), "ok"
+    return stdout.strip().replace("\r", ""), "ok"
 
 
 def _setup_git_env():
@@ -975,6 +984,8 @@ def cmd_monitor_all(argv):
             print(f"monitor timed out after {timeout_input}", file=sys.stderr)
             sys.exit(2)
         if sha_status != "ok":
+            if interrupted:
+                sys.exit(130)
             die(f"failed to resolve head SHA for PR #{pr_number}")
 
         call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
@@ -987,6 +998,8 @@ def cmd_monitor_all(argv):
             print(f"monitor timed out after {timeout_input}", file=sys.stderr)
             sys.exit(2)
         if snap_status != "ok":
+            if interrupted:
+                sys.exit(130)
             die(f"failed to fetch check runs for commit {prev_sha}")
 
         call_timeout = _monitor_call_timeout(timeout_secs, start_mono)
@@ -1001,6 +1014,8 @@ def cmd_monitor_all(argv):
             print(f"monitor timed out after {timeout_input}", file=sys.stderr)
             sys.exit(2)
         if snap_status != "ok":
+            if interrupted:
+                sys.exit(130)
             die(f"failed to fetch comments for PR #{pr_number}")
 
         while True:

--- a/test/test_python_monitor_all.sh
+++ b/test/test_python_monitor_all.sh
@@ -1,0 +1,423 @@
+#!/usr/bin/env bash
+
+script_dir="$(cd "$(dirname "$0")" && pwd)"
+repo_root="$(cd "$script_dir/.." && pwd)"
+python_script="$repo_root/gh-pr-context.py"
+if command -v py >/dev/null 2>&1; then
+  python_cmd="py -3"
+else
+  python_cmd="python3"
+fi
+
+HEAD_SHA="abc123def456abc123def456abc123def456abc1"
+NEW_SHA="def456abc123def456abc123def456abc123def4"
+
+pass=${pass:-0}
+fail=${fail:-0}
+_MOCK_DIR=""
+
+assert_exit() {
+  local expected_exit=$1 desc=$2; shift 2
+  local actual_exit=0
+  "$@" >/dev/null 2>&1 || actual_exit=$?
+  if [ "$actual_exit" -eq "$expected_exit" ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (expected exit $expected_exit, got $actual_exit)"
+  fi
+}
+
+assert_stderr_contains() {
+  local desc=$1 needle=$2; shift 2
+  local output
+  output=$("$@" 2>&1 >/dev/null) || true
+  if echo "$output" | grep -qF "$needle"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: $desc (stderr did not contain: $needle)"
+  fi
+}
+
+setup_mock_dir() {
+  _MOCK_DIR=$(mktemp -d)
+}
+
+cleanup_mock_dir() {
+  if [ -n "${_MOCK_DIR:-}" ] && [ -d "$_MOCK_DIR" ]; then
+    rm -rf "$_MOCK_DIR"
+  fi
+}
+
+write_git_mock() {
+  cat > "$_MOCK_DIR/git" << 'GIT_EOF'
+#!/usr/bin/env bash
+case "$*" in
+  "rev-parse --git-dir") echo ".git" ;;
+  "remote get-url origin") echo "https://github.com/acme/widgets.git" ;;
+  "rev-parse --abbrev-ref HEAD") echo "feature-branch" ;;
+  *) exit 1 ;;
+esac
+GIT_EOF
+  chmod +x "$_MOCK_DIR/git"
+}
+
+write_gh_stateful_mock_all() {
+  local initial_checks="$1"
+  local changed_checks="$2"
+  local initial_reviews="$3"
+  local initial_issues="$4"
+  local changed_reviews="$5"
+  local changed_issues="$6"
+  local sha_threshold="${7:-2}"
+  local checks_threshold="${8:-2}"
+  local review_threshold="${9:-3}"
+  local issue_threshold="${10:-4}"
+  echo 0 > "$_MOCK_DIR/counter_sha"
+  echo 0 > "$_MOCK_DIR/counter_checks"
+  echo 0 > "$_MOCK_DIR/counter_reviews"
+  echo 0 > "$_MOCK_DIR/counter_issues"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+esac
+case "\$*" in
+  *"pulls/42"*"--jq"*)
+    n=\$(cat "$_MOCK_DIR/counter_sha")
+    n=\$((n + 1))
+    echo "\$n" > "$_MOCK_DIR/counter_sha"
+    if [ "\$n" -le $sha_threshold ]; then
+      echo '$HEAD_SHA'
+    else
+      echo '$NEW_SHA'
+    fi
+    ;;
+  *"check-runs"*)
+    n=\$(cat "$_MOCK_DIR/counter_checks")
+    n=\$((n + 1))
+    echo "\$n" > "$_MOCK_DIR/counter_checks"
+    if [ "\$n" -le $checks_threshold ]; then
+      printf '%s' '$initial_checks'
+    else
+      printf '%s' '$changed_checks'
+    fi
+    ;;
+  *"repos/acme/widgets/pulls/42/comments"*)
+    n=\$(cat "$_MOCK_DIR/counter_reviews")
+    n=\$((n + 1))
+    echo "\$n" > "$_MOCK_DIR/counter_reviews"
+    if [ "\$n" -le $review_threshold ]; then
+      printf '%s' '$initial_reviews'
+    else
+      printf '%s' '$changed_reviews'
+    fi
+    ;;
+  *"repos/acme/widgets/issues/42/comments"*)
+    n=\$(cat "$_MOCK_DIR/counter_issues")
+    n=\$((n + 1))
+    echo "\$n" > "$_MOCK_DIR/counter_issues"
+    if [ "\$n" -le $issue_threshold ]; then
+      printf '%s' '$initial_issues'
+    else
+      printf '%s' '$changed_issues'
+    fi
+    ;;
+  *) echo "UNMATCHED: \$*" >&2; exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+write_gh_no_change_mock_all() {
+  local initial_checks="$1"
+  local initial_reviews="$2"
+  local initial_issues="$3"
+  cat > "$_MOCK_DIR/gh" << GHEOF
+#!/usr/bin/env bash
+case "\$*" in
+  *"repos/acme/widgets"*"--jq"*".fork"*) echo 'false'; exit 0 ;;
+  *"pulls/42"*"--jq"*) echo '$HEAD_SHA' ;;
+  *"check-runs"*)
+    printf '%s' '$initial_checks'
+    ;;
+  *"repos/acme/widgets/pulls/42/comments"*)
+    printf '%s' '$initial_reviews'
+    ;;
+  *"repos/acme/widgets/issues/42/comments"*)
+    printf '%s' '$initial_issues'
+    ;;
+  *) echo "UNMATCHED: \$*" >&2; exit 1 ;;
+esac
+GHEOF
+  chmod +x "$_MOCK_DIR/gh"
+}
+
+run_python() {
+  if command -v cygpath >/dev/null 2>&1; then
+    local git_bash='"C:/Program Files/Git/usr/bin/bash.exe"'
+    local git_mock="$git_bash $(cygpath -m "$_MOCK_DIR/git")"
+    local gh_mock="$git_bash $(cygpath -m "$_MOCK_DIR/gh")"
+  else
+    local git_mock="bash $_MOCK_DIR/git"
+    local gh_mock="bash $_MOCK_DIR/gh"
+  fi
+  GH_PR_CONTEXT_GIT="$git_mock" GH_PR_CONTEXT_GH="$gh_mock" \
+    timeout 15 $python_cmd "$python_script" "$@"
+}
+
+run_python_no_mock() {
+  $python_cmd "$python_script" "$@"
+}
+
+# --- Functional tests ---
+
+test_py_monitor_all_status_only() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local changed='{"total_count":1,"check_runs":[{"name":"CI","status":"completed","conclusion":"success"}]}'
+  write_gh_stateful_mock_all "$initial" "$changed" '[]' '[]' '[]' '[]' 999
+  local output
+  output=$(run_python monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "type: status" \
+    && echo "$output" | grep -qF "check: CI" \
+    && echo "$output" | grep -qF "from: in_progress" \
+    && echo "$output" | grep -qF "to: completed" \
+    && echo "$output" | grep -qF "conclusion: success" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: status only (output: $output)"
+  fi
+}
+
+test_py_monitor_all_comments_only() {
+  setup_mock_dir
+  write_git_mock
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  write_gh_stateful_mock_all '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}' \
+    '{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}' \
+    "$initial_reviews" '[]' "$changed_reviews" '[]' 999
+  local output
+  output=$(run_python monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "type: new-comment" \
+    && echo "$output" | grep -qF "count: 1" \
+    && ! echo "$output" | grep -qF "type: status"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: comments only (output: $output)"
+  fi
+}
+
+test_py_monitor_all_mixed_changes_status_first() {
+  setup_mock_dir
+  write_git_mock
+  local initial_checks='{"total_count":2,"check_runs":[{"name":"Build","status":"in_progress","conclusion":null},{"name":"Test","status":"queued","conclusion":null}]}'
+  local changed_checks='{"total_count":2,"check_runs":[{"name":"Build","status":"completed","conclusion":"success"},{"name":"Test","status":"completed","conclusion":"failure"}]}'
+  local initial_reviews='[{"id":101,"in_reply_to_id":null}]'
+  local changed_reviews='[{"id":101,"in_reply_to_id":null},{"id":102,"in_reply_to_id":null}]'
+  local initial_issues='[{"id":201}]'
+  local changed_issues='[{"id":201},{"id":202}]'
+  write_gh_stateful_mock_all "$initial_checks" "$changed_checks" \
+    "$initial_reviews" "$initial_issues" "$changed_reviews" "$changed_issues" 999 1 1 1
+  local output
+  output=$(run_python monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  local first_type last_type
+  first_type=$(echo "$output" | grep "type:" | head -1 | tr -d '\r')
+  last_type=$(echo "$output" | grep "type:" | tail -1 | tr -d '\r')
+  local first_check second_check
+  first_check=$(echo "$output" | grep -m1 "check:" | sed 's/check: //' | tr -d '\r')
+  second_check=$(echo "$output" | grep "check:" | sed 's/check: //' | tail -1 | tr -d '\r')
+  if [ "$first_type" = "type: status" ] \
+    && [ "$last_type" = "type: new-comment" ] \
+    && [ "$first_check" = "Build" ] \
+    && [ "$second_check" = "Test" ] \
+    && echo "$output" | grep -qF "count: 2"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: mixed changes status first (first_type=$first_type, last_type=$last_type, first_check=$first_check, second_check=$second_check, output: $output)"
+  fi
+}
+
+test_py_monitor_all_new_commit() {
+  setup_mock_dir
+  write_git_mock
+  local initial='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  write_gh_stateful_mock_all "$initial" "$initial" '[]' '[]' '[]' '[]' 1
+  local output
+  output=$(run_python monitor --all --pr 42 --interval 1 2>&1)
+  cleanup_mock_dir
+  if echo "$output" | grep -qF "type: new-commit" \
+    && echo "$output" | grep -qF "sha: $NEW_SHA" \
+    && ! echo "$output" | grep -qF "type: status" \
+    && ! echo "$output" | grep -qF "type: new-comment"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: new commit (output: $output)"
+  fi
+}
+
+# --- CLI validation tests ---
+
+test_py_monitor_all_help() {
+  assert_exit 0 "monitor --all --help exits 0" run_python_no_mock monitor --all --help
+  assert_exit 0 "monitor --all -h exits 0" run_python_no_mock monitor --all -h
+}
+
+test_py_monitor_all_reject_check_flag() {
+  assert_stderr_contains "--check rejected for monitor --all" \
+    "unknown option: --check (only valid with monitor status)" \
+    run_python_no_mock monitor --all --check CI
+}
+
+test_py_monitor_all_missing_interval_value() {
+  assert_stderr_contains "--all --interval without value gives clear message" \
+    "missing value for --interval" \
+    run_python_no_mock monitor --all --interval
+}
+
+test_py_monitor_all_invalid_interval() {
+  assert_stderr_contains "--all --interval abc gives clear message" \
+    "invalid --interval value: abc" \
+    run_python_no_mock monitor --all --interval abc
+  assert_stderr_contains "--all --interval 0 gives clear message" \
+    "invalid --interval value: 0" \
+    run_python_no_mock monitor --all --interval 0
+  assert_stderr_contains "--all --interval -1 gives clear message" \
+    "invalid --interval value: -1" \
+    run_python_no_mock monitor --all --interval -1
+}
+
+test_py_monitor_all_unknown_option() {
+  assert_exit 1 "monitor --all unknown option exits 1" run_python_no_mock monitor --all --bogus
+}
+
+test_py_monitor_all_missing_pr_value() {
+  assert_stderr_contains "--all --pr without value gives clear message" \
+    "missing value for --pr" \
+    run_python_no_mock monitor --all --pr
+}
+
+test_py_monitor_all_missing_timeout_value() {
+  assert_stderr_contains "--all --timeout without value gives clear message" \
+    "missing value for --timeout" \
+    run_python_no_mock monitor --all --timeout
+}
+
+test_py_monitor_all_invalid_timeout() {
+  assert_stderr_contains "--all --timeout abc gives clear message" \
+    "invalid duration" \
+    run_python_no_mock monitor --all --timeout abc
+}
+
+test_py_monitor_all_timeout_exits_two() {
+  setup_mock_dir
+  write_git_mock
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[{"id":101,"in_reply_to_id":null}]'
+  local issues='[{"id":201}]'
+  write_gh_no_change_mock_all "$checks" "$reviews" "$issues"
+  local exit_code=0
+  run_python monitor --all --pr 42 --interval 1 --timeout 2s >/dev/null 2>&1 || exit_code=$?
+  cleanup_mock_dir
+  if [ "$exit_code" -eq 2 ]; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout should exit 2 (got $exit_code)"
+  fi
+}
+
+test_py_monitor_all_timeout_stderr_message() {
+  setup_mock_dir
+  write_git_mock
+  local checks='{"total_count":1,"check_runs":[{"name":"CI","status":"in_progress","conclusion":null}]}'
+  local reviews='[{"id":101,"in_reply_to_id":null}]'
+  local issues='[{"id":201}]'
+  write_gh_no_change_mock_all "$checks" "$reviews" "$issues"
+  local stderr_output
+  stderr_output=$(run_python monitor --all --pr 42 --interval 1 --timeout 2s 2>&1 >/dev/null) || true
+  cleanup_mock_dir
+  if echo "$stderr_output" | grep -qF "monitor timed out after 2s"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: timeout stderr should contain 'monitor timed out after 2s' (got: $stderr_output)"
+  fi
+}
+
+test_py_monitor_all_help_shows_options() {
+  local output
+  output=$(run_python_no_mock monitor --all --help 2>&1)
+  if echo "$output" | grep -qF -- "--pr" \
+    && echo "$output" | grep -qF -- "--interval" \
+    && echo "$output" | grep -qF -- "--timeout"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --all --help should list --pr, --interval, --timeout (output: $output)"
+  fi
+}
+
+test_py_monitor_help_shows_all() {
+  local output
+  output=$(run_python_no_mock monitor --help 2>&1)
+  if echo "$output" | grep -qF -- "--all"; then
+    pass=$((pass + 1))
+  else
+    fail=$((fail + 1))
+    echo "FAIL: monitor --help should list --all (output: $output)"
+  fi
+}
+
+test_names+=(
+  test_py_monitor_all_status_only
+  test_py_monitor_all_comments_only
+  test_py_monitor_all_mixed_changes_status_first
+  test_py_monitor_all_new_commit
+  test_py_monitor_all_help
+  test_py_monitor_all_reject_check_flag
+  test_py_monitor_all_missing_interval_value
+  test_py_monitor_all_invalid_interval
+  test_py_monitor_all_unknown_option
+  test_py_monitor_all_missing_pr_value
+  test_py_monitor_all_missing_timeout_value
+  test_py_monitor_all_invalid_timeout
+  test_py_monitor_all_timeout_exits_two
+  test_py_monitor_all_timeout_stderr_message
+  test_py_monitor_all_help_shows_options
+  test_py_monitor_help_shows_all
+)
+
+# --- Run tests (only when executed directly, not sourced) ---
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+  set -euo pipefail
+
+  _summary_on_exit() {
+    local rc=$?
+    if [ "$rc" -ne 0 ] || [ "${fail:-0}" -gt 0 ]; then
+      echo "FAILED: exit ${rc}, ${fail:-0} test(s) failed, ${pass:-0} passed" >&2
+    fi
+    exit "$rc"
+  }
+  trap _summary_on_exit EXIT
+
+  echo "--- test_python_monitor_all.sh"
+  for t in "${test_names[@]}"; do
+    "$t"
+  done
+
+  echo ""
+  echo "$pass passed, $fail failed" >&2
+  [ "$fail" -eq 0 ]
+fi


### PR DESCRIPTION
## Summary

Implements the `monitor --all` subcommand in the Python CLI (`gh-pr-context.py`), enabling users to poll for both CI check status changes and new PR comments in a single loop.

Closes #98

## What changed

- `gh-pr-context.py`: Added `cmd_monitor_all()` with full polling loop, `usage_monitor_all()`, updated dispatcher and `usage_monitor()` to include `--all`
- `test/test_python_monitor_all.sh`: New test suite with 19 tests covering functional behavior and CLI validation
- `CHANGELOG.md`: Added v0.2.6 entry
- Version: Bumped from 0.2.5 to 0.2.6

## Behavior

- `monitor --all` polls both check status and comments in a single loop
- New-commit detection has highest priority (exits immediately)
- Status changes printed first (sorted by check name), then new-comment block
- Comment baseline stays fixed across iterations
- Exit codes: 0 (change), 1 (error), 2 (timeout), 130 (signal)
- Matches existing bash `monitor --all` semantics

## Testing

All 405 tests pass (386 existing + 19 new), including:
- Status-only change detection
- Comments-only change detection
- Mixed changes with correct ordering (status before new-comment)
- New commit detection
- CLI validation (help, --check rejection, interval/timeout parsing)
- Timeout exit code 2
