### PR TITLE
fix: Windows native PowerShell support

### DIFF
--- a/gh-pr-context.py
+++ b/gh-pr-context.py
@@ -35,7 +35,8 @@ def _gh_cmd():
 
 def run_cmd(args, timeout=None):
     result = subprocess.run(
-        args, capture_output=True, text=True, timeout=timeout
+        args, capture_output=True, text=True, encoding="utf-8",
+        errors="replace", timeout=timeout
     )
     return result.stdout.strip(), result.returncode
 
@@ -78,7 +79,7 @@ def parse_paginated_json(raw):
 
 def gh_api_paginated(endpoint):
     args = _gh_cmd() + ["api", "--paginate", endpoint]
-    result = subprocess.run(args, capture_output=True, text=True)
+    result = subprocess.run(args, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode != 0:
         return None, False
     return result.stdout, True
@@ -86,7 +87,7 @@ def gh_api_paginated(endpoint):
 
 def gh_api_jq(endpoint, jq_filter):
     args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
-    result = subprocess.run(args, capture_output=True, text=True)
+    result = subprocess.run(args, capture_output=True, text=True, encoding="utf-8", errors="replace")
     if result.returncode != 0:
         return None, False
     return result.stdout.strip().replace("\r", ""), True
@@ -100,7 +101,8 @@ def _timed_gh_api_jq(endpoint, jq_filter, timeout_secs=None):
     args = _gh_cmd() + ["api", endpoint, "--jq", jq_filter]
     try:
         result = subprocess.run(
-            args, capture_output=True, text=True, timeout=timeout_secs
+            args, capture_output=True, text=True, encoding="utf-8",
+            errors="replace", timeout=timeout_secs
         )
     except subprocess.TimeoutExpired:
         return None, "timeout"
@@ -361,7 +363,8 @@ def _timed_gh_api_paginated(endpoint, timeout_secs=None):
     global _active_subprocess
     args = _gh_cmd() + ["api", "--paginate", endpoint]
     proc = subprocess.Popen(
-        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        args, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
+        encoding="utf-8", errors="replace"
     )
     _active_subprocess = proc
     try:
@@ -955,7 +958,7 @@ def cmd_logs(argv):
         job_ids = []
         try:
             jobs_args = _gh_cmd() + ["api", f"repos/{owner_repo}/check-runs/{check_run_id}/jobs"]
-            jobs_result = subprocess.run(jobs_args, capture_output=True, text=True)
+            jobs_result = subprocess.run(jobs_args, capture_output=True, text=True, encoding="utf-8", errors="replace")
             if jobs_result.returncode == 0:
                 jobs_data = json.loads(jobs_result.stdout)
                 for job in jobs_data.get("jobs", []):
@@ -968,7 +971,7 @@ def cmd_logs(argv):
         for job_id in job_ids:
             try:
                 args = _gh_cmd() + ["api", f"repos/{owner_repo}/actions/jobs/{job_id}/logs"]
-                result = subprocess.run(args, capture_output=True, text=True)
+                result = subprocess.run(args, capture_output=True, text=True, encoding="utf-8", errors="replace")
                 if result.returncode == 0 and result.stdout:
                     if log_content:
                         log_content += "\n" + result.stdout
@@ -1221,4 +1224,8 @@ def main(argv):
 
 
 if __name__ == "__main__":
+    if sys.stdout and hasattr(sys.stdout, "reconfigure"):
+        sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+    if sys.stderr and hasattr(sys.stderr, "reconfigure"):
+        sys.stderr.reconfigure(encoding="utf-8", errors="replace")
     sys.exit(main(sys.argv[1:]))

--- a/install.sh
+++ b/install.sh
@@ -40,7 +40,9 @@ download() {
 }
 
 _is_windows() {
-  [[ "$(uname -s 2>/dev/null)" == MINGW* || "$(uname -s 2>/dev/null)" == MSYS* || "$(uname -s 2>/dev/null)" == CYGWIN* ]]
+  local osname
+  osname="$(uname -s 2>/dev/null)"
+  [[ "$osname" == MINGW* || "$osname" == MSYS* || "$osname" == CYGWIN* ]]
 }
 ON_WINDOWS=""
 is_windows() {
@@ -59,14 +61,24 @@ _python_version_ok() {
 }
 
 _find_python_cmd() {
-  if command -v python >/dev/null 2>&1 && _python_version_ok python; then
-    echo "python"
-  elif command -v python3 >/dev/null 2>&1 && _python_version_ok python3; then
-    echo "python3"
-  elif command -v py >/dev/null 2>&1 && _python_version_ok py -3; then
-    echo "py -3"
+  if is_windows; then
+    if command -v py >/dev/null 2>&1 && _python_version_ok py -3; then
+      echo "py -3"
+    elif command -v python >/dev/null 2>&1 && _python_version_ok python; then
+      echo "python"
+    elif command -v python3 >/dev/null 2>&1 && _python_version_ok python3; then
+      echo "python3"
+    else
+      echo ""
+    fi
   else
-    echo ""
+    if command -v python3 >/dev/null 2>&1 && _python_version_ok python3; then
+      echo "python3"
+    elif command -v python >/dev/null 2>&1 && _python_version_ok python; then
+      echo "python"
+    else
+      echo ""
+    fi
   fi
 }
 
@@ -99,12 +111,14 @@ CMDEOF
 fi
 
 resolved=$(command -v "$SCRIPT_NAME" 2>/dev/null) || true
-if [ -z "$resolved" ]; then
+if is_windows; then
+  if [ -z "$resolved" ]; then
+    echo "warning: $SCRIPT_NAME is not on your PATH" >&2
+  fi
+  echo "  Add it to PowerShell PATH by running:" >&2
+  echo "    \$env:PATH = \"$(_windows_path "$install_dir");\" + \$env:PATH" >&2
+elif [ -z "$resolved" ]; then
   echo "warning: $SCRIPT_NAME is not on your PATH" >&2
   echo "  Add it by running:" >&2
-  if is_windows; then
-    echo "    \$env:PATH = \"$(_windows_path "$install_dir");\" + \$env:PATH" >&2
-  else
-    echo "    export PATH=\"$install_dir:\$PATH\"" >&2
-  fi
+  echo "    export PATH=\"$install_dir:\$PATH\"" >&2
 fi

--- a/install.sh
+++ b/install.sh
@@ -5,7 +5,6 @@ REPO="akepo225/gh-pr-context"
 GH_PR_CONTEXT_VERSION="${GH_PR_CONTEXT_VERSION:-master}"
 SCRIPT_NAME="gh-pr-context"
 
-# die prints an error message to stderr and exits with status 1.
 die() {
   echo "error: $1" >&2
   exit 1
@@ -21,19 +20,51 @@ install_dir="${INSTALL_DIR:-${1:-$HOME/.local/bin}}"
 
 mkdir -p "$install_dir" 2>/dev/null || die "failed to create directory: $install_dir"
 
-tmp=$(mktemp 2>/dev/null) || die "failed to create temp file"
-trap 'rm -f "$tmp"' EXIT
+_tmpfiles=()
+cleanup_tmpfiles() { rm -f "${_tmpfiles[@]}" 2>/dev/null || true; }
+trap cleanup_tmpfiles EXIT
 
-curl -fsSL "$RAW_BASE/$SCRIPT_NAME" -o "$tmp" >/dev/null 2>&1 || die "failed to download $SCRIPT_NAME"
+download() {
+  local src="$1" dest="$2"
+  local tmp
+  tmp=$(mktemp 2>/dev/null) || die "failed to create temp file"
+  _tmpfiles+=("$tmp")
+  curl -fsSL "$RAW_BASE/$src" -o "$tmp" >/dev/null 2>&1 || { rm -f "$tmp"; die "failed to download $src"; }
+  mv "$tmp" "$dest" 2>/dev/null || { rm -f "$tmp"; die "failed to write to $dest"; }
+  _tmpfiles=("${_tmpfiles[@]//$tmp}")
+  chmod +x "$dest" 2>/dev/null || true
+}
 
-mv "$tmp" "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to write to $install_dir/$SCRIPT_NAME"
-chmod +x "$install_dir/$SCRIPT_NAME" 2>/dev/null || die "failed to set executable permissions on $install_dir/$SCRIPT_NAME"
+_is_windows() {
+  [[ "$(uname -s 2>/dev/null)" == MINGW* || "$(uname -s 2>/dev/null)" == MSYS* || "$(uname -s 2>/dev/null)" == CYGWIN* ]] || command -v cmd.exe >/dev/null 2>&1
+}
+ON_WINDOWS=""
+is_windows() {
+  if [ -z "$ON_WINDOWS" ]; then
+    if _is_windows; then ON_WINDOWS=1; else ON_WINDOWS=0; fi
+  fi
+  [ "$ON_WINDOWS" = "1" ]
+}
 
+download "$SCRIPT_NAME" "$install_dir/$SCRIPT_NAME"
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"
+
+if is_windows; then
+  download "${SCRIPT_NAME}.py" "$install_dir/${SCRIPT_NAME}.py"
+  cat > "$install_dir/${SCRIPT_NAME}.cmd" << 'CMDEOF'
+@echo off
+python "%~dp0gh-pr-context.py" %*
+CMDEOF
+  echo "installed ${SCRIPT_NAME}.cmd to $install_dir/${SCRIPT_NAME}.cmd"
+fi
 
 resolved=$(command -v "$SCRIPT_NAME" 2>/dev/null) || true
 if [ -z "$resolved" ]; then
   echo "warning: $SCRIPT_NAME is not on your PATH" >&2
   echo "  Add it by running:" >&2
-  echo "    export PATH=\"$install_dir:\$PATH\"" >&2
+  if is_windows; then
+    echo "    \$env:PATH = \"$install_dir;\" + \$env:PATH" >&2
+  else
+    echo "    export PATH=\"$install_dir:\$PATH\"" >&2
+  fi
 fi

--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ download() {
 }
 
 _is_windows() {
-  [[ "$(uname -s 2>/dev/null)" == MINGW* || "$(uname -s 2>/dev/null)" == MSYS* || "$(uname -s 2>/dev/null)" == CYGWIN* ]] || command -v cmd.exe >/dev/null 2>&1
+  [[ "$(uname -s 2>/dev/null)" == MINGW* || "$(uname -s 2>/dev/null)" == MSYS* || "$(uname -s 2>/dev/null)" == CYGWIN* ]]
 }
 ON_WINDOWS=""
 is_windows() {
@@ -46,14 +46,42 @@ is_windows() {
   [ "$ON_WINDOWS" = "1" ]
 }
 
+_find_python_cmd() {
+  if command -v python >/dev/null 2>&1 && python --version >/dev/null 2>&1; then
+    echo "python"
+  elif command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
+    echo "python3"
+  elif command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+    echo "py -3"
+  else
+    echo ""
+  fi
+}
+
+_windows_path() {
+  if command -v cygpath >/dev/null 2>&1; then
+    cygpath -w "$1" 2>/dev/null || echo "$1"
+  else
+    local p="$1"
+    if [[ "$p" =~ ^/([a-zA-Z])/ ]]; then
+      p="${p/#\/${BASH_REMATCH[1]}\//${BASH_REMATCH[1],,}:/}"
+    fi
+    echo "$p"
+  fi
+}
+
 download "$SCRIPT_NAME" "$install_dir/$SCRIPT_NAME"
 echo "installed $SCRIPT_NAME to $install_dir/$SCRIPT_NAME"
 
 if is_windows; then
   download "${SCRIPT_NAME}.py" "$install_dir/${SCRIPT_NAME}.py"
-  cat > "$install_dir/${SCRIPT_NAME}.cmd" << 'CMDEOF'
+  local_python=$(_find_python_cmd)
+  if [ -z "$local_python" ]; then
+    echo "warning: python not found; ${SCRIPT_NAME}.cmd will not work until Python is installed" >&2
+  fi
+  cat > "$install_dir/${SCRIPT_NAME}.cmd" << CMDEOF
 @echo off
-python "%~dp0gh-pr-context.py" %*
+${local_python:-python} "%~dp0gh-pr-context.py" %*
 CMDEOF
   echo "installed ${SCRIPT_NAME}.cmd to $install_dir/${SCRIPT_NAME}.cmd"
 fi
@@ -63,7 +91,7 @@ if [ -z "$resolved" ]; then
   echo "warning: $SCRIPT_NAME is not on your PATH" >&2
   echo "  Add it by running:" >&2
   if is_windows; then
-    echo "    \$env:PATH = \"$install_dir;\" + \$env:PATH" >&2
+    echo "    \$env:PATH = \"$(_windows_path "$install_dir");\" + \$env:PATH" >&2
   else
     echo "    export PATH=\"$install_dir:\$PATH\"" >&2
   fi

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,11 @@ download() {
   curl -fsSL "$RAW_BASE/$src" -o "$tmp" >/dev/null 2>&1 || { rm -f "$tmp"; die "failed to download $src"; }
   mv "$tmp" "$dest" 2>/dev/null || { rm -f "$tmp"; die "failed to write to $dest"; }
   _tmpfiles=("${_tmpfiles[@]//$tmp}")
-  chmod +x "$dest" 2>/dev/null || true
+  if ! is_windows; then
+    chmod +x "$dest" 2>/dev/null || die "failed to set executable bit on $dest"
+  else
+    chmod +x "$dest" 2>/dev/null || true
+  fi
 }
 
 _is_windows() {
@@ -46,12 +50,20 @@ is_windows() {
   [ "$ON_WINDOWS" = "1" ]
 }
 
+_python_version_ok() {
+  local cmd="$1"
+  shift
+  local ver
+  ver=$("$cmd" "$@" -c "import sys; print(sys.version_info >= (3, 11))" 2>/dev/null) || return 1
+  [ "$ver" = "True" ]
+}
+
 _find_python_cmd() {
-  if command -v python >/dev/null 2>&1 && python --version >/dev/null 2>&1; then
+  if command -v python >/dev/null 2>&1 && _python_version_ok python; then
     echo "python"
-  elif command -v python3 >/dev/null 2>&1 && python3 --version >/dev/null 2>&1; then
+  elif command -v python3 >/dev/null 2>&1 && _python_version_ok python3; then
     echo "python3"
-  elif command -v py >/dev/null 2>&1 && py -3 --version >/dev/null 2>&1; then
+  elif command -v py >/dev/null 2>&1 && _python_version_ok py -3; then
     echo "py -3"
   else
     echo ""
@@ -77,11 +89,11 @@ if is_windows; then
   download "${SCRIPT_NAME}.py" "$install_dir/${SCRIPT_NAME}.py"
   local_python=$(_find_python_cmd)
   if [ -z "$local_python" ]; then
-    echo "warning: python not found; ${SCRIPT_NAME}.cmd will not work until Python is installed" >&2
+    die "no Python 3.11+ found (tried python, python3, py -3); install Python first"
   fi
   cat > "$install_dir/${SCRIPT_NAME}.cmd" << CMDEOF
 @echo off
-${local_python:-python} "%~dp0gh-pr-context.py" %*
+${local_python} "%~dp0gh-pr-context.py" %*
 CMDEOF
   echo "installed ${SCRIPT_NAME}.cmd to $install_dir/${SCRIPT_NAME}.cmd"
 fi


### PR DESCRIPTION
## Problem

On Windows, the Python CLI crashes with `UnicodeDecodeError`/`UnicodeEncodeError` when `gh api` returns UTF-8 content (emoji in comments) because Python defaults to the system codepage (cp1252). Additionally, the installer only produces a bash script — unusable from PowerShell without a manual wrapper.

## Changes

### `gh-pr-context.py` — UTF-8 encoding on Windows

- All 7 `subprocess.run`/`Popen` calls: added `encoding="utf-8", errors="replace"` to prevent cp1252 decode errors when reading GitHub API output
- Entry point: `sys.stdout.reconfigure(encoding="utf-8")` to prevent `UnicodeEncodeError` on `print()` when outputting emoji content to cp1252 console

### `install.sh` — Windows-aware installer

- Detects Windows via `uname` (MINGW/MSYS/CYGWIN) or presence of `cmd.exe`
- On Windows: also downloads `gh-pr-context.py` and creates a `gh-pr-context.cmd` wrapper that calls `python gh-pr-context.py`
- Shows PowerShell PATH hint (`$env:PATH`) instead of bash `export`

## Result

After `curl | bash install.sh`, any AI agent can run `gh-pr-context` directly from PowerShell with zero extra setup. No bash dependency on Windows.

## Testing

- 386/386 tests pass
- Verified all commands work natively in PowerShell: `--version`, `status`, `comments`, `logs`, `monitor status --timeout`, `monitor --all --timeout`, input validation
